### PR TITLE
Test harness, lib refactor, installer download verification, release checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
       - name: bash -n on shell scripts
         run: |
           set -euo pipefail
-          for f in install.sh run.sh uninstall.sh; do
+          shopt -s nullglob
+          files=(install.sh run.sh uninstall.sh installer/lib/*.sh installer/after-install.sh installer/after-remove.sh)
+          for f in "${files[@]}"; do
+            [ -f "$f" ] || continue
             echo "checking $f"
             bash -n "$f"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,20 @@ jobs:
           find artifacts -type f \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.zip' -o -name '*.exe' -o -name '*.blockmap' -o -name 'latest*.yml' \) -exec cp -v {} release/ \;
           ls -la release/
 
+      - name: Generate SHA256SUMS for release artifacts
+        run: |
+          cd release
+          # Hash every artifact and write a single SHA256SUMS file that
+          # users can verify with `sha256sum -c SHA256SUMS`.
+          rm -f SHA256SUMS
+          for f in *; do
+            [ -f "$f" ] || continue
+            [ "$f" = "SHA256SUMS" ] && continue
+            sha256sum "$f" >> SHA256SUMS
+          done
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,11 +90,12 @@ jobs:
       - name: Install (no scripts)
         run: npm ci --ignore-scripts
 
-      - name: npm audit (high + critical, prod only)
-        # --omit=dev focuses the gate on what actually ships to users.
-        # Dev-only CVEs (electron-builder, etc.) are still visible in the
-        # JSON report below for review, just not blocking.
-        run: npm audit --audit-level=high --omit=dev
+      - name: npm audit (high + critical, all deps)
+        # Run against the full dependency graph including devDependencies
+        # since the build chain (electron-builder, electron itself) ships
+        # binaries to end users. Local-only dev tools that do not touch
+        # the build can be excluded via per-advisory ignores when needed.
+        run: npm audit --audit-level=high
 
       - name: npm audit JSON report (full, prod + dev)
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: tests
+
+on:
+  push:
+    branches: [main, "dev/**"]
+  pull_request:
+    branches: [main, "dev/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: unit (node:test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci --no-audit --no-fund
+      - run: npm test
+
+  e2e-smoke:
+    name: e2e smoke (electron)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: unit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: install system deps for headless electron
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libnss3 libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libgbm1 libasound2t64 libxss1 libxshmfence1
+      - run: npm ci --no-audit --no-fund
+      - name: smoke test under xvfb
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1280x800x24" npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ libs/pai/**/.credentials.json
 libs/pai/**/ratings.jsonl
 libs/pai/**/*reflections*.jsonl
 libs/pai/**/history.jsonl
+
+# playwright run artifacts
+test-results/
+playwright-report/

--- a/install.ps1
+++ b/install.ps1
@@ -21,6 +21,14 @@ degraded.
 $ErrorActionPreference = 'Stop'
 $AppDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 
+# Pinned SHA-256 of the upstream bun installer script revision we
+# accept. Install-Bun verifies the downloaded file against this constant
+# before running it. Procedure for bumping is in installer/lib/verify.ps1.
+$Script:BunInstallerUrl = 'https://bun.sh/install.ps1'
+$Script:BunInstallerSha256 = '54fd5c34e08d2e363e9ee4cc52f58eca72b3c307c170869eec1e394c16fb7744'
+
+. (Join-Path $AppDir 'installer/lib/verify.ps1')
+
 function Write-Info  ($msg) { Write-Host ("> " + $msg) -ForegroundColor Cyan }
 function Write-Ok    ($msg) { Write-Host ("[OK] " + $msg) -ForegroundColor Green }
 function Write-Warn2 ($msg) { Write-Host ("[!] " + $msg) -ForegroundColor Yellow }
@@ -87,12 +95,19 @@ function Install-Bun {
         return
     }
     Write-Info "Installing bun (PAI hooks need it for rating capture and learning)..."
+    # Download the bun installer to a temp file and check its SHA-256
+    # against the pinned constant before running it.
+    $installerTmp = Join-Path $env:TEMP ("husk-bun-installer-" + [Guid]::NewGuid().ToString('N') + '.ps1')
+    if (-not (Get-VerifiedDownload -Url $Script:BunInstallerUrl -Expected $Script:BunInstallerSha256 -OutFile $installerTmp)) {
+        Write-Warn2 ("bun installer SHA-256 did not match the pinned value (expected " + $Script:BunInstallerSha256 + "). Skipping. To update the pin, see installer/lib/verify.ps1.")
+        return
+    }
     try {
-        # Official unattended Windows installer.
-        Invoke-RestMethod https://bun.sh/install.ps1 | Invoke-Expression
+        & powershell -ExecutionPolicy Bypass -File $installerTmp
     } catch {
         Write-Warn2 ("bun installer failed: " + $_.Exception.Message + ". Install manually from https://bun.sh")
-        return
+    } finally {
+        Remove-Item -LiteralPath $installerTmp -Force -ErrorAction SilentlyContinue
     }
     # bun.exe lands at $env:USERPROFILE\.bun\bin\bun.exe
     $bunBin = Join-Path $env:USERPROFILE ".bun\bin"

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,15 @@ dim()  { echo -e "${C_DIM}$1${C_RST}"; }
 
 cd "$APP_DIR"
 
+# Pinned SHA-256 of the upstream bun installer script revision we
+# accept. ensure_bun verifies the downloaded file against this constant
+# before running it. Procedure for bumping is in installer/lib/verify.sh.
+BUN_INSTALLER_URL="https://bun.sh/install"
+BUN_INSTALLER_SHA256="bab8acfb046aac8c72407bdcce903957665d655d7acaa3e11c7c4616beae68dd"
+
+# shellcheck source=installer/lib/verify.sh
+. "$APP_DIR/installer/lib/verify.sh"
+
 case "$PLATFORM" in
     Linux)  ok "Detected Linux" ;;
     Darwin) ok "Detected macOS" ;;
@@ -117,13 +126,24 @@ ensure_bun() {
         return 1
     fi
     _ensure_unzip
-    # Official unattended installer. Writes to ~/.bun/bin and updates the
-    # shell rc files. The next login picks it up automatically; we also add
-    # it to this script's PATH so any further checks below see it.
-    if curl -fsSL https://bun.sh/install | bash; then :; else
-        warn "bun installer reported a failure; continuing without bun. PAI hooks will not run until bun is installed."
+    # Download the bun installer to a temp file and check its SHA-256
+    # against the pinned constant before running it.
+    local installer_tmp
+    if ! installer_tmp=$(mktemp 2>/dev/null); then
+        warn "Could not create temp file for bun installer; continuing without bun."
         return 1
     fi
+    if ! download_and_verify "$BUN_INSTALLER_URL" "$BUN_INSTALLER_SHA256" "$installer_tmp"; then
+        warn "bun installer SHA-256 did not match the pinned value (expected $BUN_INSTALLER_SHA256). Skipping. To update the pin, see installer/lib/verify.sh."
+        rm -f "$installer_tmp"
+        return 1
+    fi
+    if ! bash "$installer_tmp"; then
+        warn "bun installer reported a failure; continuing without bun. PAI hooks will not run until bun is installed."
+        rm -f "$installer_tmp"
+        return 1
+    fi
+    rm -f "$installer_tmp"
     if [ -x "$HOME/.bun/bin/bun" ]; then
         export PATH="$HOME/.bun/bin:$PATH"
         ok "bun installed at $HOME/.bun/bin (added to PATH for this session)"

--- a/installer/lib/verify.ps1
+++ b/installer/lib/verify.ps1
@@ -1,0 +1,39 @@
+# Husk installer download-and-verify helpers. Dot-sourced by install.ps1.
+#
+# Pinning policy: the SHA256 constants in install.ps1 pin a specific
+# upstream revision of any script we fetch. We download to a temp file
+# and check its hash against the pinned value before executing.
+#
+# Updating a pin: review the upstream script you intend to allow, then
+#   (Invoke-WebRequest <url>).Content | Out-File -Encoding ascii t.txt
+#   (Get-FileHash -Algorithm SHA256 t.txt).Hash.ToLower()
+# and replace the matching constant in install.ps1.
+
+function Verify-Sha256 {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Expected
+    )
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    $actual = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLower()
+    return ($actual -eq $Expected.ToLower())
+}
+
+function Get-VerifiedDownload {
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$Expected,
+        [Parameter(Mandatory)][string]$OutFile
+    )
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing -TimeoutSec 30 -ErrorAction Stop | Out-Null
+    } catch {
+        if (Test-Path -LiteralPath $OutFile) { Remove-Item -LiteralPath $OutFile -Force }
+        return $false
+    }
+    if (-not (Verify-Sha256 -Path $OutFile -Expected $Expected)) {
+        Remove-Item -LiteralPath $OutFile -Force
+        return $false
+    }
+    return $true
+}

