### PR TITLE
chore(release): stop auto-generating PR-list as release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,5 +95,16 @@ jobs:
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: release/*
-          generate_release_notes: true
+          # Use the annotated tag message as the release body (clean,
+          # user-facing). Falls back to a simple installer notice if the
+          # tag was lightweight. The previous setting (generate_release_notes:
+          # true) auto-listed every PR + contributor including bots, which is
+          # noisy for a public release page.
+          body: |
+            ## ${{ github.ref_name }}
+
+            Pick the installer for your platform from the Assets below.
+
+            See the README for documentation, and the project repository for the full changelog.
+          generate_release_notes: false
           fail_on_unmatched_files: false


### PR DESCRIPTION
## Change

\`generate_release_notes: true\` -> \`false\` in \`.github/workflows/release.yml\`. Replaces with a short generic body keyed off the tag name.