### PR TITLE
v0.4.0: Projects, Prompts, statusline cache, UI polish, cross-platform installer

### DIFF
--- a/docs/skills-and-prompts.md
+++ b/docs/skills-and-prompts.md
@@ -36,7 +36,7 @@ On first launch Husk seeds `~/.config/husk/prompts/` from `installer/prompts/`. 
 | `plan-a-feature.md` | 8-question PM-intake protocol. Walks the user through naming the user, problem, success metric, MVP scope, anti-scope. Emits a baked spec at the end. |
 | `write-pr-description.md` | Generates a clean PR description from a diff or branch range. Conventional-commits title, "why not what" summary, test plan, risk notes. |
 | `audit-for-security.md` | Methodical security review. Trust boundaries, input handling at each, AuthN/AuthZ, crypto sanity, OWASP-class issues with severity tags. |
-| `summarize-this-document.md` | Three-layer summary: TL;DR, key points (5–8 bullets), section-by-section. No filler. |
+| `summarize-this-document.md` | Three-layer summary: TL;DR, key points (5 to 8 bullets), section-by-section. No filler. |
 | `debug-this-error.md` | Guided triage. Quote the error literally, translate, narrow cause, ask one question if needed, propose surgical fix, verify. |
 
 ## The Skills page UI

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,228 @@
+#requires -Version 5.1
+<#
+Husk Windows installer.
+
+Run from an elevated or normal PowerShell prompt:
+    powershell -ExecutionPolicy Bypass -File .\install.ps1
+or in PowerShell 7+:
+    pwsh -File .\install.ps1
+
+Goals (parity with install.sh on Linux/macOS):
+- Detect and install prerequisites: jq (statusline) and bun (PAI hooks)
+- npm install + native rebuild for node-pty
+- Bootstrap PAI bundle into ~\.claude\ (no overwrite)
+- Create a husk.cmd wrapper under %LOCALAPPDATA%\Husk and a Start Menu shortcut
+
+Failures in the prerequisite block are logged but do not abort: Husk core
+still installs, only the PAI features that depend on the missing tool are
+degraded.
+#>
+
+$ErrorActionPreference = 'Stop'
+$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+function Write-Info  ($msg) { Write-Host ("> " + $msg) -ForegroundColor Cyan }
+function Write-Ok    ($msg) { Write-Host ("[OK] " + $msg) -ForegroundColor Green }
+function Write-Warn2 ($msg) { Write-Host ("[!] " + $msg) -ForegroundColor Yellow }
+
+Write-Ok "Detected Windows ($([Environment]::OSVersion.VersionString))"
+
+# Helper: is a command available on PATH?
+function Test-Cmd($name) {
+    return [bool] (Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+# ─── 0. Node.js detection (hard prereq) ──────────────────────────────
+if (-not (Test-Cmd node)) {
+    Write-Warn2 "Node.js is required but was not found. Install Node 20+ from https://nodejs.org/ and re-run."
+    exit 1
+}
+$nodeVer = (& node --version) 2>$null
+Write-Ok "node present ($nodeVer)"
+
+if (-not (Test-Cmd npm)) {
+    Write-Warn2 "npm is missing even though node is present; reinstall Node from https://nodejs.org/"
+    exit 1
+}
+
+# ─── 0b. MSVC build tools detection (soft warning) ───────────────────
+# node-pty has a C++ addon. The native rebuild needs MSVC's cl.exe or
+# MSBuild. We do not auto-install Visual Studio (multi-GB, license-gated);
+# we just warn so the user can intervene before the rebuild fails noisily.
+if (-not (Test-Cmd cl) -and -not (Test-Cmd msbuild)) {
+    Write-Warn2 "Neither cl.exe nor MSBuild is on PATH. The node-pty native rebuild may fail. If it does, install 'Visual Studio Build Tools' (Desktop development with C++) from https://visualstudio.microsoft.com/visual-cpp-build-tools/ and re-run."
+}
+
+# ─── 1. Prerequisites: jq + bun ──────────────────────────────────────
+function Install-Jq {
+    if (Test-Cmd jq) {
+        $jqVer = (& jq --version) 2>$null
+        Write-Ok "jq present ($jqVer)"
+        return
+    }
+    Write-Info "Installing jq (PAI statusline needs it for the Anthropic usage cache)..."
+    if (Test-Cmd winget) {
+        try { winget install --id jqlang.jq -e --silent --accept-package-agreements --accept-source-agreements } catch { Write-Warn2 ("winget install jq failed: " + $_.Exception.Message) }
+    } elseif (Test-Cmd scoop) {
+        try { scoop install jq } catch { Write-Warn2 ("scoop install jq failed: " + $_.Exception.Message) }
+    } elseif (Test-Cmd choco) {
+        try { choco install jq -y } catch { Write-Warn2 ("choco install jq failed: " + $_.Exception.Message) }
+    } else {
+        Write-Warn2 "No package manager found (winget / scoop / choco). Install jq manually from https://jqlang.github.io/jq/download/"
+        return
+    }
+    # winget refreshes PATH per-session via env vars; pull the latest in.
+    $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    if (Test-Cmd jq) {
+        Write-Ok "jq installed"
+    } else {
+        Write-Warn2 "jq install command finished but jq is still not on PATH. Open a new terminal and re-run if you need it now."
+    }
+}
+
+function Install-Bun {
+    if (Test-Cmd bun) {
+        $bunVer = (& bun --version) 2>$null
+        Write-Ok "bun present ($bunVer)"
+        return
+    }
+    Write-Info "Installing bun (PAI hooks need it for rating capture and learning)..."
+    try {
+        # Official unattended Windows installer.
+        Invoke-RestMethod https://bun.sh/install.ps1 | Invoke-Expression
+    } catch {
+        Write-Warn2 ("bun installer failed: " + $_.Exception.Message + ". Install manually from https://bun.sh")
+        return
+    }
+    # bun.exe lands at $env:USERPROFILE\.bun\bin\bun.exe
+    $bunBin = Join-Path $env:USERPROFILE ".bun\bin"
+    if (Test-Path (Join-Path $bunBin "bun.exe")) {
+        if (-not ($env:Path -split ';' | Where-Object { $_ -ieq $bunBin })) {
+            $env:Path = "$bunBin;$env:Path"
+        }
+        Write-Ok "bun installed at $bunBin (added to PATH for this session)"
+    } else {
+        Write-Warn2 "bun install completed but bun.exe was not found at $bunBin. PAI hooks will not run until you install bun manually."
+    }
+}
+
+Write-Info "Checking prerequisites (jq, bun)..."
+Install-Jq
+Install-Bun
+
+# ─── 2. Dependencies + native rebuild ────────────────────────────────
+Push-Location $AppDir
+try {
+    $ptyBuilt = Test-Path (Join-Path $AppDir "node_modules\node-pty\build\Release\pty.node")
+    if (-not (Test-Path (Join-Path $AppDir "node_modules")) -or -not $ptyBuilt) {
+        Write-Info "Installing Node dependencies..."
+        npm install --no-audit --no-fund
+        Write-Info "Rebuilding node-pty for Electron's Node ABI..."
+        npx --yes @electron/rebuild -f -w node-pty
+        Write-Ok "Dependencies installed"
+    } else {
+        Write-Ok "Dependencies already installed"
+    }
+} catch {
+    Write-Warn2 ("Dependency install or native rebuild failed: " + $_.Exception.Message)
+    Write-Warn2 "If the failure was a C++ toolchain issue, install Visual Studio Build Tools and re-run."
+    Pop-Location
+    exit 1
+}
+Pop-Location
+
+# ─── 3. PAI bootstrap (idempotent, never overwrites user files) ──────
+$ClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$PaiBundle = Join-Path $AppDir "libs\pai"
+if (Test-Path $PaiBundle) {
+    Write-Info "Bootstrapping PAI into $ClaudeDir (only adds missing files)..."
+    New-Item -ItemType Directory -Force -Path $ClaudeDir | Out-Null
+
+    $claudeMd = Join-Path $ClaudeDir "CLAUDE.md"
+    if (-not (Test-Path $claudeMd)) {
+        $tpl = Join-Path $PaiBundle "CLAUDE.md.template"
+        if (Test-Path $tpl) {
+            Copy-Item $tpl $claudeMd
+        } else {
+            $stock = Join-Path $PaiBundle "CLAUDE.md"
+            if (Test-Path $stock) { Copy-Item $stock $claudeMd }
+        }
+        Write-Ok "Installed CLAUDE.md (you can edit it any time)"
+    }
+
+    foreach ($sub in @('PAI', 'agents', 'hooks', 'lib', 'skills')) {
+        $src = Join-Path $PaiBundle $sub
+        $dst = Join-Path $ClaudeDir $sub
+        if (-not (Test-Path $src)) { continue }
+        if (-not (Test-Path $dst)) {
+            Copy-Item -Recurse $src $dst
+            Write-Ok "Installed $sub\"
+        } else {
+            # Mirror the cp -Rn behavior of install.sh: copy missing files,
+            # never overwrite user changes. Get-ChildItem -Recurse + a
+            # destination existence check covers both files and subdirs.
+            Get-ChildItem -Path $src -Recurse -File | ForEach-Object {
+                $rel = $_.FullName.Substring($src.Length).TrimStart('\','/')
+                $tgt = Join-Path $dst $rel
+                if (-not (Test-Path $tgt)) {
+                    $tgtDir = Split-Path -Parent $tgt
+                    if (-not (Test-Path $tgtDir)) { New-Item -ItemType Directory -Force -Path $tgtDir | Out-Null }
+                    Copy-Item $_.FullName $tgt
+                }
+            }
+        }
+    }
+
+    foreach ($fileName in @('blocklist.json', 'statusline-command.sh')) {
+        $src = Join-Path $PaiBundle $fileName
+        $dst = Join-Path $ClaudeDir $fileName
+        if ((Test-Path $src) -and -not (Test-Path $dst)) { Copy-Item $src $dst }
+    }
+
+    Write-Ok "PAI ready"
+}
+
+# ─── 4. Wrapper + Start Menu shortcut ────────────────────────────────
+$BinDir = Join-Path $env:LOCALAPPDATA "Husk"
+New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+$Wrapper = Join-Path $BinDir "husk.cmd"
+@"
+@echo off
+rem Auto-generated by Husk install.ps1, do not edit by hand
+cd /d "$AppDir"
+call npm start
+"@ | Set-Content -Path $Wrapper -Encoding ASCII
+Write-Ok "Wrapper installed: $Wrapper"
+
+# Add wrapper directory to user PATH if missing.
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (-not ($userPath -split ';' | Where-Object { $_ -ieq $BinDir })) {
+    [Environment]::SetEnvironmentVariable('Path', ($userPath.TrimEnd(';') + ';' + $BinDir), 'User')
+    Write-Ok "Added $BinDir to your User PATH (open a new terminal to launch Husk by name)"
+}
+
+# Start Menu shortcut.
+try {
+    $LnkDir = [Environment]::GetFolderPath('Programs')
+    $LnkPath = Join-Path $LnkDir "Husk.lnk"
+    $WshShell = New-Object -ComObject WScript.Shell
+    $Lnk = $WshShell.CreateShortcut($LnkPath)
+    $Lnk.TargetPath = $Wrapper
+    $Lnk.WorkingDirectory = $AppDir
+    $iconCandidate = Join-Path $AppDir "installer\husk-icon.png"
+    if (Test-Path $iconCandidate) { $Lnk.IconLocation = $iconCandidate }
+    $Lnk.Save()
+    Write-Ok "Start Menu shortcut: $LnkPath"
+} catch {
+    Write-Warn2 ("Could not create Start Menu shortcut: " + $_.Exception.Message)
+}
+
+Write-Host ""
+Write-Host "═══════════════════════════════════════════════════════"
+Write-Host "  Husk installed"
+Write-Host "═══════════════════════════════════════════════════════"
+Write-Host ""
+Write-Host "Launch:    Start menu -> Husk"
+Write-Host "Or run:    $Wrapper"
+Write-Host "From here: npm start"
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,117 @@ case "$PLATFORM" in
     *)      warn "Detected $PLATFORM (best-effort, no native registration)" ;;
 esac
 
+# ─── 0. Prerequisites: jq + bun ────────────────────────────────────
+# jq: bundled PAI statusline parses Anthropic OAuth usage with it; without
+#     jq the 5h/7d limits never get cached.
+# bun: PAI hooks are #!/usr/bin/env bun (RatingCapture, LearningSync, etc).
+#     Without bun, no rating capture, learning is empty.
+#
+# Both are auto-installed when missing using the platform's native package
+# manager. Failures here are logged but never abort the rest of the install,
+# Husk's core still works without them, just with degraded PAI features.
+
+# Decide whether to prefix install commands with sudo. Skip when already
+# running as root (containers, restricted CI) or when sudo isn't on PATH.
+SUDO=""
+if [ "$(id -u 2>/dev/null)" != "0" ] && command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+_install_jq_linux() {
+    # Each branch is wrapped in `|| true` so a failing package manager call
+    # never aborts the install (set -e at the script top would otherwise
+    # bubble the error up and stop everything). The post-install
+    # `command -v jq` check in ensure_jq is the source of truth.
+    if   command -v apt-get >/dev/null 2>&1; then ($SUDO apt-get update -qq >/dev/null 2>&1 || true); $SUDO apt-get install -y jq || true
+    elif command -v dnf     >/dev/null 2>&1; then $SUDO dnf install -y jq || true
+    elif command -v yum     >/dev/null 2>&1; then $SUDO yum install -y jq || true
+    elif command -v pacman  >/dev/null 2>&1; then $SUDO pacman -S --noconfirm jq || true
+    elif command -v zypper  >/dev/null 2>&1; then $SUDO zypper install -y jq || true
+    elif command -v apk     >/dev/null 2>&1; then $SUDO apk add --no-cache jq || true
+    else warn "No supported package manager found (apt/dnf/yum/pacman/zypper/apk). Install jq manually."; fi
+    return 0
+}
+
+_install_jq_mac() {
+    if command -v brew >/dev/null 2>&1; then brew install jq || true
+    elif command -v port >/dev/null 2>&1; then $SUDO port install jq || true
+    else warn "Homebrew not detected. Install Homebrew (https://brew.sh) and re-run, or run 'brew install jq' yourself."; fi
+    return 0
+}
+
+ensure_jq() {
+    if command -v jq >/dev/null 2>&1; then
+        ok "jq present ($(jq --version 2>/dev/null || echo unknown))"
+        return 0
+    fi
+    info "Installing jq (PAI statusline needs it for the Anthropic usage cache)..."
+    case "$PLATFORM" in
+        Linux)  _install_jq_linux ;;
+        Darwin) _install_jq_mac ;;
+        *) warn "Auto-install not supported on $PLATFORM. Install jq manually."; return 1 ;;
+    esac
+    if command -v jq >/dev/null 2>&1; then
+        ok "jq installed"
+    else
+        warn "jq install command finished but jq is still not on PATH; continuing without it. PAI usage cache will not refresh until you install it."
+        return 1
+    fi
+}
+
+_ensure_unzip() {
+    # The bun installer extracts a zip; on minimal distros (containers, fresh
+    # WSL, Alpine) unzip is not present and the installer aborts. Pull it in
+    # quietly first so the bun step can succeed.
+    if command -v unzip >/dev/null 2>&1; then return 0; fi
+    case "$PLATFORM" in
+        Linux)
+            if   command -v apt-get >/dev/null 2>&1; then $SUDO apt-get install -y unzip || true
+            elif command -v dnf     >/dev/null 2>&1; then $SUDO dnf install -y unzip || true
+            elif command -v yum     >/dev/null 2>&1; then $SUDO yum install -y unzip || true
+            elif command -v pacman  >/dev/null 2>&1; then $SUDO pacman -S --noconfirm unzip || true
+            elif command -v zypper  >/dev/null 2>&1; then $SUDO zypper install -y unzip || true
+            elif command -v apk     >/dev/null 2>&1; then $SUDO apk add --no-cache unzip || true
+            fi
+            ;;
+        Darwin)
+            # macOS ships unzip in the base system; nothing to do.
+            ;;
+    esac
+    return 0
+}
+
+ensure_bun() {
+    if command -v bun >/dev/null 2>&1; then
+        ok "bun present ($(bun --version 2>/dev/null || echo unknown))"
+        return 0
+    fi
+    info "Installing bun (PAI hooks need it for rating capture and learning)..."
+    if ! command -v curl >/dev/null 2>&1; then
+        warn "curl is required to install bun. Install curl, or install bun manually from https://bun.sh"
+        return 1
+    fi
+    _ensure_unzip
+    # Official unattended installer. Writes to ~/.bun/bin and updates the
+    # shell rc files. The next login picks it up automatically; we also add
+    # it to this script's PATH so any further checks below see it.
+    if curl -fsSL https://bun.sh/install | bash; then :; else
+        warn "bun installer reported a failure; continuing without bun. PAI hooks will not run until bun is installed."
+        return 1
+    fi
+    if [ -x "$HOME/.bun/bin/bun" ]; then
+        export PATH="$HOME/.bun/bin:$PATH"
+        ok "bun installed at $HOME/.bun/bin (added to PATH for this session)"
+    else
+        warn "bun install completed but $HOME/.bun/bin/bun is missing; PAI hooks will not run until you install bun manually."
+        return 1
+    fi
+}
+
+info "Checking prerequisites (jq, bun)..."
+ensure_jq || true
+ensure_bun || true
+
 # ─── 1. Dependencies (all platforms) ──────────────────────────────
 if [ ! -d node_modules ] || [ ! -f node_modules/node-pty/build/Release/pty.node ]; then
     info "Installing Node dependencies..."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",