--- a/installer/lib/verify.sh
+++ b/installer/lib/verify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Husk installer download-and-verify helpers. Sourced by install.sh.
+#
+# Pinning policy: the SHA256 constants in install.sh pin a specific
+# upstream revision of any script we fetch. We download to a temp file
+# and check its hash against the pinned value before executing.
+#
+# Updating a pin: review the upstream script you intend to allow, run
+#   curl -fsSL <url> | sha256sum
+# and replace the matching constant in install.sh.
+
+# verify_sha256 <file> <expected-hex>
+# Exit 0 if the file's SHA-256 equals expected, non-zero otherwise.
+# Returns 2 on missing tool or unreadable file, 1 on mismatch.
+verify_sha256() {
+    local file="$1"
+    local expected="$2"
+    if [ -z "$file" ] || [ -z "$expected" ]; then
+        return 2
+    fi
+    if [ ! -r "$file" ]; then
+        return 2
+    fi
+    local actual=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file" | awk '{print $1}')
+    else
+        return 2
+    fi
+    [ "$actual" = "$expected" ]
+}
+
+# download_and_verify <url> <expected-sha256> <out-file>
+# curls url into out-file, then verifies. On any failure, removes the
+# out-file and returns non-zero so the caller can refuse to proceed.
+download_and_verify() {
+    local url="$1"
+    local expected="$2"
+    local out="$3"
+    if ! command -v curl >/dev/null 2>&1; then
+        return 2
+    fi
+    if ! curl -fsSL --max-time 30 "$url" -o "$out"; then
+        rm -f "$out"
+        return 1
+    fi
+    if ! verify_sha256 "$out" "$expected"; then
+        rm -f "$out"
+        return 1
+    fi
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
       },
       "devDependencies": {
         "@electron/rebuild": "^4.0.0",
+        "@playwright/test": "^1.60.0",
         "electron": "^41.6.1",
-        "electron-builder": "^26.0.12"
+        "electron-builder": "^26.0.12",
+        "playwright": "^1.60.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -492,6 +494,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -2234,6 +2252,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3244,6 +3277,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux --publish never",
     "dist:mac": "electron-builder --mac --publish never",
-    "dist:win": "electron-builder --win --publish never"
+    "dist:win": "electron-builder --win --publish never",
+    "test": "node --test test/unit/",
+    "test:e2e": "playwright test",
+    "test:all": "npm run test && npm run test:e2e"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -28,8 +31,10 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.0",
+    "@playwright/test": "^1.60.0",
     "electron": "^41.6.1",
-    "electron-builder": "^26.0.12"
+    "electron-builder": "^26.0.12",
+    "playwright": "^1.60.0"
   },
   "build": {
     "appId": "com.husk.app",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: 'test/e2e',
+  testMatch: '*.spec.js',
+  timeout: 60_000,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['list']],
+});

--- a/src/lib/agent-md.js
+++ b/src/lib/agent-md.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// parseAgentMd parses one Claude Code style agent markdown file: optional
+// YAML frontmatter delimited by --- lines, followed by the body. Only the
+// `name` and `description` fields matter for the profile mapping, so we
+// keep the parser tight and dependency-free.
+function parseAgentMd(text) {
+  const t = String(text || '');
+  const m = t.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!m) return { name: null, description: null, body: t.trim() };
+  const fm = m[1];
+  const body = m[2].trim();
+  const getField = (k) => {
+    const re = new RegExp(`^${k}\\s*:\\s*(.*)$`, 'm');
+    const mm = fm.match(re);
+    if (!mm) return null;
+    let v = mm[1].trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+    return v;
+  };
+  return { name: getField('name'), description: getField('description'), body };
+}
+
+module.exports = { parseAgentMd };

--- a/src/lib/path-confine.js
+++ b/src/lib/path-confine.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const path = require('path');
+
+// resolveInside(root, name) returns an absolute path that is provably
+// inside `root`. Throws when `name` is empty, absolute, contains a
+// null byte, or would resolve outside `root`. Use whenever a fixed
+// root is joined with a name that comes from outside the function.
+function resolveInside(root, name) {
+  if (typeof root !== 'string' || !root) throw new Error('resolveInside: root required');
+  if (typeof name !== 'string' || !name) throw new Error('resolveInside: name required');
+  if (name.indexOf('\x00') !== -1) throw new Error('resolveInside: null byte');
+  if (path.isAbsolute(name)) throw new Error('resolveInside: absolute path');
+  const rootAbs = path.resolve(root);
+  const candidate = path.resolve(rootAbs, name);
+  if (candidate !== rootAbs && !candidate.startsWith(rootAbs + path.sep)) {
+    throw new Error('resolveInside: outside root');
+  }
+  return candidate;
+}
+
+// isInside is the predicate form: true when `target` resolves under `root`.
+function isInside(root, target) {
+  if (typeof root !== 'string' || typeof target !== 'string') return false;
+  const rootAbs = path.resolve(root);
+  const targetAbs = path.resolve(target);
+  return targetAbs === rootAbs || targetAbs.startsWith(rootAbs + path.sep);
+}
+
+module.exports = { resolveInside, isInside };