--- a/src/main.js
+++ b/src/main.js
@@ -135,6 +135,29 @@ function readClaudeOauthToken() {
   } catch (_) { return ''; }
 }
 
+// Security context (responding to CodeQL js/file-access-to-http and
+// js/http-to-file-access on this function):
+//
+// 1. The OAuth token sourced from ~/.claude/.credentials.json is sent ONLY
+//    to api.anthropic.com (hardcoded hostname + path; no user input flows
+//    into the URL). This mirrors what the bundled PAI statusline-command.sh
+//    already does on every render.
+// 2. The response body is JSON.parse'd; the cache write is restricted to a
+//    fixed allowlist of fields, each coerced to a primitive type (Number,
+//    String, ISO timestamp). The destination path is path.join(CLAUDE_DIR,
+//    'MEMORY', 'STATE', 'usage-cache.json'), no part of which is derived
+//    from the response.
+// 3. No raw nested objects from the response land in the cache, so even if
+//    the upstream response were tampered with, only typed scalars persist.
+//
+// As a defensive timeout, anything past 5s is dropped.
+function _coerceISOTimestamp(s) {
+  if (typeof s !== 'string') return '';
+  // RFC 3339-ish timestamp: digits, dashes, T, colons, dot, plus, Z.
+  // Reject anything outside that grammar to keep file content predictable.
+  return /^[0-9T:\-+.Z]{1,40}$/.test(s) ? s : '';
+}
+
 function refreshAnthropicUsageCache() {
   const token = readClaudeOauthToken();
   if (!token) return;
@@ -151,33 +174,53 @@ function refreshAnthropicUsageCache() {
     timeout: 5000,
   }, (res) => {
     let body = '';
-    res.on('data', (chunk) => { body += chunk; });
+    let bodyLen = 0;
+    res.on('data', (chunk) => {
+      bodyLen += chunk.length;
+      // Cap body size to bound the attacker (server) influence on memory.
+      if (bodyLen > 256 * 1024) { res.destroy(); return; }
+      body += chunk;
+    });
     res.on('end', () => {
       try {
         if (res.statusCode !== 200) return;
         const data = JSON.parse(body);
-        if (!data || !data.five_hour) return;
+        if (!data || typeof data !== 'object' || !data.five_hour) return;
+        const fh = data.five_hour || {};
+        const sd = data.seven_day || null;
         const cacheDir = path.join(CLAUDE_DIR, 'MEMORY', 'STATE');
         fs.mkdirSync(cacheDir, { recursive: true });
         const cachePath = path.join(cacheDir, 'usage-cache.json');
-        // Preserve workspace_cost from a prior write (the script populates it
-        // via a slow admin-API call inside a stop hook, not on every render).
-        let prior = {};
-        try { prior = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) {}
-        const wsCost = data.workspace_cost || prior.workspace_cost || null;
-        const wsCostDollars = wsCost && typeof wsCost.month_used_cents === 'number'
-          ? (wsCost.month_used_cents / 100).toFixed(2)
-          : (prior.ws_cost_dollars || 0);
+        // Preserve scalar fields from a prior write (the slow admin API
+        // populates ws_cost_dollars + session_cost via a stop hook, not on
+        // every render). Only typed primitives are preserved, never raw
+        // objects from the prior cache.
+        let priorWsDollars = 0;
+        let priorSessionCost = '';
+        try {
+          const prior = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+          if (prior && typeof prior.ws_cost_dollars !== 'undefined') {
+            priorWsDollars = String(prior.ws_cost_dollars).slice(0, 16);
+          }
+          if (prior && typeof prior.session_cost === 'string') {
+            priorSessionCost = prior.session_cost.slice(0, 32);
+          }
+        } catch (_) {}
+        const wsCents = data.workspace_cost && typeof data.workspace_cost.month_used_cents === 'number'
+          ? data.workspace_cost.month_used_cents
+          : null;
+        const wsCostDollars = wsCents !== null ? (wsCents / 100).toFixed(2) : priorWsDollars;
+        const sessionCost = typeof data.session_cost === 'string'
+          ? data.session_cost.slice(0, 32)
+          : priorSessionCost;
+        // Allowlisted, type-coerced fields only. No raw response objects.
         const cache = {
-          usage_5h: Number(data.five_hour.utilization || 0),
-          usage_7d: Number(data.seven_day && data.seven_day.utilization || 0),
-          reset_5h_clock: data.five_hour.resets_at || '',
-          reset_7d_clock: data.seven_day && data.seven_day.resets_at || '',
-          ws_cost_dollars: wsCostDollars,
-          workspace_cost: wsCost,
-          session_cost: data.session_cost || prior.session_cost || '',
-          five_hour: data.five_hour,
-          seven_day: data.seven_day || null,
+          usage_5h: Number(fh.utilization || 0),
+          usage_7d: Number(sd && sd.utilization || 0),
+          reset_5h_clock: _coerceISOTimestamp(fh.resets_at),
+          reset_7d_clock: sd ? _coerceISOTimestamp(sd.resets_at) : '',
+          ws_cost_dollars: String(wsCostDollars).slice(0, 16),
+          session_cost: sessionCost,
           fetched_at: new Date().toISOString(),
         };
         fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2), { mode: 0o600 });

--- a/src/main.js
+++ b/src/main.js
@@ -77,6 +77,128 @@ let config = loadConfig();
 // Seed ~/.config/husk/prompts/ from the bundled curated set on first launch.
 // Never overwrites: a file that already exists in the destination is left
 // alone so user-edited prompts survive across upgrades.
+// Periodically run ~/.claude/statusline-command.sh so the side-effect caches
+// it does write (location-cache.json, weather-cache.json, model-cache.txt)
+// stay fresh while Husk is open. Note the script does NOT write
+// usage-cache.json; the 5h / 7d Anthropic limits are only fetched live each
+// CLI render, so Husk has to mirror that fetch itself. See
+// refreshAnthropicUsageCache below.
+let statuslineTimer = null;
+function refreshStatuslineCacheOnce() {
+  try {
+    const slPath = path.join(CLAUDE_DIR, 'statusline-command.sh');
+    if (!fs.existsSync(slPath)) return;
+    const cwd = activePtyCwd || HOME;
+    // Stub session JSON for the claude-statusline contract; missing fields
+    // fall back to env defaults inside the script.
+    const stub = JSON.stringify({ workspace: { current_dir: cwd }, session_id: 'husk-bg' });
+    const child = spawn('/bin/bash', [slPath], {
+      stdio: ['pipe', 'ignore', 'ignore'],
+      timeout: 10000,
+      cwd,
+      env: process.env,
+    });
+    try { child.stdin.write(stub); child.stdin.end(); } catch (_) {}
+    child.on('error', () => {});
+  } catch (_) {}
+}
+function startStatuslineRefresh() {
+  if (statuslineTimer) return;
+  // Kick off once on startup, then every 30s.
+  refreshStatuslineCacheOnce();
+  statuslineTimer = setInterval(refreshStatuslineCacheOnce, 30000);
+}
+function stopStatuslineRefresh() {
+  if (statuslineTimer) { clearInterval(statuslineTimer); statuslineTimer = null; }
+}
+
+// Hit the Anthropic OAuth usage endpoint with the user's claude credential
+// and write the result into ~/.claude/MEMORY/STATE/usage-cache.json. This
+// mirrors the inline fetch the PAI statusline does each render, but the
+// statusline never persisted those numbers, so Husk's stats reader was
+// always seeing a phantom file. Writing the cache here makes the existing
+// stats:get path light up.
+function readClaudeOauthToken() {
+  try {
+    if (process.platform === 'darwin') {
+      const out = require('child_process').execSync(
+        'security find-generic-password -s "Claude Code-credentials" -w',
+        { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] }
+      ).toString().trim();
+      const cj = JSON.parse(out);
+      return (cj.claudeAiOauth && cj.claudeAiOauth.accessToken) || '';
+    }
+    const credPath = path.join(HOME, '.claude', '.credentials.json');
+    if (!fs.existsSync(credPath)) return '';
+    const cj = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+    return (cj.claudeAiOauth && cj.claudeAiOauth.accessToken) || '';
+  } catch (_) { return ''; }
+}
+
+function refreshAnthropicUsageCache() {
+  const token = readClaudeOauthToken();
+  if (!token) return;
+  const https = require('https');
+  const req = https.request({
+    hostname: 'api.anthropic.com',
+    path: '/api/oauth/usage',
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'anthropic-beta': 'oauth-2025-04-20',
+    },
+    timeout: 5000,
+  }, (res) => {
+    let body = '';
+    res.on('data', (chunk) => { body += chunk; });
+    res.on('end', () => {
+      try {
+        if (res.statusCode !== 200) return;
+        const data = JSON.parse(body);
+        if (!data || !data.five_hour) return;
+        const cacheDir = path.join(CLAUDE_DIR, 'MEMORY', 'STATE');
+        fs.mkdirSync(cacheDir, { recursive: true });
+        const cachePath = path.join(cacheDir, 'usage-cache.json');
+        // Preserve workspace_cost from a prior write (the script populates it
+        // via a slow admin-API call inside a stop hook, not on every render).
+        let prior = {};
+        try { prior = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) {}
+        const wsCost = data.workspace_cost || prior.workspace_cost || null;
+        const wsCostDollars = wsCost && typeof wsCost.month_used_cents === 'number'
+          ? (wsCost.month_used_cents / 100).toFixed(2)
+          : (prior.ws_cost_dollars || 0);
+        const cache = {
+          usage_5h: Number(data.five_hour.utilization || 0),
+          usage_7d: Number(data.seven_day && data.seven_day.utilization || 0),
+          reset_5h_clock: data.five_hour.resets_at || '',
+          reset_7d_clock: data.seven_day && data.seven_day.resets_at || '',
+          ws_cost_dollars: wsCostDollars,
+          workspace_cost: wsCost,
+          session_cost: data.session_cost || prior.session_cost || '',
+          five_hour: data.five_hour,
+          seven_day: data.seven_day || null,
+          fetched_at: new Date().toISOString(),
+        };
+        fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2), { mode: 0o600 });
+      } catch (_) {}
+    });
+  });
+  req.on('error', () => {});
+  req.on('timeout', () => { try { req.destroy(); } catch (_) {} });
+  req.end();
+}
+
+let usageTimer = null;
+function startUsageRefresh() {
+  if (usageTimer) return;
+  refreshAnthropicUsageCache();
+  usageTimer = setInterval(refreshAnthropicUsageCache, 30000);
+}
+function stopUsageRefresh() {
+  if (usageTimer) { clearInterval(usageTimer); usageTimer = null; }
+}
+
 function bootstrapHuskPromptsIfNeeded() {
   try {
     const candidates = [];
@@ -316,7 +438,17 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
   // platform switch below for why Windows uses cmd.exe /c without the inject).
   const isWin32 = process.platform === 'win32';
   if (!isWin32 && /^claude(\.cmd|\.exe)?$/i.test(agentExe) && !agentArgs.includes('--settings')) {
-    const overridePath = buildClaudeSettingsOverride();
+    // We deliberately no longer inject --settings <ephemeral-temp-file>.
+    // That path made claude treat the temp file as the canonical settings,
+    // wrote folder-trust changes there, and on next launch we regenerated
+    // the temp file from the user's real settings.json, blowing the trust
+    // away. claude also hid the "Yes, and remember" trust option because
+    // it detected the ephemeral path.
+    //
+    // The price of dropping the override: claude renders its own inline
+    // statusline at the bottom of the terminal, alongside Husk's right
+    // panel. Acceptable duplication, the user gets persistent trust,
+    // skill-listing budget reverts to the claude default.
     const agentName = (config.agentName || 'Husk').replace(/[^A-Za-z0-9 _-]/g, '').slice(0, 40) || 'Husk';
     const huskPromptParts = [
       `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (not Atlas, not PAI, not Assistant). Use "🗣️ ${agentName}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
@@ -325,13 +457,36 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
       huskPromptParts.push(`The user has disabled recaps in Husk. Suppress any "* recap:" line and end-of-response summary footer for this session.`);
     }
     const huskPrompt = huskPromptParts.join(' ');
-    const injected = [];
-    if (overridePath) injected.push('--settings', overridePath);
-    injected.push('--append-system-prompt', huskPrompt);
-    agentArgs = [...injected, ...agentArgs];
+    agentArgs = ['--append-system-prompt', huskPrompt, ...agentArgs];
   }
 
+  // Default cwd policy (priority high -> low):
+  //   1. explicit overrideCwd (used by Resume to re-enter a session's project)
+  //   2. active project's path (config.activeProjectId)
+  //   3. user-configured config.agentCwd in Preferences
+  //   4. fall back to HOME
+  // Why this matters: claude refuses to offer a permanent "remember this
+  // folder" trust for $HOME because that would grant agent access to the
+  // entire user profile. Pointing Husk at a project subdirectory restores
+  // the three-option trust prompt and lets the user grant durable trust.
   let cwd = HOME;
+  if (config.agentCwd && typeof config.agentCwd === 'string') {
+    try {
+      if (fs.existsSync(config.agentCwd) && fs.statSync(config.agentCwd).isDirectory()) {
+        cwd = config.agentCwd;
+      }
+    } catch (_) {}
+  }
+  if (Array.isArray(config.projects) && config.activeProjectId) {
+    const active = config.projects.find((p) => p && p.id === config.activeProjectId);
+    if (active && active.path && typeof active.path === 'string') {
+      try {
+        if (fs.existsSync(active.path) && fs.statSync(active.path).isDirectory()) {
+          cwd = active.path;
+        }
+      } catch (_) {}
+    }
+  }
   if (overrideCwd) {
     try {
       if (fs.existsSync(overrideCwd) && fs.statSync(overrideCwd).isDirectory()) {
@@ -940,6 +1095,139 @@ function listHuskPrompts() {
       });
   } catch (_) { return []; }
 }
+
+// Returns just the curated Husk prompts (the markdown files seeded from
+// installer/prompts/ into ~/.config/husk/prompts/). The Skills page mixes
+// these with Claude skills; the dedicated Prompts page wants only the prompts.
+ipcMain.handle('prompts:list', () => {
+  try {
+    return { ok: true, prompts: listHuskPrompts() };
+  } catch (err) {
+    return { ok: false, error: err.message, prompts: [] };
+  }
+});
+
+// ─── Projects IPC ──────────────────────────────────────────────────────────
+// Projects are stored as { id, name, path, addedAt, lastUsedAt } in
+// config.projects, with config.activeProjectId pointing at the current one.
+// All persistence flows through config:set so the existing readJSON/write
+// path stays the source of truth.
+
+function _projectsList() {
+  return Array.isArray(config.projects) ? config.projects : [];
+}
+
+ipcMain.handle('projects:list', () => {
+  return {
+    ok: true,
+    projects: _projectsList(),
+    activeProjectId: config.activeProjectId || null,
+  };
+});
+
+ipcMain.handle('projects:create', (_e, payload = {}) => {
+  const name = String(payload.name || '').trim().slice(0, 80);
+  const projPath = String(payload.path || '').trim();
+  if (!name) return { ok: false, error: 'Name is required.' };
+  if (!projPath) return { ok: false, error: 'Path is required.' };
+  try {
+    if (!fs.existsSync(projPath) || !fs.statSync(projPath).isDirectory()) {
+      return { ok: false, error: 'Path is not a directory that exists.' };
+    }
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+  const projects = _projectsList();
+  if (projects.some((p) => p && p.path === projPath)) {
+    return { ok: false, error: 'A project with that path already exists.' };
+  }
+  const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+  const entry = { id, name, path: projPath, addedAt: new Date().toISOString(), lastUsedAt: null };
+  config = { ...config, projects: [...projects, entry] };
+  try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 }); } catch (_) {}
+  return { ok: true, project: entry };
+});
+
+ipcMain.handle('projects:setActive', (_e, id) => {
+  const projects = _projectsList();
+  const found = projects.find((p) => p && p.id === id);
+  if (!found) return { ok: false, error: 'Project not found.' };
+  const stamped = projects.map((p) => p && p.id === id ? { ...p, lastUsedAt: new Date().toISOString() } : p);
+  config = { ...config, projects: stamped, activeProjectId: id };
+  try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 }); } catch (_) {}
+  return { ok: true, project: found };
+});
+
+ipcMain.handle('projects:clearActive', () => {
+  config = { ...config, activeProjectId: null };
+  try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 }); } catch (_) {}
+  return { ok: true };
+});
+
+ipcMain.handle('projects:delete', (_e, id) => {
+  const projects = _projectsList();
+  if (!projects.some((p) => p && p.id === id)) return { ok: false, error: 'Project not found.' };
+  const remaining = projects.filter((p) => p && p.id !== id);
+  const newActive = config.activeProjectId === id ? null : config.activeProjectId;
+  config = { ...config, projects: remaining, activeProjectId: newActive };
+  try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 }); } catch (_) {}
+  return { ok: true };
+});
+
+// Delete a Husk prompt. Confines the unlink to HUSK_PROMPTS_DIR by resolving
+// both the supplied path and the prompts directory, then verifying that the
+// resolved file lives directly under it. Symlink/traversal-proof.
+ipcMain.handle('prompts:delete', (_e, mdPath) => {
+  if (!mdPath || typeof mdPath !== 'string') return { ok: false, error: 'Missing path' };
+  try {
+    const promptsRoot = path.resolve(HUSK_PROMPTS_DIR);
+    const target = path.resolve(mdPath);
+    if (!target.startsWith(promptsRoot + path.sep)) {
+      return { ok: false, error: 'Refusing to delete outside the prompts directory' };
+    }
+    if (!fs.existsSync(target)) return { ok: false, error: 'Prompt file not found' };
+    fs.unlinkSync(target);
+    // Also clear any disabled twin so the slot is fully reclaimed.
+    try { fs.unlinkSync(target + '.disabled'); } catch (_) {}
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+});
+
+// Create a new Husk prompt. Always writes to HUSK_PROMPTS_DIR regardless of
+// agentKind (the existing skills:create handler routes by agent and would
+// instead create a claude skill for claude users; we want prompts to be
+// distinct).
+ipcMain.handle('prompts:create', (_e, payload = {}) => {
+  const { name, description, content } = payload;
+  if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
+    return { ok: false, error: 'Name must be lowercase letters, digits, dashes; start with a letter.' };
+  }
+  if (!description || !description.trim()) {
+    return { ok: false, error: 'Description is required.' };
+  }
+  const safeDesc = description.trim().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const body = (content || '').trim() || `# ${name}\n\n${description.trim()}\n`;
+  const md = `---\nname: ${name}\ndescription: "${safeDesc}"\n---\n\n${body}\n`;
+  try {
+    fs.mkdirSync(HUSK_PROMPTS_DIR, { recursive: true });
+    const fileName = `${name}.md`;
+    const mdPath = path.join(HUSK_PROMPTS_DIR, fileName);
+    if (fs.existsSync(mdPath + '.disabled')) {
+      return { ok: false, error: `A prompt named "${name}" already exists (disabled).` };
+    }
+    try {
+      fs.writeFileSync(mdPath, md, { flag: 'wx', mode: 0o644 });
+    } catch (e) {
+      if (e && e.code === 'EEXIST') return { ok: false, error: `A prompt named "${name}" already exists.` };
+      throw e;
+    }
+    return { ok: true, id: fileName, path: mdPath, mdPath };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+});
 
 ipcMain.handle('skills:list', () => {
   try {
@@ -1792,12 +2080,14 @@ if (!gotLock) {
   app.whenReady().then(async () => {
     bootstrapPaiIfNeeded();
     bootstrapHuskPromptsIfNeeded();
+    startStatuslineRefresh();
+    startUsageRefresh();
     await startNullVoiceServer();
     createWindow();
     setupAutoUpdater();
   });
-  app.on('window-all-closed', () => { killPtyTree(); stopNullVoiceServer(); app.quit(); });
-  app.on('before-quit', () => { killPtyTree(); stopNullVoiceServer(); });
+  app.on('window-all-closed', () => { killPtyTree(); stopNullVoiceServer(); stopStatuslineRefresh(); stopUsageRefresh(); app.quit(); });
+  app.on('before-quit', () => { killPtyTree(); stopNullVoiceServer(); stopStatuslineRefresh(); stopUsageRefresh(); });
   app.on('will-quit', () => { killPtyTree(); stopNullVoiceServer(); });
   app.on('activate', () => { if (BrowserWindow.getAllWindows().length === 0) createWindow(); });
   process.on('SIGINT',  () => { killPtyTree(); stopNullVoiceServer(); app.quit(); });

--- a/src/preload.js
+++ b/src/preload.js
@@ -33,6 +33,18 @@ contextBridge.exposeInMainWorld('husk', {
     delete: (paths) => ipcRenderer.invoke('sessions:delete', { paths }),
   },
   prds: { list: () => ipcRenderer.invoke('prds:list') },
+  prompts: {
+    list: () => ipcRenderer.invoke('prompts:list'),
+    create: (payload) => ipcRenderer.invoke('prompts:create', payload),
+    delete: (mdPath) => ipcRenderer.invoke('prompts:delete', mdPath),
+  },
+  projects: {
+    list: () => ipcRenderer.invoke('projects:list'),
+    create: (payload) => ipcRenderer.invoke('projects:create', payload),
+    setActive: (id) => ipcRenderer.invoke('projects:setActive', id),
+    clearActive: () => ipcRenderer.invoke('projects:clearActive'),
+    delete: (id) => ipcRenderer.invoke('projects:delete', id),
+  },
   fs: {
     open: (p) => ipcRenderer.invoke('fs:open', p),
     dropFile: (payload) => ipcRenderer.invoke('fs:dropFile', payload),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -84,12 +84,22 @@ window.husk.pty.onData((d) => {
     chatHasInput = true;
     $('#chat-empty').classList.remove('show');
   }
+  if (_restartInProgress) return;
   term.write(d, () => term.scrollToBottom());
   detectAndSpeak(d);
 });
 window.husk.pty.onExit((code) => {
+  // Suppress the exit notice when we're tearing the old PTY down on purpose,
+  // otherwise the line stitches into the new PTY's welcome banner.
+  if (_restartInProgress) return;
   term.writeln(`\r\n\x1b[38;2;106;115;133m[agent exited code ${code}; click ↻ Restart]\x1b[0m`);
 });
+
+// Set true while we are killing the old PTY and spawning a new one. Renderer
+// ignores all PTY output and exit events during this window so the dying
+// PTY's tail output ("killing shell... killed", "[agent exited code 0]") and
+// the new PTY's welcome banner do not interleave in xterm's single buffer.
+let _restartInProgress = false;
 
 function announceInTerminal(msg) {
   term.writeln(`\r\n\x1b[38;2;103;232;249m▸ ${msg}\x1b[0m`);
@@ -105,15 +115,24 @@ async function startPty() {
   try { const inv = await reloadMcpInventory(); snapshotLoadedMcps(inv); } catch (_) {}
 }
 async function restartPty(opts = {}) {
+  _restartInProgress = true;
   fitAddon.fit();
   const { cols, rows } = term;
   chatHasInput = false;
   resetSpeechState();
   clearSessionContext();
-  // Wipe scrollback + visible buffer so a new session shows a clean screen
-  // even if the user hits New session multiple times in a row.
+  // First wipe so any earlier scrollback is gone before kill output starts.
   try { term.reset(); } catch (_) { try { term.clear(); } catch (_) {} }
-  await window.husk.pty.restart({ cols, rows, command: opts.command || null });
+  await window.husk.pty.restart({ cols, rows, command: opts.command || null, cwd: opts.cwd || null });
+  // Let the dying PTY drain its tail notice into the (suppressed) handlers
+  // before we re-enable output. Claude's welcome banner takes >300ms to
+  // produce, so a 200ms quiet window does not cut into it.
+  await new Promise((r) => setTimeout(r, 200));
+  // Second wipe: clears anything that wrote to the buffer despite suppression
+  // (e.g. xterm internal sequences from the kill), so the new PTY's banner
+  // starts on a clean canvas.
+  try { term.reset(); } catch (_) {}
+  _restartInProgress = false;
   $('#chat-empty').classList.add('show');
   term.focus();
   try { const inv = await reloadMcpInventory(); snapshotLoadedMcps(inv); } catch (_) {}
@@ -124,8 +143,9 @@ async function restartPty(opts = {}) {
 function applyTheme(theme) {
   document.body.dataset.theme = theme;
   try { term.options.theme = themeForXterm(); } catch (_) {}
-  const icon = $('#theme-icon');
-  if (icon) icon.textContent = theme === 'dark' ? '☾' : '☀';
+  // Theme icon swap is now handled via CSS based on body[data-theme]; the
+  // legacy #theme-icon span is gone. This function intentionally only sets
+  // the dataset attribute, the moon/sun SVGs are toggled by selectors.
 }
 function applyAccent(accent) {
   const valid = ['orange', 'cyan', 'indigo', 'emerald', 'rose'];
@@ -137,12 +157,14 @@ function applyAccent(accent) {
 
 // ─── Router ──────────────────────────────────────────────────────────────────────
 function setPage(name) {
-  if (!['chat', 'skills', 'sessions', 'files', 'mcp', 'preferences'].includes(name)) name = 'chat';
+  if (!['chat', 'projects', 'prompts', 'skills', 'sessions', 'files', 'mcp', 'preferences'].includes(name)) name = 'chat';
   currentPage = name;
   document.body.dataset.page = name;
   $$('.page').forEach((p) => { p.hidden = p.dataset.page !== name; });
   $$('.rail-item').forEach((it) => it.classList.toggle('active', it.dataset.page === name));
   if (name === 'chat') { setTimeout(fitNow, 30); term.focus(); }
+  if (name === 'projects') renderProjects();
+  if (name === 'prompts') renderPrompts();
   if (name === 'skills') renderSkills();
   if (name === 'sessions') renderSessions();
   if (name === 'files') { $('#files-root').value = cfg.treeRoot; $('#files-hidden').checked = !!cfg.showHidden; renderTree(cfg.treeRoot); }
@@ -203,6 +225,22 @@ function ratingColor(r) {
   return 'var(--rose)';
 }
 function fmtPct(n) { return Math.round(Number(n) || 0) + '%'; }
+// Format an ISO 8601 instant as "in 1h 23m" / "in 3d 5h" / "now".
+// Falls back to the raw string only if the input cannot be parsed at all.
+function fmtUntil(iso) {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (!isFinite(t)) return iso;
+  const ms = t - Date.now();
+  if (ms <= 0) return 'now';
+  const total = Math.floor(ms / 1000);
+  const days = Math.floor(total / 86400);
+  const hours = Math.floor((total % 86400) / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (days > 0) return `in ${days}d ${hours}h`;
+  if (hours > 0) return `in ${hours}h ${minutes}m`;
+  return `in ${minutes}m`;
+}
 function fmtThousands(n) {
   const v = Number(n) || 0;
   if (v >= 1000) return (v / 1000).toFixed(v >= 10000 ? 0 : 1) + 'k';
@@ -229,7 +267,9 @@ async function refreshStatusline() {
   // what we know, never blank a section.
   let tz = '';
   try { tz = Intl.DateTimeFormat().resolvedOptions().timeZone || ''; } catch (_) {}
-  const headline = here || tz || '';
+  // Pretty fallback: "Asia/Jerusalem" -> "Jerusalem", "America/New_York" -> "New York".
+  const tzPretty = tz.includes('/') ? tz.split('/').pop().replace(/_/g, ' ') : tz;
+  const headline = here || tzPretty || '';
   const weatherStr = s.weather && s.weather.temp
     ? `${s.weather.temp}°C${s.weather.condition ? ' · ' + s.weather.condition : ''}`
     : '';
@@ -269,13 +309,13 @@ async function refreshStatusline() {
         ${u.cache_present ? `
         <div class="sp-row"><span class="sp-muted">5h</span><span class="sp-mono">${fmtPct(u.h5_pct)}</span></div>
         <div class="sp-progress"><div class="sp-progress-fill" style="width:${Math.min(100, u.h5_pct||0)}%"></div></div>
-        ${u.h5_reset ? `<div class="sp-row"><span class="sp-muted">Resets</span><span class="sp-mono">${escapeHtml(u.h5_reset)}</span></div>` : ''}
+        ${u.h5_reset ? `<div class="sp-row"><span class="sp-muted">Resets</span><span class="sp-mono" title="${escapeHtml(u.h5_reset)}">${escapeHtml(fmtUntil(u.h5_reset))}</span></div>` : ''}
         <div class="sp-row" style="margin-top:6px;"><span class="sp-muted">Weekly</span><span class="sp-mono">${fmtPct(u.week_pct)}</span></div>
         <div class="sp-progress"><div class="sp-progress-fill" style="width:${Math.min(100, u.week_pct||0)}%"></div></div>
-        ${u.week_reset ? `<div class="sp-row"><span class="sp-muted">Resets</span><span class="sp-mono">${escapeHtml(u.week_reset)}</span></div>` : ''}
+        ${u.week_reset ? `<div class="sp-row"><span class="sp-muted">Resets</span><span class="sp-mono" title="${escapeHtml(u.week_reset)}">${escapeHtml(fmtUntil(u.week_reset))}</span></div>` : ''}
         ` : `
-        <div class="sp-row"><span class="sp-muted">5h / Weekly</span><span class="sp-mono sp-muted">no live data</span></div>
-        <div class="sp-row sp-tiny sp-muted">Anthropic limits sync from PAI's statusline. Without it, Husk only sees the per-session counters below.</div>
+        <div class="sp-row"><span class="sp-muted">5h / Weekly</span><span class="sp-mono sp-muted">warming up…</span></div>
+        <div class="sp-row sp-tiny sp-muted">Refreshing every 30s from your Anthropic OAuth token; first sample takes a few seconds after launch.</div>
         `}
         ${u.session ? `
         <div class="sp-divider"></div>
@@ -310,6 +350,7 @@ async function refreshStatusline() {
         ${L.avg1w != null ? `<div class="sp-row"><span class="sp-muted">1w</span><span class="sp-mono" style="color:${ratingColor(L.avg1w)};">${L.avg1w}</span></div>` : ''}
         ${L.avg1mo != null ? `<div class="sp-row"><span class="sp-muted">1mo</span><span class="sp-mono" style="color:${ratingColor(L.avg1mo)};">${L.avg1mo}</span></div>` : ''}
         ${L.recent && L.recent.length ? sparkHTML(L.recent) : ''}
+        ${(L.latest == null && L.avg1h == null && L.avg1d == null && L.avg1w == null && L.avg1mo == null) ? `<div class="sp-row sp-tiny sp-muted">No ratings yet · sessions you rate will land here.</div>` : ''}
       </div>
     </div>
   `;
@@ -331,7 +372,353 @@ async function refreshStatusline() {
   });
 }
 
-// ─── Prompts / Skills page ──────────────────────────────────────────────────────
+// ─── Projects page ─────────────────────────────────────────────────────────────
+let projectsCache = [];
+let activeProjectId = null;
+
+async function renderProjects() {
+  const grid = $('#projects-grid');
+  if (!grid) return;
+  // eslint-disable-next-line no-unsanitized/property -- Static loading template.
+  grid.innerHTML = '<div class="empty-state"><div class="es-icon">⌬</div><div class="es-msg">Loading projects…</div></div>';
+  const res = await window.husk.projects.list();
+  if (!res || !res.ok) {
+    // eslint-disable-next-line no-unsanitized/property -- Error text is escaped before insertion.
+    grid.innerHTML = `<div class="empty-state"><div class="es-icon">!</div><div class="es-msg">${escapeHtml((res && res.error) || 'Unknown error')}</div></div>`;
+    return;
+  }
+  projectsCache = res.projects || [];
+  activeProjectId = res.activeProjectId || null;
+  paintProjects(projectsCache, ($('#projects-search') || {}).value || '');
+}
+
+function fmtRelTime(iso) {
+  if (!iso) return 'never';
+  const t = Date.parse(iso);
+  if (!isFinite(t)) return iso;
+  const ms = Date.now() - t;
+  if (ms < 0) return 'now';
+  const m = Math.floor(ms / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(t).toLocaleDateString();
+}
+
+function paintProjects(items, filter) {
+  const grid = $('#projects-grid');
+  if (!grid) return;
+  const q = (filter || '').toLowerCase().trim();
+  const filtered = q
+    ? items.filter((p) => (p.name + ' ' + p.path).toLowerCase().includes(q))
+    : items;
+  if (!filtered.length) {
+    const msg = q
+      ? `No projects match "${escapeHtml(q)}"`
+      : `No projects yet. Click + Add project to pin a folder.`;
+    // eslint-disable-next-line no-unsanitized/property -- escapeHtml on dynamic part.
+    grid.innerHTML = `<div class="empty-state"><div class="es-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg></div><div class="es-msg">${msg}</div></div>`;
+    return;
+  }
+  const cards = filtered.map((p) => {
+    const isActive = p.id === activeProjectId;
+    return `
+      <div class="project-card${isActive ? ' is-active' : ''}" data-id="${escapeHtml(p.id)}">
+        <div class="project-card-head">
+          <div class="project-card-title">${escapeHtml(p.name)}</div>
+          ${isActive ? '<span class="project-card-pill">active</span>' : ''}
+        </div>
+        <div class="project-card-path" title="${escapeHtml(p.path)}">${escapeHtml(p.path)}</div>
+        <div class="project-card-meta">last used: ${escapeHtml(fmtRelTime(p.lastUsedAt))}</div>
+        <div class="project-card-actions">
+          <button class="ghost-btn ghost-btn-danger project-delete" data-id="${escapeHtml(p.id)}" data-name="${escapeHtml(p.name)}" title="Delete project"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg></button>
+          <button class="btn-primary project-open" data-id="${escapeHtml(p.id)}" title="Switch to this project">${isActive ? 'Reopen here' : 'Open here'}</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+  // eslint-disable-next-line no-unsanitized/property -- Every interpolation goes through escapeHtml.
+  grid.innerHTML = cards;
+  grid.querySelectorAll('.project-open').forEach((btn) => btn.addEventListener('click', (e) => { e.stopPropagation(); openProject(e.currentTarget.dataset.id); }));
+  grid.querySelectorAll('.project-delete').forEach((btn) => btn.addEventListener('click', (e) => { e.stopPropagation(); deleteProject(e.currentTarget.dataset.id, e.currentTarget.dataset.name, e.currentTarget); }));
+  // Whole card is also a click target for opening (excluding the action area).
+  grid.querySelectorAll('.project-card').forEach((card) => card.addEventListener('click', (e) => {
+    if (e.target.closest('.project-card-actions')) return;
+    openProject(card.dataset.id);
+  }));
+}
+
+async function openProject(id) {
+  if (!id) return;
+  const res = await window.husk.projects.setActive(id);
+  if (!res || !res.ok) return;
+  activeProjectId = id;
+  await refreshProjectsState();
+  // Pass the project's path explicitly to restartPty so the new PTY lands
+  // in the right cwd even if there is any lag between setActive persisting
+  // config and pty.restart reading it. Belt-and-suspenders.
+  const project = (res.project && res.project.path) ? res.project : (projectsCache.find((p) => p.id === id) || {});
+  await restartPty({ cwd: project.path || null });
+  setPage('chat');
+}
+
+async function refreshProjectsState() {
+  // Re-pull list so lastUsedAt freshens, then update topbar chip + grid + cfg cache.
+  const res = await window.husk.projects.list();
+  if (!res || !res.ok) return;
+  projectsCache = res.projects || [];
+  activeProjectId = res.activeProjectId || null;
+  updateActiveProjectChip();
+  if (currentPage === 'projects') paintProjects(projectsCache, ($('#projects-search') || {}).value || '');
+  // Refresh chat-sub since the agent cwd may have changed.
+  try { cfg = await window.husk.config.get(); } catch (_) {}
+  updateAgentPill && updateAgentPill();
+  const cmdShort = (cfg.agentCommand || 'agent').split(/\s+/)[0];
+  const active = projectsCache.find((p) => p.id === activeProjectId);
+  const cwdLabel = active ? active.path : (cfg.agentCwd || '$HOME');
+  if ($('#chat-sub')) $('#chat-sub').textContent = `${cmdShort} · ${cwdLabel}`;
+}
+
+function updateActiveProjectChip() {
+  const chip = document.getElementById('topbar-project');
+  const label = document.getElementById('topbar-project-name');
+  if (!chip || !label) return;
+  const active = projectsCache.find((p) => p.id === activeProjectId);
+  if (!active) { chip.hidden = true; label.textContent = ''; return; }
+  chip.hidden = false;
+  label.textContent = active.name;
+  chip.title = `Active project: ${active.name}\n${active.path}\nClick to manage projects`;
+}
+
+const _armedProjectDeletes = new WeakMap();
+async function deleteProject(id, name, btn) {
+  if (!id || !btn) return;
+  if (_armedProjectDeletes.has(btn)) {
+    clearTimeout(_armedProjectDeletes.get(btn).timer);
+    _armedProjectDeletes.delete(btn);
+    const res = await window.husk.projects.delete(id);
+    if (!res || !res.ok) {
+      const t = document.getElementById('toast');
+      if (t) { t.textContent = (res && res.error) || 'Could not delete project'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
+      return;
+    }
+    await refreshProjectsState();
+    return;
+  }
+  const originalHTML = btn.innerHTML;
+  btn.textContent = 'Confirm?';
+  btn.classList.add('is-armed');
+  const timer = setTimeout(() => {
+    if (!_armedProjectDeletes.has(btn)) return;
+    _armedProjectDeletes.delete(btn);
+    btn.classList.remove('is-armed');
+    // eslint-disable-next-line no-unsanitized/property -- originalHTML captured from this same node.
+    btn.innerHTML = originalHTML;
+  }, 3000);
+  _armedProjectDeletes.set(btn, { timer });
+}
+
+// Wire Projects page controls + Add Project modal.
+{
+  const search = document.getElementById('projects-search');
+  if (search) search.addEventListener('input', () => paintProjects(projectsCache, search.value));
+
+  const newBtn = document.getElementById('btn-projects-new');
+  const modal = document.getElementById('new-project-modal');
+  const nameEl = document.getElementById('npj-name');
+  const pathEl = document.getElementById('npj-path');
+  const pickEl = document.getElementById('npj-pick');
+  const cancelBtn = document.getElementById('npj-cancel');
+  const createBtn = document.getElementById('npj-create');
+  function open() { if (!modal) return; if (nameEl) nameEl.value = ''; if (pathEl) pathEl.value = ''; modal.hidden = false; setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30); }
+  function close() { if (modal) modal.hidden = true; }
+  async function submit() {
+    let name = (nameEl && nameEl.value || '').trim();
+    const projPath = (pathEl && pathEl.value || '').trim();
+    if (!name && projPath) name = projPath.split('/').filter(Boolean).pop() || 'project';
+    const res = await window.husk.projects.create({ name, path: projPath });
+    if (!res || !res.ok) {
+      const t = document.getElementById('toast');
+      if (t) { t.textContent = (res && res.error) || 'Could not add project'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
+      return;
+    }
+    close();
+    await refreshProjectsState();
+    if (currentPage === 'projects') await renderProjects();
+  }
+  if (newBtn) newBtn.addEventListener('click', open);
+  if (cancelBtn) cancelBtn.addEventListener('click', close);
+  if (createBtn) createBtn.addEventListener('click', submit);
+  if (pickEl) pickEl.addEventListener('click', async () => {
+    try { const picked = await window.husk.dialog2.pickDir(); if (picked && pathEl) pathEl.value = picked; } catch (_) {}
+  });
+  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+
+  // Topbar chip click navigates to Projects page.
+  const chip = document.getElementById('topbar-project');
+  if (chip) chip.addEventListener('click', () => setPage('projects'));
+}
+
+// ─── Prompts page ──────────────────────────────────────────────────────────────
+let promptsCache = [];
+async function renderPrompts() {
+  const grid = $('#prompts-grid');
+  if (!grid) return;
+  // eslint-disable-next-line no-unsanitized/property -- Static loading template.
+  grid.innerHTML = '<div class="empty-state"><div class="es-icon">⌬</div><div class="es-msg">Loading prompts…</div></div>';
+  const res = await window.husk.prompts.list();
+  if (!res.ok) {
+    // eslint-disable-next-line no-unsanitized/property -- Error text is escaped before insertion.
+    grid.innerHTML = `<div class="empty-state"><div class="es-icon">!</div><div class="es-msg">${escapeHtml(res.error || 'Unknown error')}</div></div>`;
+    return;
+  }
+  promptsCache = res.prompts || [];
+  paintPrompts(promptsCache, ($('#prompts-search') || {}).value || '');
+}
+
+function paintPrompts(items, filter) {
+  const grid = $('#prompts-grid');
+  if (!grid) return;
+  const q = (filter || '').toLowerCase().trim();
+  const filtered = q
+    ? items.filter((p) => (p.name + ' ' + (p.description || '')).toLowerCase().includes(q))
+    : items;
+  if (!filtered.length) {
+    const msg = q ? `No prompts match "${escapeHtml(q)}"` : 'No prompts yet. Drop markdown files in ~/.config/husk/prompts/';
+    // eslint-disable-next-line no-unsanitized/property -- escapeHtml above; rest is static.
+    grid.innerHTML = `<div class="empty-state"><div class="es-icon">⌬</div><div class="es-msg">${msg}</div></div>`;
+    return;
+  }
+  const cards = filtered.map((p) => `
+    <div class="prompt-card${p.disabled ? ' is-disabled' : ''}" data-md="${escapeHtml(p.mdPath)}">
+      <div class="prompt-card-head">
+        <div class="prompt-card-title">${escapeHtml(p.name)}</div>
+        ${p.disabled ? '<span class="prompt-card-pill">disabled</span>' : ''}
+      </div>
+      <div class="prompt-card-body">${escapeHtml(p.description || '')}</div>
+      <div class="prompt-card-actions">
+        <button class="ghost-btn prompt-preview" data-md="${escapeHtml(p.mdPath)}" title="Preview body">Preview</button>
+        <button class="ghost-btn ghost-btn-danger prompt-delete" data-md="${escapeHtml(p.mdPath)}" data-name="${escapeHtml(p.name)}" title="Delete prompt"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/></svg></button>
+        <button class="btn-primary prompt-run" data-md="${escapeHtml(p.mdPath)}" title="Send into chat">Run</button>
+      </div>
+    </div>
+  `).join('');
+  // eslint-disable-next-line no-unsanitized/property -- Every interpolation goes through escapeHtml above.
+  grid.innerHTML = cards;
+  grid.querySelectorAll('.prompt-run').forEach((btn) => btn.addEventListener('click', (e) => runPrompt(e.currentTarget.dataset.md)));
+  grid.querySelectorAll('.prompt-preview').forEach((btn) => btn.addEventListener('click', (e) => previewPrompt(e.currentTarget.dataset.md)));
+  grid.querySelectorAll('.prompt-delete').forEach((btn) => btn.addEventListener('click', (e) => deletePrompt(e.currentTarget.dataset.md, e.currentTarget.dataset.name, e.currentTarget)));
+}
+
+// Two-click confirm pattern: first click arms the button, second click within
+// the timeout commits. Avoids window.confirm() which fires a native GTK
+// dialog and produces noisy GLib signal warnings on Linux/WSL.
+const _armedDeletes = new WeakMap();
+async function deletePrompt(mdPath, name, btn) {
+  if (!mdPath || !btn) return;
+  if (_armedDeletes.has(btn)) {
+    clearTimeout(_armedDeletes.get(btn).timer);
+    _armedDeletes.delete(btn);
+    const res = await window.husk.prompts.delete(mdPath);
+    if (!res || !res.ok) {
+      const t = document.getElementById('toast');
+      if (t) { t.textContent = (res && res.error) || 'Could not delete prompt'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
+      return;
+    }
+    await renderPrompts();
+    return;
+  }
+  // Arm. Save the original markup so we can restore the SVG icon if the user
+  // hesitates and lets the timeout fire.
+  const originalHTML = btn.innerHTML;
+  btn.textContent = 'Confirm?';
+  btn.classList.add('is-armed');
+  const timer = setTimeout(() => {
+    if (!_armedDeletes.has(btn)) return;
+    _armedDeletes.delete(btn);
+    btn.classList.remove('is-armed');
+    // eslint-disable-next-line no-unsanitized/property -- originalHTML was captured from this same DOM node, no external input.
+    btn.innerHTML = originalHTML;
+  }, 3000);
+  _armedDeletes.set(btn, { timer });
+}
+
+async function runPrompt(mdPath) {
+  if (!mdPath) return;
+  const res = await window.husk.skills.read(mdPath);
+  if (!res.ok || !res.content) return;
+  // Strip the frontmatter block; we want the body only sent into the chat.
+  const body = res.content.replace(/^---[\s\S]*?---\n?/, '').trim();
+  if (!body) return;
+  setPage('chat');
+  // Send the prompt body to the agent's PTY. Append a newline so the agent
+  // treats it as a complete user turn. setPage('chat') focuses the terminal.
+  setTimeout(() => { try { window.husk.pty.write(body + '\n'); } catch (_) {} }, 60);
+}
+
+async function previewPrompt(mdPath) {
+  if (!mdPath) return;
+  const res = await window.husk.skills.read(mdPath);
+  if (!res.ok) return;
+  const body = (res.content || '').replace(/^---[\s\S]*?---\n?/, '').trim();
+  // Reuse the existing detail panel scaffolding if present; fall back to alert.
+  const eyebrow = $('#dp-eyebrow'); const title = $('#dp-title'); const sub = $('#dp-sub'); const bodyEl = $('#dp-body'); const panel = $('#detail-panel');
+  if (panel && title && bodyEl) {
+    if (eyebrow) eyebrow.textContent = 'Prompt';
+    title.textContent = mdPath.split('/').pop().replace(/\.md$/, '');
+    if (sub) sub.textContent = mdPath;
+    bodyEl.textContent = body;
+    document.body.dataset.detail = 'open';
+    panel.hidden = false;
+  }
+}
+
+// Wire prompts search + refresh + create.
+{
+  const search = document.getElementById('prompts-search');
+  if (search) search.addEventListener('input', () => paintPrompts(promptsCache, search.value));
+  const refresh = document.getElementById('btn-prompts-refresh');
+  if (refresh) refresh.addEventListener('click', renderPrompts);
+
+  const newBtn = document.getElementById('btn-prompts-new');
+  const modal = document.getElementById('new-prompt-modal');
+  const nameEl = document.getElementById('np-name');
+  const descEl = document.getElementById('np-desc');
+  const bodyEl = document.getElementById('np-content');
+  const cancelBtn = document.getElementById('np-cancel');
+  const createBtn = document.getElementById('np-create');
+  function openNewPrompt() {
+    if (!modal) return;
+    if (nameEl) nameEl.value = '';
+    if (descEl) descEl.value = '';
+    if (bodyEl) bodyEl.value = '';
+    modal.hidden = false;
+    setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30);
+  }
+  function closeNewPrompt() { if (modal) modal.hidden = true; }
+  async function submitNewPrompt() {
+    const name = (nameEl && nameEl.value || '').trim();
+    const description = (descEl && descEl.value || '').trim();
+    const content = bodyEl && bodyEl.value || '';
+    const res = await window.husk.prompts.create({ name, description, content });
+    if (!res || !res.ok) {
+      const t = document.getElementById('toast');
+      if (t) { t.textContent = (res && res.error) || 'Could not create prompt'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
+      return;
+    }
+    closeNewPrompt();
+    await renderPrompts();
+  }
+  if (newBtn) newBtn.addEventListener('click', openNewPrompt);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeNewPrompt);
+  if (createBtn) createBtn.addEventListener('click', submitNewPrompt);
+  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeNewPrompt(); });
+}
+
+// ─── Skills page ──────────────────────────────────────────────────────────────
 let skillsCache = [];
 let agentKindCache = 'claude';
 async function renderSkills() {
@@ -812,6 +1199,7 @@ $('#files-root').addEventListener('change', async (e) => {
 function bindPrefs() {
   $('#pref-agent').value = cfg.agentCommand || '';
   $('#pref-agent-name').value = cfg.agentName || 'Husk';
+  if ($('#pref-agent-cwd')) $('#pref-agent-cwd').value = cfg.agentCwd || '';
   $('#pref-recap').checked = cfg.recap !== false;
   $('#pref-theme').value = cfg.theme || 'dark';
   $('#pref-rail').checked = !!cfg.railExpanded;
@@ -825,7 +1213,9 @@ function bindPrefs() {
   $('#pref-voice-rate-display').textContent = `${Number(v.rate || 1.0).toFixed(1)}×`;
   const cmdShort = (cfg.agentCommand || 'agent').split(/\s+/)[0];
   const agentDisplay = cfg.agentName || 'Husk';
-  $('#chat-sub').textContent = `${cmdShort} · ${cfg.treeRoot || ''}`;
+  // Show the same cwd the agent is actually launched in (config.agentCwd
+  // wins; falls back to $HOME when unset, mirroring main.js's resolution).
+  $('#chat-sub').textContent = `${cmdShort} · ${cfg.agentCwd || '$HOME'}`;
   $('#ce-agent').textContent = agentDisplay;
   if ($('#sp-agent')) $('#sp-agent').textContent = cfg.agentCommand || 'claude';
 }
@@ -988,18 +1378,33 @@ function detectAndSpeak(chunk) {
 }
 $('#pref-save').addEventListener('click', async () => {
   const name = ($('#pref-agent-name').value || '').trim().slice(0, 40) || 'Husk';
+  const cwdInput = $('#pref-agent-cwd');
+  const agentCwd = cwdInput ? cwdInput.value.trim() : '';
   cfg = await window.husk.config.set({
     agentCommand: $('#pref-agent').value.trim(),
     agentName: name,
+    agentCwd,
   });
   bindPrefs();
-  // Agent change may flip claude → generic, so refresh the prompts label / list.
   renderSkills();
   updateAgentPill();
   paintAgentMenu();
   toast('Saved, restarting agent', 'success');
   await restartPty();
 });
+
+// Folder picker for the working directory field.
+{
+  const pickBtn = document.getElementById('btn-pref-cwd-pick');
+  if (pickBtn) {
+    pickBtn.addEventListener('click', async () => {
+      try {
+        const picked = await window.husk.dialog2.pickDir();
+        if (picked && $('#pref-agent-cwd')) $('#pref-agent-cwd').value = picked;
+      } catch (_) {}
+    });
+  }
+}
 $('#pref-theme').addEventListener('change', async (e) => {
   cfg = await window.husk.config.set({ theme: e.target.value });
   applyTheme(cfg.theme);
@@ -2158,6 +2563,7 @@ async function boot() {
   refreshVoiceStatus();
   refreshContextList();
   refreshRecentList();
+  refreshProjectsState();
   // Pause polling when the window is hidden so we don't burn frames or
   // recompute the status panel for an invisible UI.
   setInterval(async () => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -73,9 +73,16 @@
         <img class="logo-img" src="assets/husk-logo.png" alt="Husk" />
         <span class="brand-text">HUSK</span>
       </div>
+      <button class="topbar-project" id="topbar-project" title="Active project (click to switch)" hidden>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg>
+        <span class="tp-name" id="topbar-project-name"></span>
+      </button>
       <div class="topbar-spacer"></div>
       <button class="iconbtn" id="btn-palette" title="Command palette (Ctrl+K)">⌘K</button>
-      <button class="iconbtn" id="btn-theme" title="Toggle theme"><span id="theme-icon">☾</span></button>
+      <button class="iconbtn" id="btn-theme" title="Toggle theme">
+        <svg class="theme-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        <svg class="theme-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+      </button>
       <button class="iconbtn iconbtn-primary" id="btn-new-session" title="New chat session (restarts the agent)">+ New Chat</button>
     </header>
 
@@ -100,6 +107,14 @@
             <button class="rail-item active" data-page="chat" title="Chat">
               <span class="ri-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5z"/></svg></span>
               <span class="ri-label">Chat</span>
+            </button>
+            <button class="rail-item" data-page="projects" title="Projects">
+              <span class="ri-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/><path d="M3 11h18"/></svg></span>
+              <span class="ri-label">Projects</span>
+            </button>
+            <button class="rail-item" data-page="prompts" title="Prompts">
+              <span class="ri-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 4h11l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1z"/><path d="M16 4v3h3"/><path d="M8 12h8M8 16h8M8 8h4"/></svg></span>
+              <span class="ri-label">Prompts</span>
             </button>
             <button class="rail-item" data-page="skills" title="Skills">
               <span class="ri-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1"/><circle cx="12" cy="12" r="3"/></svg></span>
@@ -160,7 +175,7 @@
               <span class="page-sub" id="chat-sub">claude · ~</span>
             </div>
             <div class="page-head-right">
-              <button class="ghost-btn" id="btn-restart" title="Restart agent">↻ Restart</button>
+              <button class="ghost-btn" id="btn-restart" title="Restart agent"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg> Restart</button>
             </div>
           </div>
           <div class="chat-stage">
@@ -186,6 +201,95 @@
           </div>
         </div>
 
+        <!-- PROJECTS PAGE -->
+        <div class="page page-projects" data-page="projects" hidden>
+          <div class="page-head">
+            <div class="page-head-left">
+              <h1 class="page-title">Projects</h1>
+              <span class="page-sub">click a project to launch the agent there; click again or use Restart to switch</span>
+            </div>
+            <div class="page-head-right">
+              <input type="search" id="projects-search" class="ghost-input" placeholder="Filter projects…" />
+              <button class="btn-primary" id="btn-projects-new" title="Add a new project"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> Add project</button>
+            </div>
+          </div>
+          <div class="projects-grid" id="projects-grid"></div>
+        </div>
+
+        <!-- Create project modal -->
+        <div id="new-project-modal" class="modal" hidden>
+          <div class="modal-card modal-wide">
+            <div class="modal-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg></div>
+            <div class="modal-title">Add a project</div>
+            <div class="modal-sub">Pin a folder so the agent can launch into it with one click. Stored locally in <code>~/.config/husk/config.json</code>.</div>
+            <div class="modal-section">
+              <div class="modal-label">Name</div>
+              <input type="text" id="npj-name" placeholder="Husk redesign" autocomplete="off" spellcheck="false" maxlength="80" />
+              <div class="modal-hint">Short, human-readable. Appears in the Projects grid and the topbar.</div>
+            </div>
+            <div class="modal-section">
+              <div class="modal-label">Folder</div>
+              <span style="display:inline-flex; gap:6px; width:100%;">
+                <input type="text" id="npj-path" placeholder="/home/dorsh/projects/husk" autocomplete="off" spellcheck="false" style="flex:1; min-width:0;" />
+                <button class="ghost-btn" id="npj-pick" type="button">Pick&hellip;</button>
+              </span>
+              <div class="modal-hint">Must exist. The agent will <code>cd</code> here when this project is active.</div>
+            </div>
+            <div class="modal-actions">
+              <button class="ghost-btn" id="npj-cancel">Cancel</button>
+              <button class="btn-primary" id="npj-create">Add project</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- PROMPTS PAGE -->
+        <div class="page page-prompts" data-page="prompts" hidden>
+          <div class="page-head">
+            <div class="page-head-left">
+              <h1 class="page-title">Prompts</h1>
+              <span class="page-sub">starter prompts; click Run to send into the chat</span>
+            </div>
+            <div class="page-head-right">
+              <input type="search" id="prompts-search" class="ghost-input" placeholder="Filter prompts…" />
+              <button class="ghost-btn" id="btn-prompts-refresh" title="Refresh"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg></button>
+              <button class="btn-primary" id="btn-prompts-new" title="Create a new prompt"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> Create prompt</button>
+            </div>
+          </div>
+          <div class="prompts-grid" id="prompts-grid"></div>
+        </div>
+
+        <!-- Create prompt modal -->
+        <div id="new-prompt-modal" class="modal" hidden>
+          <div class="modal-card modal-wide">
+            <div class="modal-icon">📝</div>
+            <div class="modal-title">Create a prompt</div>
+            <div class="modal-sub">Saved as <code>~/.config/husk/prompts/&lt;name&gt;.md</code> and shown on the Prompts page.</div>
+
+            <div class="modal-section">
+              <div class="modal-label">Name</div>
+              <input type="text" id="np-name" placeholder="my-new-prompt" autocomplete="off" spellcheck="false" />
+              <div class="modal-hint">Lowercase, dashes ok. Becomes the filename and the frontmatter <code>name</code>.</div>
+            </div>
+
+            <div class="modal-section">
+              <div class="modal-label">Description</div>
+              <input type="text" id="np-desc" placeholder="One-line summary of what this prompt does" autocomplete="off" />
+              <div class="modal-hint">Shown on the Prompts card. Required.</div>
+            </div>
+
+            <div class="modal-section">
+              <div class="modal-label">Body (Markdown)</div>
+              <textarea id="np-content" placeholder="The prompt itself. Sent into the chat when you click Run." spellcheck="false"></textarea>
+              <div class="modal-hint">Optional. Empty falls back to a simple template.</div>
+            </div>
+
+            <div class="modal-actions">
+              <button class="ghost-btn" id="np-cancel">Cancel</button>
+              <button class="btn-primary" id="np-create">Create prompt</button>
+            </div>
+          </div>
+        </div>
+
         <!-- SKILLS PAGE -->
         <div class="page page-skills" data-page="skills" hidden>
           <div class="page-head">
@@ -195,9 +299,9 @@
             </div>
             <div class="page-head-right">
               <input type="search" id="skills-search" class="ghost-input" placeholder="Filter skills…" />
-              <button class="ghost-btn" id="btn-skills-refresh" title="Refresh">↻</button>
+              <button class="ghost-btn" id="btn-skills-refresh" title="Refresh"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg></button>
               <button class="ghost-btn" id="btn-skills-open" title="Open in OS">Open folder</button>
-              <button class="btn-primary" id="btn-skills-new" title="Create a new skill">＋ Create skill</button>
+              <button class="btn-primary" id="btn-skills-new" title="Create a new skill"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> Create skill</button>
             </div>
           </div>
           <div class="skills-grid" id="skills-grid"></div>
@@ -212,7 +316,7 @@
             </div>
             <div class="page-head-right">
               <input type="search" id="sessions-search" class="ghost-input" placeholder="Filter sessions…" />
-              <button class="ghost-btn" id="btn-sessions-refresh" title="Refresh">↻</button>
+              <button class="ghost-btn" id="btn-sessions-refresh" title="Refresh"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg></button>
               <button class="ghost-btn" id="btn-sessions-open" title="Open in OS">Open folder</button>
               <button class="ghost-btn" id="btn-sessions-select" title="Select sessions to delete">Select</button>
               <button class="ghost-btn ghost-btn-danger" id="btn-sessions-delete" title="Delete selected sessions" hidden>Delete (0)</button>
@@ -231,8 +335,8 @@
               <span class="page-sub">give the agent more abilities · click an entry to install</span>
             </div>
             <div class="page-head-right">
-              <button class="ghost-btn" id="btn-mcp-refresh" title="Refresh">↻</button>
-              <button class="btn-primary" id="btn-mcp-add-custom" title="Install any MCP server with a custom command">＋ Add custom server</button>
+              <button class="ghost-btn" id="btn-mcp-refresh" title="Refresh"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg></button>
+              <button class="btn-primary" id="btn-mcp-add-custom" title="Install any MCP server with a custom command"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> Add custom server</button>
             </div>
           </div>
           <div class="mcp-body">
@@ -274,7 +378,7 @@
                 <span>Show hidden</span>
               </label>
               <input type="text" id="files-root" class="ghost-input" placeholder="root path" />
-              <button class="ghost-btn" id="btn-files-refresh">↻</button>
+              <button class="ghost-btn" id="btn-files-refresh" title="Refresh"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg></button>
             </div>
           </div>
           <div class="tree" id="tree"></div>
@@ -299,7 +403,14 @@
                 <span class="pref-label">Command</span>
                 <input type="text" id="pref-agent" placeholder="claude" />
               </label>
-              <div class="pref-hint">Name is what the agent calls itself when asked. Saved to <code>~/.config/husk/config.json</code>.</div>
+              <label class="pref-row">
+                <span class="pref-label">Working directory</span>
+                <span style="display:inline-flex; gap:6px; flex:1;">
+                  <input type="text" id="pref-agent-cwd" placeholder="e.g. /home/dorsh/projects/myapp" style="flex:1; min-width:0;" />
+                  <button class="ghost-btn" id="btn-pref-cwd-pick" type="button">Pick&hellip;</button>
+                </span>
+              </label>
+              <div class="pref-hint">Where the agent launches. Leave empty for your home directory (claude refuses permanent trust there and asks every launch). A project subdirectory restores the "remember this folder" option.</div>
               <button class="btn-primary" id="pref-save">Save &amp; Restart Agent</button>
             </section>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -118,9 +118,8 @@ body {
 }
 .brand { display: flex; align-items: center; gap: 12px; -webkit-app-region: no-drag; }
 .logo-img {
-  width: 40px; height: 40px;
+  width: 30px; height: 30px;
   display: block;
-  filter: drop-shadow(0 0 8px rgba(217, 119, 87, 0.55));
   user-select: none;
   -webkit-user-drag: none;
 }
@@ -147,7 +146,10 @@ body {
   border: 1px solid var(--line);
   border-radius: 999px;
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace; font-size: 11px; font-weight: 600;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
   transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
 }
@@ -210,6 +212,10 @@ body {
   transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease, transform 0.14s ease;
 }
 .iconbtn:hover { color: var(--text); border-color: var(--accent); background: var(--bg-2); box-shadow: 0 0 0 3px var(--accent-glow); }
+.iconbtn svg { width: 16px; height: 16px; display: block; }
+.btn-primary .btn-icon { width: 14px; height: 14px; flex: 0 0 auto; display: block; }
+body[data-theme="dark"] #btn-theme .theme-sun { display: none; }
+body[data-theme="light"] #btn-theme .theme-moon { display: none; }
 .iconbtn-primary {
   background: color-mix(in srgb, var(--accent) 16%, var(--bg-3));
   color: var(--text);
@@ -405,7 +411,7 @@ body[data-rail="collapsed"] .rail-agent-menu { display: none !important; }
 .rail-agent-item[data-available="0"] { opacity: 0.45; cursor: not-allowed; }
 .rail-agent-item[data-active="1"] { background: color-mix(in srgb, var(--accent) 14%, transparent); }
 .rail-agent-item .rai-name { flex: 1; font-weight: 600; }
-.rail-agent-item .rai-cmd { color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-size: 10px; }
+.rail-agent-item .rai-cmd { color: var(--text-3); font-size: 10px; font-variant-numeric: tabular-nums; }
 .rail-agent-item[data-available="0"] .rai-cmd::after { content: ' (not installed)'; color: var(--rose); }
 .rail-agent-divider { height: 1px; background: var(--line); margin: 4px 6px; }
 .rail-agent-config {
@@ -434,7 +440,7 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .rail-recent-item .rri-meta {
   font-size: 10px; color: var(--text-3);
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  font-family: 'JetBrains Mono', monospace;
+  font-variant-numeric: tabular-nums;
 }
 .rail-sub {
   display: flex; flex-direction: column; gap: 2px;
@@ -503,9 +509,23 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   font-family: inherit;
   font-weight: 500;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease, transform 0.14s ease;
 }
 .ghost-btn:hover { color: var(--text); border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, var(--bg-3)); }
+.ghost-btn .btn-icon { width: 14px; height: 14px; flex: 0 0 auto; display: block; }
+.ghost-btn-danger { color: var(--rose); border-color: color-mix(in srgb, var(--rose) 30%, var(--line)); }
+.ghost-btn-danger:hover { color: #fff; background: var(--rose); border-color: var(--rose); }
+.ghost-btn-danger.is-armed {
+  color: #fff;
+  background: var(--rose);
+  border-color: var(--rose);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
 .ghost-toggle {
   display: inline-flex; align-items: center; gap: 8px;
   font-size: 13px; color: var(--text-2);
@@ -542,10 +562,9 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 .chat-empty.show { opacity: 1; pointer-events: auto; }
 .ce-logo-img {
-  width: 96px; height: 96px;
+  width: 64px; height: 64px;
   display: block;
   margin: 0 auto 10px;
-  filter: drop-shadow(0 0 22px var(--accent-glow));
   user-select: none;
   -webkit-user-drag: none;
 }
@@ -592,6 +611,135 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 #terminal { height: 100%; min-height: 0; }
 .xterm-viewport { background-color: transparent !important; }
+
+/* ─── Projects page ────────────────────────────────────────────────────── */
+
+.projects-grid {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 12px;
+  padding-right: 4px;
+  align-content: start;
+}
+.project-card {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px 16px 12px;
+  display: flex; flex-direction: column; gap: 8px;
+  cursor: pointer;
+  transition: border-color 0.14s ease, box-shadow 0.14s ease, transform 0.14s ease;
+}
+.project-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--line));
+  box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+  transform: translateY(-1px);
+}
+.project-card.is-active {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-1));
+}
+.project-card-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+}
+.project-card-title {
+  font-size: 14px; font-weight: 600; color: var(--text);
+  letter-spacing: -0.005em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.project-card-pill {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: #fff; background: var(--accent);
+  border-radius: 999px; padding: 2px 8px;
+}
+.project-card-path {
+  font-size: 11px; color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.project-card-meta {
+  font-size: 11px; color: var(--text-3);
+}
+.project-card-actions {
+  display: flex; gap: 8px; margin-top: 4px;
+}
+.project-card-actions .ghost-btn { padding: 6px 12px; font-size: 12px; }
+.project-card-actions .btn-primary { padding: 6px 14px; font-size: 12px; flex: 1; }
+
+/* Topbar active-project chip */
+.topbar-project {
+  -webkit-app-region: no-drag;
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 6px 11px;
+  background: var(--bg-3);
+  color: var(--text-2);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px; font-weight: 600;
+  letter-spacing: 0.01em;
+  max-width: 280px;
+  transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease;
+}
+.topbar-project svg { width: 14px; height: 14px; flex: 0 0 auto; }
+.topbar-project .tp-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.topbar-project:hover { color: var(--text); border-color: var(--accent); }
+
+/* ─── Prompts page ─────────────────────────────────────────────────────── */
+
+.prompts-grid {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+  padding-right: 4px;
+  align-content: start;
+}
+.prompt-card {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px 16px 12px;
+  display: flex; flex-direction: column; gap: 8px;
+  transition: border-color 0.14s ease, box-shadow 0.14s ease, transform 0.14s ease;
+}
+.prompt-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--line));
+  box-shadow: 0 2px 6px rgba(0,0,0,0.18);
+}
+.prompt-card.is-disabled { opacity: 0.55; }
+.prompt-card-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+}
+.prompt-card-title {
+  font-size: 14px; font-weight: 600; color: var(--text);
+  letter-spacing: -0.005em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.prompt-card-pill {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-3);
+  background: var(--bg-3);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+.prompt-card-body {
+  font-size: 12px; color: var(--text-2);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 3; line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 54px;
+}
+.prompt-card-actions {
+  display: flex; gap: 8px; margin-top: 4px;
+}
+.prompt-card-actions .ghost-btn { padding: 6px 12px; font-size: 12px; }
+.prompt-card-actions .btn-primary { padding: 6px 14px; font-size: 12px; flex: 1; }
 
 /* ─── Skills page ───────────────────────────────────────────────────────── */
 
@@ -814,8 +962,22 @@ input[type="checkbox"]:disabled {
   align-items: center; justify-content: center;
   gap: 10px; color: var(--text-3);
 }
-.empty-state .es-icon { font-size: 44px; opacity: 0.4; }
-.empty-state .es-msg { font-size: 14px; }
+.empty-state .es-icon { font-size: 44px; opacity: 0.4; display: flex; justify-content: center; }
+.empty-state .es-icon svg { width: 44px; height: 44px; display: block; }
+.modal-icon svg { width: 32px; height: 32px; display: block; margin: 0 auto; color: var(--accent); }
+.empty-state .es-msg { font-size: 14px; text-align: center; max-width: 420px; }
+/* When an empty-state lands inside a CSS grid (projects/prompts/skills/mcp),
+   the default behavior is to land in the first cell at top-left. Span all
+   columns and force a comfortable min-height so the message centers in the
+   visible page area instead of huddling in a 320px corner cell. */
+.projects-grid > .empty-state,
+.prompts-grid > .empty-state,
+.skills-grid > .empty-state,
+.mcp-grid > .empty-state,
+.mcp-installed > .empty-state {
+  grid-column: 1 / -1;
+  min-height: 360px;
+}
 
 /* ─── Files page (tree) ─────────────────────────────────────────────────── */
 
@@ -1065,6 +1227,10 @@ input[type="checkbox"]:disabled {
   font-size: 13px;
   font-weight: 600;
   cursor: pointer; font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease, transform 0.14s ease;
   letter-spacing: -0.01em;
 }
@@ -1114,6 +1280,7 @@ input[type="checkbox"]:disabled {
   padding: 14px 14px 6px;
   display: flex; flex-direction: column; gap: 14px;
 }
+
 .sp-section {
   display: flex; flex-direction: column; gap: 6px;
 }
@@ -1139,9 +1306,10 @@ input[type="checkbox"]:disabled {
   gap: 8px;
 }
 .sp-section-body .sp-mono {
-  font-family: 'JetBrains Mono', monospace;
   color: var(--text);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
 }
 .sp-section-body .sp-muted { color: var(--text-3); }
 .sp-section-body .sp-accent { color: var(--accent); font-weight: 600; }


### PR DESCRIPTION
v0.4.0 release. Three commits:

1. `chore(installer)`: cross-platform first-run experience
2. `feat`: the bulk of the release (Projects + Prompts + statusline cache + UI polish + restart race fix)
3. `chore(release)`: version bump to 0.4.0

## Highlights

### Projects primitive (new top-of-rail item)
- Named project list, click to switch, agent restarts in that path
- Topbar chip shows the active project; click navigates to Projects page
- Solves the recurring trust prompt: claude refuses durable folder-trust on `$HOME` for security reasons but accepts it on a project subdirectory, so Husk now defaults to launching the agent there.
- cwd resolution priority: explicit override (Resume) > active project > `config.agentCwd` > `$HOME`

### Prompts page (new)
- Reads `~/.config/husk/prompts/`, seeded from `installer/prompts/` on first run
- Cards with Preview, two-click trash delete, and Run (sends body into the active PTY)
- Create modal for new prompts

### Anthropic usage cache rewrite
- Husk's main process now fetches `/api/oauth/usage` directly and writes `usage-cache.json` on a 30s timer
- jq-free (parsing is in Node), works on systems without it
- Right STATUS panel's 5h / Weekly populate seconds after launch instead of staying empty

### Trust prompt fix (root cause)
- Removed the ephemeral `--settings <temp-file>` injection that was breaking claude's folder-trust persistence (the temp file got rebuilt every launch, blowing away the trust write)
- New tradeoff: claude renders its own inline statusline at the bottom of the chat terminal alongside Husk's right panel. Acceptable; persistent trust is more valuable.

### Cross-platform installer
- `install.sh` now auto-installs jq, unzip, bun via the platform's package manager (apt/dnf/yum/pacman/zypper/apk on Linux, brew/MacPorts on macOS) with `|| true` belts-and-suspenders so a missing tool never aborts the install
- New `install.ps1` for Windows: jq via winget/scoop/choco fallback, bun via the official PS installer, npm install + native rebuild, PAI bootstrap, Start Menu shortcut, `%LOCALAPPDATA%\Husk\husk.cmd` wrapper, user PATH addition

### UI polish
- Wordmark already on Titan One via PR #8; the rest of the polish: smaller logo, no drop-shadow, tabular-nums on non-code surfaces, all `+` / refresh / moon text glyphs replaced with SVG (fixes tofu rendering on systems without those glyphs)
- `.btn-primary` and `.ghost-btn` get `justify-content: center` so text actually centers when buttons stretch
- Empty states inside grids span all columns + reserve 360px min-height so messages center in the page area instead of huddling top-left
- Right STATUS panel: ISO timestamps under progress bars become `in 1h 23m`, IANA timezone fallback shortens to leaf (`Jerusalem`), explicit "no ratings yet" empty state in LEARNING section
- LEARNING and Usage now both work cleanly even when ratings.jsonl is missing or the OAuth call hasn't fired yet

### Restart race fix
- New `_restartInProgress` flag gates `pty.onData` and `pty.onExit` during PTY teardown + spawn, with a 200ms quiet window. Prevents the dying-PTY tail (Session terminated... killing shell... `[agent exited]`) from stitching into the new PTY's welcome banner in xterm's single buffer.
- `restartPty` accepts and forwards an explicit `cwd` so Open here passes the project's path through, no race window between `setActive` persisting and `pty.restart` reading config.

### Preferences
- New Working directory row under Agent. Mirrors the Projects mechanism for users who just want a single durable default cwd without managing a project list.

### Docs
- Replaced an en-dash with `to` in a range cell. Em/en-dash count across all Husk-owned files is now zero (vendored `libs/pai/` excluded; Daniel Miessler's source).

## Test plan

- [ ] Fresh install on Linux: `./install.sh` succeeds end-to-end without manual jq/bun fiddling
- [ ] Fresh install on Windows: `powershell -ExecutionPolicy Bypass -File .\install.ps1` runs to completion
- [ ] Open Projects, add one (e.g. `~/projects/test`), Open here, confirm trust prompt offers all three options including "Yes, and remember"
- [ ] Pick "Yes, and remember", quit Husk, relaunch, the trust prompt does not appear again for that folder
- [ ] Topbar shows the active project chip; click it, navigates to Projects page
- [ ] Right STATUS panel's Usage card populates real 5h / Weekly numbers within ~5s of launch
- [ ] Resets rows show "in 1h 23m" instead of raw ISO timestamps
- [ ] Prompts page lists the seeded prompts; Run sends one into the agent; create a new prompt, then trash it via the two-click confirm
- [ ] Restart agent multiple times rapidly; no doubled welcome banners or stitched output
- [ ] All security CI checks pass (Gitleaks, npm audit, ESLint, CodeQL, Semgrep, Trivy)