--- a/src/lib/shell-quote.js
+++ b/src/lib/shell-quote.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// shJoin serializes an (exe, argv) tuple into a string the POSIX shell
+// rebuilds as the same argv. Single-quote every token (exe included);
+// escape an embedded single quote with the canonical close-escape-open
+// trick ('\''). Quoting the first word lets the shell treat it as a
+// literal program name even when it contains metacharacters or spaces.
+function shJoin(exe, args) {
+  const q = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'";
+  return [q(exe), ...(args || []).map(q)].join(' ');
+}
+
+module.exports = { shJoin };

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -1,0 +1,155 @@
+'use strict';
+
+// Pure data-model helpers for the workflow graph: sanitization, migration,
+// linear ordering, and edge resolution. No Electron, no fs, no spawn. The
+// IPC handlers in main.js wrap these for the renderer.
+
+function sanitizeNode(n) {
+  n = n || {};
+  return {
+    id: n.id || `node-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    name: String(n.name || 'Step').slice(0, 64),
+    agentCommand: String(n.agentCommand || '').slice(0, 128) || null,
+    prompt: String(n.prompt || '').slice(0, 8192),
+    passContext: ['full', 'last50', 'none'].includes(n.passContext) ? n.passContext : 'full',
+    x: Number.isFinite(n.x) ? n.x : 0,
+    y: Number.isFinite(n.y) ? n.y : 0,
+  };
+}
+
+function sanitizeEdge(e) {
+  e = e || {};
+  const c = (e.condition && typeof e.condition === 'object') ? e.condition : {};
+  return {
+    id: e.id || `edge-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    from: String(e.from || ''),
+    to: String(e.to || ''),
+    condition: {
+      type: ['always', 'contains', 'regex', 'otherwise'].includes(c.type) ? c.type : 'always',
+      value: String(c.value || '').slice(0, 256),
+    },
+  };
+}
+
+function sanitizeGraph(g) {
+  if (!g || typeof g !== 'object') return { nodes: [], edges: [] };
+  const nodes = Array.isArray(g.nodes) ? g.nodes.map(sanitizeNode) : [];
+  const ids = new Set(nodes.map((n) => n.id));
+  const edges = Array.isArray(g.edges)
+    ? g.edges.map(sanitizeEdge).filter((e) => ids.has(e.from) && ids.has(e.to))
+    : [];
+  return { nodes, edges };
+}
+
+function migrateWorkflow(w) {
+  if (w && w.graph && Array.isArray(w.graph.nodes)) {
+    const { steps, ...rest } = w;
+    return rest;
+  }
+  const steps = Array.isArray(w && w.steps) ? w.steps : [];
+  const nodes = steps.map((s, i) => ({
+    id: s.id || `node-mig-${i}-${Math.random().toString(36).slice(2, 6)}`,
+    name: s.name || `Step ${i + 1}`,
+    agentCommand: s.agentCommand || null,
+    prompt: s.prompt || '',
+    passContext: s.passContext || 'full',
+    x: 80, y: 80 + i * 200,
+  }));
+  const edges = [];
+  for (let i = 1; i < nodes.length; i++) {
+    edges.push({ id: `edge-mig-${i}`, from: nodes[i - 1].id, to: nodes[i].id, condition: { type: 'always', value: '' } });
+  }
+  const { steps: _drop, ...rest } = w || {};
+  return { ...rest, graph: { nodes, edges } };
+}
+
+function graphToOrderedSteps(graph) {
+  const g = sanitizeGraph(graph);
+  if (!g.nodes.length) return [];
+  const byId = new Map(g.nodes.map((n) => [n.id, n]));
+  const hasIncoming = new Set(g.edges.map((e) => e.to));
+  let cur = g.nodes.find((n) => !hasIncoming.has(n.id)) || g.nodes[0];
+  const order = [];
+  const seen = new Set();
+  while (cur && !seen.has(cur.id)) {
+    seen.add(cur.id);
+    order.push(cur);
+    const edge = g.edges.find((e) => e.from === cur.id);
+    cur = edge ? byId.get(edge.to) : null;
+  }
+  return order;
+}
+
+function wfEdgeMatches(condition, output) {
+  const c = condition || { type: 'always' };
+  const text = String(output || '');
+  if (c.type === 'contains') return text.toLowerCase().includes(String(c.value || '').toLowerCase());
+  if (c.type === 'regex') {
+    try { return new RegExp(c.value || '').test(text); } catch (_) { return false; }
+  }
+  return false;
+}
+
+function wfPickNextEdge(graph, nodeId, output) {
+  const out = graph.edges.filter((e) => e.from === nodeId);
+  if (!out.length) return null;
+  const conditional = out.filter((e) => e.condition && (e.condition.type === 'contains' || e.condition.type === 'regex'));
+  for (const e of conditional) {
+    if (wfEdgeMatches(e.condition, output)) return e;
+  }
+  const fallback = out.find((e) => !e.condition || e.condition.type === 'always' || e.condition.type === 'otherwise');
+  return fallback || null;
+}
+
+function wfIsAiRouted(graph, nodeId) {
+  const out = graph.edges.filter((e) => e.from === nodeId);
+  if (out.length < 2) return false;
+  return !out.some((e) => e.condition && (e.condition.type === 'contains' || e.condition.type === 'regex'));
+}
+
+function wfRouteInstruction(targetNames) {
+  return `\n\nThis step decides which step runs next. After your full response, on a final separate line, output exactly:\nROUTE: <name>\nwhere <name> is one of: ${targetNames.join(' | ')}. To end the workflow instead, output ROUTE: END. The ROUTE line must be the very last line, with nothing after it.`;
+}
+
+function wfResolveNext(graph, node, output, byId) {
+  const out = graph.edges.filter((e) => e.from === node.id);
+  if (!out.length) return null;
+  if (out.length === 1) return { edge: out[0], decision: null };
+
+  if (!wfIsAiRouted(graph, node.id)) {
+    const edge = wfPickNextEdge(graph, node.id, output);
+    return edge ? { edge, decision: null } : null;
+  }
+
+  const matches = String(output || '').match(/ROUTE:\s*([^\n\r]+)/gi);
+  if (matches && matches.length) {
+    const raw = matches[matches.length - 1].replace(/ROUTE:\s*/i, '').trim();
+    if (/^END\b/i.test(raw)) return { edge: null, decision: 'END' };
+    const want = raw.toLowerCase();
+    let edge = out.find((e) => {
+      const n = byId.get(e.to);
+      return n && n.name.trim().toLowerCase() === want;
+    });
+    if (!edge) {
+      edge = out.find((e) => {
+        const n = byId.get(e.to);
+        return n && n.name.trim() && want.includes(n.name.trim().toLowerCase());
+      });
+    }
+    if (edge) return { edge, decision: (byId.get(edge.to) || {}).name };
+  }
+  return { edge: out[0], decision: null };
+}
+
+module.exports = {
+  sanitizeNode,
+  sanitizeEdge,
+  sanitizeGraph,
+  migrateWorkflow,
+  graphToOrderedSteps,
+  wfEdgeMatches,
+  wfPickNextEdge,
+  wfIsAiRouted,
+  wfRouteInstruction,
+  wfResolveNext,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,23 @@ const http = require('http');
 const { spawn } = require('child_process');
 const pty = require('node-pty');
 
+const { shJoin } = require('./lib/shell-quote');
+const { resolveInside, isInside } = require('./lib/path-confine');
+const { parseAgentMd } = require('./lib/agent-md');
+const wfLib = require('./lib/workflow-graph');
+const {
+  sanitizeNode,
+  sanitizeEdge,
+  sanitizeGraph,
+  migrateWorkflow,
+  graphToOrderedSteps,
+  wfEdgeMatches,
+  wfPickNextEdge,
+  wfIsAiRouted,
+  wfRouteInstruction,
+  wfResolveNext,
+} = wfLib;
+
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const HOME = os.homedir();
 const CONFIG_DIR = path.join(HOME, '.config', 'husk');
@@ -445,14 +462,6 @@ function killPtyTree() {
 }
 
 // ─── PTY ─────────────────────────────────────────────────────────────────────────
-
-// POSIX-shell-quote one argument: 'value' with internal single-quotes escaped
-// as '\\''. Use to serialize an (exe, argv) tuple back into a string we can
-// hand to /bin/sh -c or /usr/bin/script -q -c. Not used on Windows.
-function shJoin(exe, args) {
-  const q = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'";
-  return [exe, ...args.map(q)].join(' ');
-}
 
 function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null) {
   if (ptyProc) try { ptyProc.kill(); } catch (_) {}
@@ -1319,162 +1328,8 @@ ipcMain.handle('workflows:stop', (_e, runId) => {
 // A workflow is a graph of step nodes connected by edges. Edges carry a
 // routing condition (used by the 2b branch engine; 2a treats all as 'always').
 
-function sanitizeNode(n) {
-  return {
-    id: n.id || `node-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-    name: String(n.name || 'Step').slice(0, 64),
-    agentCommand: String(n.agentCommand || '').slice(0, 128) || null,
-    prompt: String(n.prompt || '').slice(0, 8192),
-    passContext: ['full', 'last50', 'none'].includes(n.passContext) ? n.passContext : 'full',
-    x: Number.isFinite(n.x) ? n.x : 0,
-    y: Number.isFinite(n.y) ? n.y : 0,
-  };
-}
-
-function sanitizeEdge(e) {
-  const c = (e && e.condition && typeof e.condition === 'object') ? e.condition : {};
-  return {
-    id: e.id || `edge-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-    from: String(e.from || ''),
-    to: String(e.to || ''),
-    condition: {
-      type: ['always', 'contains', 'regex'].includes(c.type) ? c.type : 'always',
-      value: String(c.value || '').slice(0, 256),
-    },
-  };
-}
-
-function sanitizeGraph(g) {
-  if (!g || typeof g !== 'object') return { nodes: [], edges: [] };
-  const nodes = Array.isArray(g.nodes) ? g.nodes.map(sanitizeNode) : [];
-  const ids = new Set(nodes.map((n) => n.id));
-  const edges = Array.isArray(g.edges)
-    ? g.edges.map(sanitizeEdge).filter((e) => ids.has(e.from) && ids.has(e.to))
-    : [];
-  return { nodes, edges };
-}
-
-// Convert a legacy steps[] workflow to the graph model: a straight node chain.
-function migrateWorkflow(w) {
-  if (w && w.graph && Array.isArray(w.graph.nodes)) {
-    const { steps, ...rest } = w;
-    return rest;
-  }
-  const steps = Array.isArray(w && w.steps) ? w.steps : [];
-  const nodes = steps.map((s, i) => ({
-    id: s.id || `node-mig-${i}-${Math.random().toString(36).slice(2, 6)}`,
-    name: s.name || `Step ${i + 1}`,
-    agentCommand: s.agentCommand || null,
-    prompt: s.prompt || '',
-    passContext: s.passContext || 'full',
-    x: 80, y: 80 + i * 200,
-  }));
-  const edges = [];
-  for (let i = 1; i < nodes.length; i++) {
-    edges.push({ id: `edge-mig-${i}`, from: nodes[i - 1].id, to: nodes[i].id, condition: { type: 'always', value: '' } });
-  }
-  const { steps: _drop, ...rest } = w || {};
-  return { ...rest, graph: { nodes, edges } };
-}
-
-// Resolve a graph to a linear ordered step list: start at the node with no
-// incoming edge, follow the first outgoing edge. 2b replaces this with real
-// condition-based branch traversal.
-function graphToOrderedSteps(graph) {
-  const g = sanitizeGraph(graph);
-  if (!g.nodes.length) return [];
-  const byId = new Map(g.nodes.map((n) => [n.id, n]));
-  const hasIncoming = new Set(g.edges.map((e) => e.to));
-  let cur = g.nodes.find((n) => !hasIncoming.has(n.id)) || g.nodes[0];
-  const order = [];
-  const seen = new Set();
-  while (cur && !seen.has(cur.id)) {
-    seen.add(cur.id);
-    order.push(cur);
-    const edge = g.edges.find((e) => e.from === cur.id);
-    cur = edge ? byId.get(edge.to) : null;
-  }
-  return order;
-}
-
 function wfEmit(event, channel, data) {
   try { if (!event.sender.isDestroyed()) event.sender.send(channel, data); } catch (_) {}
-}
-
-// Evaluate one edge condition against a node's output text.
-function wfEdgeMatches(condition, output) {
-  const c = condition || { type: 'always' };
-  const text = String(output || '');
-  if (c.type === 'contains') return text.toLowerCase().includes(String(c.value || '').toLowerCase());
-  if (c.type === 'regex') {
-    try { return new RegExp(c.value || '').test(text); } catch (_) { return false; }
-  }
-  // 'always' and 'otherwise' are not matched here; 'always' is an
-  // unconditional follow, 'otherwise' is the fallback. Both handled by caller.
-  return false;
-}
-
-// Pick the next node id after `nodeId` produced `output`. Conditional edges
-// (contains/regex) are evaluated in order; the first match wins. If none
-// match, an 'otherwise'/'always' edge is the fallback.
-function wfPickNextEdge(graph, nodeId, output) {
-  const out = graph.edges.filter((e) => e.from === nodeId);
-  if (!out.length) return null;
-  const conditional = out.filter((e) => e.condition && (e.condition.type === 'contains' || e.condition.type === 'regex'));
-  for (const e of conditional) {
-    if (wfEdgeMatches(e.condition, output)) return e;
-  }
-  const fallback = out.find((e) => !e.condition || e.condition.type === 'always' || e.condition.type === 'otherwise');
-  return fallback || null;
-}
-
-// True when a branching node should route by the AI's own decision: it has
-// 2+ outgoing edges and none of them carries an explicit text condition.
-function wfIsAiRouted(graph, nodeId) {
-  const out = graph.edges.filter((e) => e.from === nodeId);
-  if (out.length < 2) return false;
-  return !out.some((e) => e.condition && (e.condition.type === 'contains' || e.condition.type === 'regex'));
-}
-
-// Instruction appended to a branching step's system prompt so it ends its
-// response with a machine-readable routing directive.
-function wfRouteInstruction(targetNames) {
-  return `\n\nThis step decides which step runs next. After your full response, on a final separate line, output exactly:\nROUTE: <name>\nwhere <name> is one of: ${targetNames.join(' | ')}. To end the workflow instead, output ROUTE: END. The ROUTE line must be the very last line, with nothing after it.`;
-}
-
-// Resolve the next edge for a branching node. AI-routed nodes parse the
-// ROUTE: directive from the output; explicit-condition nodes use the
-// condition matcher. Returns { edge, decision } or null to end.
-function wfResolveNext(graph, node, output, byId) {
-  const out = graph.edges.filter((e) => e.from === node.id);
-  if (!out.length) return null;
-  if (out.length === 1) return { edge: out[0], decision: null };
-
-  if (!wfIsAiRouted(graph, node.id)) {
-    const edge = wfPickNextEdge(graph, node.id, output);
-    return edge ? { edge, decision: null } : null;
-  }
-
-  // AI-routed: parse the last ROUTE: line.
-  const matches = String(output || '').match(/ROUTE:\s*([^\n\r]+)/gi);
-  if (matches && matches.length) {
-    const raw = matches[matches.length - 1].replace(/ROUTE:\s*/i, '').trim();
-    if (/^END\b/i.test(raw)) return { edge: null, decision: 'END' };
-    const want = raw.toLowerCase();
-    let edge = out.find((e) => {
-      const n = byId.get(e.to);
-      return n && n.name.trim().toLowerCase() === want;
-    });
-    if (!edge) {
-      edge = out.find((e) => {
-        const n = byId.get(e.to);
-        return n && n.name.trim() && want.includes(n.name.trim().toLowerCase());
-      });
-    }
-    if (edge) return { edge, decision: (byId.get(edge.to) || {}).name };
-  }
-  // The AI did not give a usable directive: fall back to the first branch.
-  return { edge: out[0], decision: null };
 }
 
 async function executeWorkflow(event, workflow, run) {
@@ -1672,26 +1527,6 @@ Create an agent profile. Return ONLY valid JSON, no markdown fences, no explanat
     child.on('error', (e) => resolve({ ok: false, error: e.message }));
   });
 });
-
-// Parse one Claude Code agent markdown file: YAML frontmatter + body.
-// Frontmatter is intentionally parsed with regex (no yaml dep): only the
-// name and description fields matter for the profile mapping.
-function parseAgentMd(text) {
-  const t = String(text || '');
-  const m = t.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
-  if (!m) return { name: null, description: null, body: t.trim() };
-  const fm = m[1];
-  const body = m[2].trim();
-  const getField = (k) => {
-    const re = new RegExp(`^${k}\\s*:\\s*(.*)$`, 'm');
-    const mm = fm.match(re);
-    if (!mm) return null;
-    let v = mm[1].trim();
-    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
-    return v;
-  };
-  return { name: getField('name'), description: getField('description'), body };
-}
 
 // Per-tool directories to scan for importable agents. To add a tool, append
 // a { label, dir } entry. Files in each dir are parsed by parseAgentMd.
@@ -2050,24 +1885,29 @@ ipcMain.handle('skills:toggle', (_e, payload = {}) => {
   const itemId = id || dirName;
   if (!itemId) return { ok: false, error: 'No item id' };
   if (source === 'husk' || (!source && itemId.endsWith('.md') || itemId.endsWith('.md.disabled'))) {
-    const oldPath = path.join(HUSK_PROMPTS_DIR, itemId);
-    if (!fs.existsSync(oldPath)) return { ok: false, error: 'Prompt not found' };
     const isDisabled = itemId.endsWith('.disabled');
     const newName = isDisabled ? itemId.slice(0, -'.disabled'.length) : `${itemId}.disabled`;
-    const newPath = path.join(HUSK_PROMPTS_DIR, newName);
+    let oldPath, newPath;
+    try {
+      oldPath = resolveInside(HUSK_PROMPTS_DIR, itemId);
+      newPath = resolveInside(HUSK_PROMPTS_DIR, newName);
+    } catch (_) { return { ok: false, error: 'Invalid prompt name' }; }
+    if (!fs.existsSync(oldPath)) return { ok: false, error: 'Prompt not found' };
     if (fs.existsSync(newPath)) return { ok: false, error: 'Target already exists' };
     try {
       fs.renameSync(oldPath, newPath);
       return { ok: true, source: 'husk', id: newName, dirName: newName, disabled: !isDisabled };
     } catch (err) { return { ok: false, error: err.message }; }
   }
-  // Claude skill (default).
   const skillsDir = path.join(CLAUDE_DIR, 'skills');
-  const oldPath = path.join(skillsDir, itemId);
-  if (!fs.existsSync(oldPath)) return { ok: false, error: 'Skill not found' };
   const isDisabled = itemId.startsWith(DISABLED_PREFIX);
   const newDirName = isDisabled ? itemId.slice(DISABLED_PREFIX.length) : DISABLED_PREFIX + itemId;
-  const newPath = path.join(skillsDir, newDirName);
+  let oldPath, newPath;
+  try {
+    oldPath = resolveInside(skillsDir, itemId);
+    newPath = resolveInside(skillsDir, newDirName);
+  } catch (_) { return { ok: false, error: 'Invalid skill name' }; }
+  if (!fs.existsSync(oldPath)) return { ok: false, error: 'Skill not found' };
   if (fs.existsSync(newPath)) return { ok: false, error: 'Target already exists' };
   try {
     fs.renameSync(oldPath, newPath);

--- a/src/main.js
+++ b/src/main.js
@@ -2520,24 +2520,30 @@ ipcMain.handle('voice:uninstall', async () => {
   }
 });
 
-// Claim port 8888 with a silent sink so external TTS POSTs do not produce sound.
-// Husk owns voice while it is running; whatever else listens on 8888 is freed and
-// the port is reclaimed. Released cleanly on quit.
+// Listen on 127.0.0.1:8888 with a silent sink so external TTS POSTs do
+// not produce sound while Husk is running. If the port is already held
+// by another process we leave it alone and continue without the sink.
+// Released cleanly on quit.
 let nullVoiceServer = null;
 function startNullVoiceServer() {
   return new Promise((resolve) => {
-    const claim = spawn('bash', ['-c', 'lsof -ti:8888 -sTCP:LISTEN 2>/dev/null | xargs -r kill -9 2>/dev/null; true'], { stdio: 'ignore' });
-    claim.on('close', () => {
-      setTimeout(() => {
-        const server = http.createServer((req, res) => {
-          if (req.method === 'POST') { req.resume(); req.on('end', () => { res.writeHead(200, { 'Content-Type': 'application/json' }); res.end('{"status":"ok","silent":true}'); }); }
-          else { res.writeHead(200, { 'Content-Type': 'text/plain' }); res.end('husk-null-voice'); }
+    const server = http.createServer((req, res) => {
+      if (req.method === 'POST') {
+        req.resume();
+        req.on('end', () => {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end('{"status":"ok","silent":true}');
         });
-        server.on('error', () => resolve());
-        server.listen(8888, '127.0.0.1', () => { nullVoiceServer = server; resolve(); });
-      }, 200);
+      } else {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('husk-null-voice');
+      }
     });
-    claim.on('error', () => resolve());
+    server.on('error', () => resolve());
+    server.listen(8888, '127.0.0.1', () => {
+      nullVoiceServer = server;
+      resolve();
+    });
   });
 }
 function stopNullVoiceServer() {

--- a/test/e2e/smoke.spec.js
+++ b/test/e2e/smoke.spec.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// Smoke test: launch the real Electron app and assert it boots cleanly.
+// Canary that catches a hard boot regression: main process throws at
+// boot, preload blocks the bridge, or the renderer crashes early. Does
+// not exercise features beyond mount; feature E2E goes in other specs.
+
+const { test, expect, _electron: electron } = require('@playwright/test');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// Isolate config so the test never reads/writes the developer's real config.
+function makeIsolatedHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-e2e-'));
+  fs.mkdirSync(path.join(dir, '.config', 'husk'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+  return dir;
+}
+
+test('app boots, exposes preload bridge, no console errors', async () => {
+  const homeDir = makeIsolatedHome();
+  const app = await electron.launch({
+    args: [path.join(REPO_ROOT, 'src', 'main.js'), '--no-sandbox'],
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      ELECTRON_DISABLE_SANDBOX: '1',
+      HUSK_E2E: '1',
+    },
+    timeout: 30_000,
+  });
+
+  const consoleErrors = [];
+  app.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+
+  const win = await app.firstWindow({ timeout: 30_000 });
+  await win.waitForLoadState('domcontentloaded');
+
+  const title = await win.title();
+  expect(title.toLowerCase()).toContain('husk');
+
+  const bridge = await win.evaluate(() => {
+    const w = window;
+    return {
+      hasHusk: !!w.husk,
+      ptyShape: w.husk && typeof w.husk.pty === 'object',
+      configShape: w.husk && typeof w.husk.config === 'object',
+      workflowsShape: w.husk && typeof w.husk.workflows === 'object',
+    };
+  });
+  expect(bridge.hasHusk).toBe(true);
+  expect(bridge.ptyShape).toBe(true);
+  expect(bridge.configShape).toBe(true);
+  expect(bridge.workflowsShape).toBe(true);
+
+  const pages = await win.evaluate(() => {
+    return Array.from(document.querySelectorAll('.page')).map((el) => el.getAttribute('data-page'));
+  });
+  expect(pages.length).toBeGreaterThan(0);
+
+  await app.close();
+
+  const fatal = consoleErrors.filter((t) => !/Autofill|DevTools|Failed to load resource: net::ERR_FILE_NOT_FOUND/i.test(t));
+  expect(fatal, `unexpected console errors:\n${fatal.join('\n')}`).toEqual([]);
+});

--- a/test/unit/agent-md.test.js
+++ b/test/unit/agent-md.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseAgentMd } = require('../../src/lib/agent-md');
+
+test('parseAgentMd: full frontmatter extracts name and description', () => {
+  const text = [
+    '---',
+    'name: bappsec-agent',
+    'description: Bright Security CS/TSE debugging agent.',
+    '---',
+    '',
+    'Body text here.',
+    '',
+  ].join('\n');
+  const out = parseAgentMd(text);
+  assert.equal(out.name, 'bappsec-agent');
+  assert.equal(out.description, 'Bright Security CS/TSE debugging agent.');
+  assert.equal(out.body, 'Body text here.');
+});
+
+test('parseAgentMd: double-quoted values are unquoted', () => {
+  const text = '---\nname: "with spaces"\ndescription: "alpha: beta"\n---\nbody';
+  const out = parseAgentMd(text);
+  assert.equal(out.name, 'with spaces');
+  assert.equal(out.description, 'alpha: beta');
+});
+
+test('parseAgentMd: single-quoted values are unquoted', () => {
+  const text = "---\nname: 'hello'\ndescription: 'world'\n---\nbody";
+  const out = parseAgentMd(text);
+  assert.equal(out.name, 'hello');
+  assert.equal(out.description, 'world');
+});
+
+test('parseAgentMd: no frontmatter returns null fields, full body', () => {
+  const text = 'just body, no frontmatter';
+  const out = parseAgentMd(text);
+  assert.equal(out.name, null);
+  assert.equal(out.description, null);
+  assert.equal(out.body, 'just body, no frontmatter');
+});
+
+test('parseAgentMd: empty input returns null fields', () => {
+  const out = parseAgentMd('');
+  assert.equal(out.name, null);
+  assert.equal(out.description, null);
+  assert.equal(out.body, '');
+});
+
+test('parseAgentMd: missing name field is null', () => {
+  const text = '---\ndescription: only a description\n---\nbody';
+  const out = parseAgentMd(text);
+  assert.equal(out.name, null);
+  assert.equal(out.description, 'only a description');
+});
+
+test('parseAgentMd: CRLF line endings are accepted', () => {
+  const text = '---\r\nname: crlf\r\ndescription: works\r\n---\r\nbody\r\n';
+  const out = parseAgentMd(text);
+  assert.equal(out.name, 'crlf');
+  assert.equal(out.description, 'works');
+  assert.equal(out.body, 'body');
+});
+
+test('parseAgentMd: non-string input does not throw', () => {
+  const out = parseAgentMd(null);
+  assert.equal(out.name, null);
+  assert.equal(out.body, '');
+});

--- a/test/unit/installer-verify.test.js
+++ b/test/unit/installer-verify.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// Exercises installer/lib/verify.sh by sourcing it in a real /bin/sh
+// and checking its documented contract. Adds static assertions about
+// the shape of install.sh and install.ps1 so they keep using the
+// verified-download pattern.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const VERIFY_SH = path.join(REPO_ROOT, 'installer', 'lib', 'verify.sh');
+
+function runBash(script) {
+  return spawnSync('bash', ['-c', script], { encoding: 'utf8' });
+}
+
+function tempFileWith(contents) {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'husk-vsh-')), 'data.bin');
+  fs.writeFileSync(p, contents);
+  return p;
+}
+
+test('verify_sha256: returns 0 on a matching hash', () => {
+  const tmp = tempFileWith('hello husk');
+  const expected = spawnSync('sha256sum', [tmp], { encoding: 'utf8' }).stdout.split(/\s+/)[0];
+  const res = runBash(`. "${VERIFY_SH}"; verify_sha256 "${tmp}" "${expected}" && echo PASS || echo FAIL`);
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /PASS/);
+});
+
+test('verify_sha256: returns non-zero on a mismatched hash', () => {
+  const tmp = tempFileWith('hello husk');
+  const bogus = '0'.repeat(64);
+  const res = runBash(`. "${VERIFY_SH}"; verify_sha256 "${tmp}" "${bogus}" && echo PASS || echo FAIL`);
+  assert.match(res.stdout, /FAIL/);
+});
+
+test('verify_sha256: refuses an unreadable file', () => {
+  const res = runBash(`. "${VERIFY_SH}"; verify_sha256 /no/such/path "${'0'.repeat(64)}" && echo PASS || echo FAIL`);
+  assert.match(res.stdout, /FAIL/);
+});
+
+test('verify_sha256: refuses missing arguments', () => {
+  const res = runBash(`. "${VERIFY_SH}"; verify_sha256 && echo PASS || echo FAIL`);
+  assert.match(res.stdout, /FAIL/);
+});
+
+test('verify_sha256: a one-byte change makes the hash mismatch', () => {
+  const tmp = tempFileWith('hello husk');
+  const expected = spawnSync('sha256sum', [tmp], { encoding: 'utf8' }).stdout.split(/\s+/)[0];
+  fs.appendFileSync(tmp, 'X');
+  const res = runBash(`. "${VERIFY_SH}"; verify_sha256 "${tmp}" "${expected}" && echo PASS || echo FAIL`);
+  assert.match(res.stdout, /FAIL/);
+});
+
+// ─── Installer-script shape ─────────────────────────────────────────────
+
+test('install.sh: bun installer is downloaded to a temp file before running', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf8');
+  assert.match(text, /download_and_verify[^\n]*BUN_INSTALLER_URL/);
+  assert.match(text, /bash\s+"\$installer_tmp"/);
+});
+
+test('install.sh: sources installer/lib/verify.sh', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf8');
+  assert.match(text, /installer\/lib\/verify\.sh/);
+});
+
+test('install.sh: pins BUN_INSTALLER_SHA256 to a 64-hex value', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'install.sh'), 'utf8');
+  const m = text.match(/BUN_INSTALLER_SHA256="([0-9a-f]{64})"/);
+  assert.ok(m, 'expected BUN_INSTALLER_SHA256="<64-hex>" in install.sh');
+});
+
+test('install.ps1: bun installer is downloaded to a temp file before running', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf8');
+  assert.match(text, /Get-VerifiedDownload[^\n]*BunInstallerUrl/);
+  assert.match(text, /-File\s+\$installerTmp/);
+});
+
+test('install.ps1: sources installer/lib/verify.ps1', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf8');
+  assert.match(text, /installer\/lib\/verify\.ps1/);
+});
+
+test('install.ps1: pins BunInstallerSha256 to a 64-hex value', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'install.ps1'), 'utf8');
+  const m = text.match(/BunInstallerSha256\s*=\s*'([0-9a-f]{64})'/);
+  assert.ok(m, "expected $Script:BunInstallerSha256 = '<64-hex>' in install.ps1");
+});

--- a/test/unit/ipc-skills-toggle.test.js
+++ b/test/unit/ipc-skills-toggle.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Contract checks for the skills:toggle IPC handler. We do not boot
+// Electron here; we verify the handler source uses resolveInside for
+// every join under HUSK_PROMPTS_DIR and the claude skills dir, and we
+// exercise resolveInside on the shapes the handler accepts.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveInside } = require('../../src/lib/path-confine');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+test('resolveInside: a parent-relative item name throws', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-skt-'));
+  assert.throws(() => resolveInside(tmp, '../sibling'));
+});
+
+test('resolveInside: an absolute item name throws', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-skt-'));
+  assert.throws(() => resolveInside(tmp, '/abs/path'));
+});
+
+test('resolveInside: a normal item name resolves under root', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-skt-'));
+  assert.equal(resolveInside(tmp, 'my-prompt.md'), path.join(tmp, 'my-prompt.md'));
+});
+
+test('skills:toggle handler joins both roots via resolveInside', () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, 'src', 'main.js'), 'utf8');
+  const m = text.match(/ipcMain\.handle\('skills:toggle'[\s\S]*?\n\}\);/);
+  assert.ok(m, 'skills:toggle handler not found');
+  const handler = m[0];
+
+  const husk = handler.match(/resolveInside\(HUSK_PROMPTS_DIR/g) || [];
+  assert.ok(husk.length >= 2, 'expected resolveInside(HUSK_PROMPTS_DIR, ...) for both oldPath and newPath');
+
+  const claude = handler.match(/resolveInside\(skillsDir/g) || [];
+  assert.ok(claude.length >= 2, 'expected resolveInside(skillsDir, ...) for both oldPath and newPath');
+
+  const rawHusk = /path\.join\(HUSK_PROMPTS_DIR,\s*(itemId|newName)\)/.test(handler);
+  assert.equal(rawHusk, false, 'skills:toggle still path.joins HUSK_PROMPTS_DIR with itemId/newName');
+
+  const rawClaude = /path\.join\(skillsDir,\s*(itemId|newDirName)\)/.test(handler);
+  assert.equal(rawClaude, false, 'skills:toggle still path.joins skillsDir with itemId/newDirName');
+});

--- a/test/unit/path-confine.test.js
+++ b/test/unit/path-confine.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveInside, isInside } = require('../../src/lib/path-confine');
+
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-pc-'));
+
+test('resolveInside: simple name resolves under root', () => {
+  assert.equal(resolveInside(ROOT, 'a.md'), path.join(ROOT, 'a.md'));
+});
+
+test('resolveInside: nested name resolves under root', () => {
+  assert.equal(resolveInside(ROOT, 'sub/a.md'), path.join(ROOT, 'sub', 'a.md'));
+});
+
+test('resolveInside: a parent-relative name throws', () => {
+  assert.throws(() => resolveInside(ROOT, '../sibling'), /outside root/);
+});
+
+test('resolveInside: a deeply-nested parent-relative name throws', () => {
+  assert.throws(() => resolveInside(ROOT, 'a/b/../../../sibling'), /outside root/);
+});
+
+test('resolveInside: an absolute name throws', () => {
+  assert.throws(() => resolveInside(ROOT, '/abs/path'), /absolute path/);
+});
+
+test('resolveInside: an empty name throws', () => {
+  assert.throws(() => resolveInside(ROOT, ''), /name required/);
+});
+
+test('resolveInside: a name containing a null byte throws', () => {
+  assert.throws(() => resolveInside(ROOT, 'a\x00b'), /null byte/);
+});
+
+test('resolveInside: a missing root throws', () => {
+  assert.throws(() => resolveInside('', 'a.md'), /root required/);
+});
+
+test('isInside: a target inside root returns true', () => {
+  assert.equal(isInside(ROOT, path.join(ROOT, 'a', 'b.md')), true);
+});
+
+test('isInside: a target outside root returns false', () => {
+  assert.equal(isInside(ROOT, '/somewhere/else'), false);
+});
+
+test('isInside: a target built with ../ returns false', () => {
+  assert.equal(isInside(ROOT, path.join(ROOT, '..', '..', 'sibling')), false);
+});
+
+test('isInside: root itself returns true', () => {
+  assert.equal(isInside(ROOT, ROOT), true);
+});

--- a/test/unit/shell-quote.test.js
+++ b/test/unit/shell-quote.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+
+const { shJoin } = require('../../src/lib/shell-quote');
+
+// Contract: shJoin produces a string that /bin/sh -c parses back into
+// the same argv we passed in. We feed the result into /bin/sh and read
+// argv back as NUL-delimited words.
+
+function shellArgv(exe, args) {
+  const cmd = shJoin(exe, args);
+  const res = spawnSync('/bin/sh', ['-c', `set -- ${cmd}; printf '%s\\0' "$@"`], { encoding: 'utf8' });
+  assert.equal(res.status, 0, `shell exited ${res.status}: ${res.stderr}`);
+  return res.stdout.split('\0').filter(Boolean);
+}
+
+test('shJoin: single arg round-trips through /bin/sh', () => {
+  assert.deepEqual(shellArgv('echo', ['hello world']), ['echo', 'hello world']);
+});
+
+test('shJoin: single quote inside argument is escaped', () => {
+  assert.deepEqual(shellArgv('printf', ["it's fine"]), ['printf', "it's fine"]);
+});
+
+test('shJoin: double quote and backslash pass through literally', () => {
+  assert.deepEqual(shellArgv('printf', ['a"b\\c']), ['printf', 'a"b\\c']);
+});
+
+test('shJoin: semicolon in argument stays one word', () => {
+  assert.deepEqual(shellArgv('printf', ['a;b']), ['printf', 'a;b']);
+});
+
+test('shJoin: $VAR in argument is not expanded', () => {
+  assert.deepEqual(shellArgv('printf', ['$HOME']), ['printf', '$HOME']);
+});
+
+test('shJoin: backticks in argument are not evaluated', () => {
+  assert.deepEqual(shellArgv('printf', ['`id`']), ['printf', '`id`']);
+});
+
+test('shJoin: empty args list produces a quoted exe', () => {
+  assert.equal(shJoin('echo', []), "'echo'");
+});
+
+test('shJoin: undefined args list does not throw', () => {
+  assert.equal(shJoin('echo'), "'echo'");
+});
+
+test('shJoin: exe is shell-escaped', () => {
+  assert.equal(shJoin('a;b', ['c']), "'a;b' 'c'");
+});
+
+test('shJoin: backtick in exe is shell-escaped', () => {
+  assert.equal(shJoin('`id`', ['x']), "'`id`' 'x'");
+});
+
+test('shJoin: single quote in exe is escaped', () => {
+  assert.equal(shJoin("a'b", ['x']), "'a'\\''b' 'x'");
+});
+
+test('shJoin: shell parses the exe as a single word', () => {
+  const cmd = shJoin('a;b', ['c']);
+  const res = spawnSync('/bin/sh', ['-c', `set -- ${cmd}; printf '%s\\0' "$@"`], { encoding: 'utf8' });
+  const words = res.stdout.split('\0').filter(Boolean);
+  assert.deepEqual(words, ['a;b', 'c']);
+});

--- a/test/unit/workflow-graph.test.js
+++ b/test/unit/workflow-graph.test.js
@@ -1,0 +1,277 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const wf = require('../../src/lib/workflow-graph');
+
+// ─── sanitizeNode ────────────────────────────────────────────────────────────
+
+test('sanitizeNode: clamps name to 64 chars', () => {
+  const n = wf.sanitizeNode({ name: 'a'.repeat(100) });
+  assert.equal(n.name.length, 64);
+});
+
+test('sanitizeNode: clamps prompt to 8192 chars', () => {
+  const n = wf.sanitizeNode({ prompt: 'x'.repeat(10000) });
+  assert.equal(n.prompt.length, 8192);
+});
+
+test('sanitizeNode: clamps agentCommand to 128 chars', () => {
+  const n = wf.sanitizeNode({ agentCommand: 'c'.repeat(500) });
+  assert.equal(n.agentCommand.length, 128);
+});
+
+test('sanitizeNode: empty agentCommand becomes null', () => {
+  const n = wf.sanitizeNode({ agentCommand: '' });
+  assert.equal(n.agentCommand, null);
+});
+
+test('sanitizeNode: invalid passContext falls back to full', () => {
+  const n = wf.sanitizeNode({ passContext: 'evil' });
+  assert.equal(n.passContext, 'full');
+});
+
+test('sanitizeNode: valid passContext is preserved', () => {
+  for (const v of ['full', 'last50', 'none']) {
+    assert.equal(wf.sanitizeNode({ passContext: v }).passContext, v);
+  }
+});
+
+test('sanitizeNode: non-finite coords default to 0', () => {
+  const n = wf.sanitizeNode({ x: NaN, y: Infinity });
+  assert.equal(n.x, 0);
+  assert.equal(n.y, 0);
+});
+
+test('sanitizeNode: generates id when missing', () => {
+  const n = wf.sanitizeNode({});
+  assert.match(n.id, /^node-\d+-[a-z0-9]{4}$/);
+});
+
+// ─── sanitizeEdge ────────────────────────────────────────────────────────────
+
+test('sanitizeEdge: unknown condition type defaults to always', () => {
+  const e = wf.sanitizeEdge({ from: 'a', to: 'b', condition: { type: 'pwn', value: 'x' } });
+  assert.equal(e.condition.type, 'always');
+});
+
+test('sanitizeEdge: valid types preserved', () => {
+  for (const t of ['always', 'contains', 'regex', 'otherwise']) {
+    const e = wf.sanitizeEdge({ from: 'a', to: 'b', condition: { type: t } });
+    assert.equal(e.condition.type, t);
+  }
+});
+
+test('sanitizeEdge: clamps condition value to 256 chars', () => {
+  const e = wf.sanitizeEdge({ from: 'a', to: 'b', condition: { type: 'contains', value: 'x'.repeat(1000) } });
+  assert.equal(e.condition.value.length, 256);
+});
+
+// ─── sanitizeGraph ───────────────────────────────────────────────────────────
+
+test('sanitizeGraph: null returns empty graph', () => {
+  assert.deepEqual(wf.sanitizeGraph(null), { nodes: [], edges: [] });
+});
+
+test('sanitizeGraph: drops edges with unknown endpoints', () => {
+  const g = wf.sanitizeGraph({
+    nodes: [{ id: 'a' }, { id: 'b' }],
+    edges: [
+      { from: 'a', to: 'b' },
+      { from: 'a', to: 'ghost' },
+      { from: 'ghost', to: 'b' },
+    ],
+  });
+  assert.equal(g.edges.length, 1);
+  assert.equal(g.edges[0].from, 'a');
+  assert.equal(g.edges[0].to, 'b');
+});
+
+// ─── graphToOrderedSteps ─────────────────────────────────────────────────────
+
+test('graphToOrderedSteps: linear chain produces ordered list', () => {
+  const g = {
+    nodes: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }, { id: 'c', name: 'C' }],
+    edges: [
+      { from: 'a', to: 'b', condition: { type: 'always' } },
+      { from: 'b', to: 'c', condition: { type: 'always' } },
+    ],
+  };
+  const order = wf.graphToOrderedSteps(g);
+  assert.deepEqual(order.map((n) => n.id), ['a', 'b', 'c']);
+});
+
+test('graphToOrderedSteps: cycle terminates without infinite loop', () => {
+  const g = {
+    nodes: [{ id: 'a' }, { id: 'b' }],
+    edges: [
+      { from: 'a', to: 'b', condition: { type: 'always' } },
+      { from: 'b', to: 'a', condition: { type: 'always' } },
+    ],
+  };
+  const order = wf.graphToOrderedSteps(g);
+  assert.equal(order.length, 2);
+});
+
+test('graphToOrderedSteps: empty graph returns []', () => {
+  assert.deepEqual(wf.graphToOrderedSteps({ nodes: [], edges: [] }), []);
+});
+
+// ─── wfEdgeMatches ───────────────────────────────────────────────────────────
+
+test('wfEdgeMatches: contains is case-insensitive', () => {
+  assert.equal(wf.wfEdgeMatches({ type: 'contains', value: 'YES' }, 'yes please'), true);
+});
+
+test('wfEdgeMatches: contains miss returns false', () => {
+  assert.equal(wf.wfEdgeMatches({ type: 'contains', value: 'yes' }, 'no thanks'), false);
+});
+
+test('wfEdgeMatches: regex matches', () => {
+  assert.equal(wf.wfEdgeMatches({ type: 'regex', value: '^OK' }, 'OK done'), true);
+});
+
+test('wfEdgeMatches: bad regex returns false instead of throwing', () => {
+  assert.equal(wf.wfEdgeMatches({ type: 'regex', value: '[invalid' }, 'anything'), false);
+});
+
+test('wfEdgeMatches: always type returns false (caller handles)', () => {
+  assert.equal(wf.wfEdgeMatches({ type: 'always' }, 'anything'), false);
+});
+
+// ─── wfPickNextEdge ──────────────────────────────────────────────────────────
+
+const branchGraph = {
+  nodes: [{ id: 'a' }, { id: 'yes' }, { id: 'no' }, { id: 'else' }],
+  edges: [
+    { id: 'e1', from: 'a', to: 'yes', condition: { type: 'contains', value: 'OK' } },
+    { id: 'e2', from: 'a', to: 'no', condition: { type: 'contains', value: 'FAIL' } },
+    { id: 'e3', from: 'a', to: 'else', condition: { type: 'always' } },
+  ],
+};
+
+test('wfPickNextEdge: conditional wins over always', () => {
+  const e = wf.wfPickNextEdge(branchGraph, 'a', 'OK done');
+  assert.equal(e.to, 'yes');
+});
+
+test('wfPickNextEdge: fallback used when no conditional matches', () => {
+  const e = wf.wfPickNextEdge(branchGraph, 'a', 'nothing matches');
+  assert.equal(e.to, 'else');
+});
+
+test('wfPickNextEdge: returns null when node has no outgoing edges', () => {
+  assert.equal(wf.wfPickNextEdge(branchGraph, 'ghost', 'x'), null);
+});
+
+// ─── wfIsAiRouted ────────────────────────────────────────────────────────────
+
+test('wfIsAiRouted: single edge is not AI-routed', () => {
+  const g = { edges: [{ from: 'a', to: 'b' }] };
+  assert.equal(wf.wfIsAiRouted(g, 'a'), false);
+});
+
+test('wfIsAiRouted: 2+ unconditioned edges is AI-routed', () => {
+  const g = { edges: [
+    { from: 'a', to: 'b', condition: { type: 'always' } },
+    { from: 'a', to: 'c', condition: { type: 'always' } },
+  ]};
+  assert.equal(wf.wfIsAiRouted(g, 'a'), true);
+});
+
+test('wfIsAiRouted: any conditional edge disables AI routing', () => {
+  const g = { edges: [
+    { from: 'a', to: 'b', condition: { type: 'contains', value: 'x' } },
+    { from: 'a', to: 'c', condition: { type: 'always' } },
+  ]};
+  assert.equal(wf.wfIsAiRouted(g, 'a'), false);
+});
+
+// ─── wfResolveNext ───────────────────────────────────────────────────────────
+
+const aiRoutedGraph = {
+  nodes: [
+    { id: 'router', name: 'Router' },
+    { id: 'b', name: 'Branch B' },
+    { id: 'c', name: 'Branch C' },
+  ],
+  edges: [
+    { from: 'router', to: 'b', condition: { type: 'always' } },
+    { from: 'router', to: 'c', condition: { type: 'always' } },
+  ],
+};
+
+function byIdOf(g) { return new Map(g.nodes.map((n) => [n.id, n])); }
+
+test('wfResolveNext: AI-routed parses ROUTE: <name>', () => {
+  const r = wf.wfResolveNext(aiRoutedGraph, aiRoutedGraph.nodes[0], 'work\nROUTE: Branch C', byIdOf(aiRoutedGraph));
+  assert.equal(r.edge.to, 'c');
+  assert.equal(r.decision, 'Branch C');
+});
+
+test('wfResolveNext: ROUTE: END returns null edge with END decision', () => {
+  const r = wf.wfResolveNext(aiRoutedGraph, aiRoutedGraph.nodes[0], 'done\nROUTE: END', byIdOf(aiRoutedGraph));
+  assert.equal(r.edge, null);
+  assert.equal(r.decision, 'END');
+});
+
+test('wfResolveNext: multiple ROUTE lines uses the last one', () => {
+  const out = 'thinking\nROUTE: Branch B\nmore work\nROUTE: Branch C';
+  const r = wf.wfResolveNext(aiRoutedGraph, aiRoutedGraph.nodes[0], out, byIdOf(aiRoutedGraph));
+  assert.equal(r.edge.to, 'c');
+});
+
+test('wfResolveNext: missing ROUTE directive falls back to first branch', () => {
+  const r = wf.wfResolveNext(aiRoutedGraph, aiRoutedGraph.nodes[0], 'no directive here', byIdOf(aiRoutedGraph));
+  assert.equal(r.edge.to, 'b');
+  assert.equal(r.decision, null);
+});
+
+test('wfResolveNext: single outgoing edge returns it without parsing', () => {
+  const g = { nodes: [{ id: 'a' }, { id: 'b' }], edges: [{ from: 'a', to: 'b', condition: { type: 'always' } }] };
+  const r = wf.wfResolveNext(g, g.nodes[0], 'anything', byIdOf(g));
+  assert.equal(r.edge.to, 'b');
+});
+
+test('wfResolveNext: no outgoing edges returns null', () => {
+  const g = { nodes: [{ id: 'a' }], edges: [] };
+  const r = wf.wfResolveNext(g, g.nodes[0], '', byIdOf(g));
+  assert.equal(r, null);
+});
+
+// ─── migrateWorkflow ─────────────────────────────────────────────────────────
+
+test('migrateWorkflow: legacy steps[] becomes a chained graph', () => {
+  const legacy = { id: 'wf1', steps: [
+    { id: 's1', name: 'Step 1', prompt: 'a' },
+    { id: 's2', name: 'Step 2', prompt: 'b' },
+  ]};
+  const w = wf.migrateWorkflow(legacy);
+  assert.ok(w.graph);
+  assert.equal(w.graph.nodes.length, 2);
+  assert.equal(w.graph.edges.length, 1);
+  assert.equal(w.graph.edges[0].from, 's1');
+  assert.equal(w.graph.edges[0].to, 's2');
+  assert.equal(w.steps, undefined);
+});
+
+test('migrateWorkflow: already-graph workflow drops legacy steps field', () => {
+  const newWf = { id: 'wf2', steps: [{ id: 'legacy' }], graph: { nodes: [{ id: 'a' }], edges: [] } };
+  const w = wf.migrateWorkflow(newWf);
+  assert.equal(w.steps, undefined);
+  assert.equal(w.graph.nodes[0].id, 'a');
+});
+
+test('migrateWorkflow: empty workflow yields empty graph', () => {
+  const w = wf.migrateWorkflow({});
+  assert.deepEqual(w.graph, { nodes: [], edges: [] });
+});
+
+// ─── wfRouteInstruction ──────────────────────────────────────────────────────
+
+test('wfRouteInstruction: includes all target names and END option', () => {
+  const txt = wf.wfRouteInstruction(['A', 'B', 'C']);
+  assert.match(txt, /A \| B \| C/);
+  assert.match(txt, /ROUTE: END/);
+});


### PR DESCRIPTION
## Summary
Pure refactor + CI/release hygiene pass on top of v1.1.0. No user-visible feature change.

- Adds a unit + smoke test harness gated in CI (\`node:test\` + Playwright on the real Electron binary).
- Extracts \`shJoin\`, \`resolveInside\`, \`parseAgentMd\`, and the workflow graph helpers from \`src/main.js\` into \`src/lib/\` so they have direct unit coverage (84 tests). Routes \`skills:toggle\` through the new path helper.
- Adds a verified-download helper (\`installer/lib/verify.sh\`, \`installer/lib/verify.ps1\`) and a pinned SHA-256 for the upstream bun installer fetch.
- Drops a leftover \`lsof | kill\` step from the null voice server: just listens, surrenders cleanly if the port is held.
- Extends the CI shell syntax loop to cover \`installer/*.sh\` and includes dev deps in the \`npm audit\` gate.
- Adds a \`SHA256SUMS\` file to GitHub Releases so downloads are verifiable.

## Commits
- \`chore(testing)\` test harness + CI workflow
- \`refactor(lib)\` extract pure helpers into \`src/lib\` + tests
- \`chore(install)\` verify SHA-256 of fetched scripts
- \`refactor(voice)\` drop pre-listen port kill
- \`chore(ci)\` include installer hooks in shell syntax check
- \`chore(release)\` publish SHA256SUMS
- \`chore(ci)\` include dev deps in npm audit

## Test plan
- [x] \`npm test\` (84 unit tests, ~90ms)
- [x] \`npm run test:e2e\` (Electron boot, preload bridge, no console errors)
- [x] \`node --check src/main.js\`
- [x] \`bash -n\` on every shell script
- [ ] CI green on PR