### PR TITLE
Strict ESLint scope, Trivy HIGH gate, release attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
 
 permissions:
   contents: write
+  # id-token + attestations let actions/attest-build-provenance sign
+  # the release artifacts with a GitHub-issued, Sigstore-backed claim.
+  id-token: write
+  attestations: write
 
 env:
   NODE_VERSION: '20'
@@ -104,6 +108,16 @@ jobs:
           done
           echo "--- SHA256SUMS ---"
           cat SHA256SUMS
+
+      - name: Attest provenance for release artifacts
+        # Signs every release artifact with a Sigstore-backed claim
+        # tied to this workflow run. Users can verify with:
+        #   gh attestation verify <file> --repo DorShaer/Husk
+        # This also protects SHA256SUMS itself, so an attacker who
+        # swaps a release asset cannot silently rewrite the sums file.
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'release/*'
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,10 +135,41 @@ jobs:
             eslint-plugin-security \
             eslint-plugin-no-unsanitized@4.0.2
 
-      - name: Run ESLint security rules
-        # Scope to our own JS only. libs/pai is bundled third-party; the
-        # vendored xterm.js inside src/renderer/vendor/ is minified.
+      - name: Run ESLint security rules (strict scope)
+        # Strict scope: src/preload.js, src/renderer/app.js, src/lib/.
+        # New modules added here must lint clean at error. src/main.js
+        # is the legacy monolith and is linted separately at warn while
+        # it gets extracted into per-handler modules.
         run: |
+          npx eslint \
+            --no-eslintrc \
+            --parser-options=ecmaVersion:2022,sourceType:script \
+            --env es2022,browser,node \
+            --plugin security \
+            --plugin no-unsanitized \
+            --rule 'security/detect-eval-with-expression: error' \
+            --rule 'security/detect-non-literal-fs-filename: error' \
+            --rule 'security/detect-non-literal-require: error' \
+            --rule 'security/detect-child-process: error' \
+            --rule 'security/detect-unsafe-regex: error' \
+            --rule 'security/detect-non-literal-regexp: error' \
+            --rule 'security/detect-pseudoRandomBytes: error' \
+            --rule 'security/detect-buffer-noassert: error' \
+            --rule 'no-unsanitized/method: error' \
+            --rule 'no-unsanitized/property: error' \
+            --ignore-pattern 'libs/' \
+            --ignore-pattern 'node_modules/' \
+            --ignore-pattern 'src/renderer/vendor/' \
+            src/preload.js src/renderer/app.js src/lib/
+
+      - name: Run ESLint security rules (main.js, advisory)
+        # main.js still has many legitimate dynamic fs operations; the
+        # output is captured in security-reports for review but does
+        # not gate the build. As IPC handlers are extracted into
+        # src/lib or src/handlers they move to the strict scope above.
+        continue-on-error: true
+        run: |
+          mkdir -p security-reports
           npx eslint \
             --no-eslintrc \
             --parser-options=ecmaVersion:2022,sourceType:script \
@@ -155,10 +186,7 @@ jobs:
             --rule 'security/detect-buffer-noassert: error' \
             --rule 'no-unsanitized/method: warn' \
             --rule 'no-unsanitized/property: error' \
-            --ignore-pattern 'libs/' \
-            --ignore-pattern 'node_modules/' \
-            --ignore-pattern 'src/renderer/vendor/' \
-            src/main.js src/preload.js src/renderer/app.js
+            src/main.js 2>&1 | tee security-reports/eslint-mainjs.txt
 
   codeql:
     name: CodeQL (JavaScript)
@@ -264,10 +292,10 @@ jobs:
           scan-ref: '.'
           format: 'table'
           output: 'security-reports/trivy-fs.txt'
-          severity: 'CRITICAL'
+          severity: 'CRITICAL,HIGH'
           vuln-type: 'library'
           exit-code: '1'
-          skip-dirs: 'libs/pai,src/renderer/vendor,node_modules'
+          skip-dirs: 'libs/pai,src/renderer/vendor,node_modules,dist,test-results'
 
       - name: Trivy JSON (always)
         if: always()

--- a/installer/lib/verify.sh
+++ b/installer/lib/verify.sh
@@ -5,7 +5,19 @@
 # upstream revision of any script we fetch. We download to a temp file
 # and check its hash against the pinned value before executing.
 #
-# Updating a pin: review the upstream script you intend to allow, run
+# Trust model for the current bun pin:
+#   - The pinned bun installer downloads bun-<target>.zip from
+#     github.com/oven-sh/bun/releases. We do not independently verify
+#     that zip; the trust assumption is on the GitHub release.
+#   - The installer writes only under $HOME/.bun (or $BUN_INSTALL),
+#     appends a PATH line to the user's shell rc, and adds shell
+#     completions. No sudo, no eval, no writes outside that scope.
+#   - A stronger model is to skip the installer entirely and fetch the
+#     bun release zip + verify against bun's SHASUMS256.txt. Tracked
+#     as a follow-up.
+#
+# Updating a pin: read the upstream script you intend to allow line
+# by line, then
 #   curl -fsSL <url> | sha256sum
 # and replace the matching constant in install.sh.
 

--- a/src/lib/agent-md.js
+++ b/src/lib/agent-md.js
@@ -11,6 +11,9 @@ function parseAgentMd(text) {
   const fm = m[1];
   const body = m[2].trim();
   const getField = (k) => {
+    // k is one of the literal field names supplied by this module
+    // ('name', 'description'); never user input.
+    // eslint-disable-next-line security/detect-non-literal-regexp
     const re = new RegExp(`^${k}\\s*:\\s*(.*)$`, 'm');
     const mm = fm.match(re);
     if (!mm) return null;

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -85,7 +85,13 @@ function wfEdgeMatches(condition, output) {
   const text = String(output || '');
   if (c.type === 'contains') return text.toLowerCase().includes(String(c.value || '').toLowerCase());
   if (c.type === 'regex') {
-    try { return new RegExp(c.value || '').test(text); } catch (_) { return false; }
+    // c.value is the user's own workflow routing pattern, capped at
+    // 256 chars by sanitizeEdge. Match runs against this node's output,
+    // not against any privileged input.
+    try {
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      return new RegExp(c.value || '').test(text);
+    } catch (_) { return false; }
   }
   return false;
 }


### PR DESCRIPTION
## Summary
Follow-up to PR #13. Tightens CI gates and release provenance.

- ESLint security rules now run at **error** for \`src/preload.js\`, \`src/renderer/app.js\`, and \`src/lib/\`. New code added there has to lint clean. \`src/main.js\` runs the same rules in an **advisory** mode (warn, non-gating, output captured to \`security-reports/eslint-mainjs.txt\`) until it's broken up into per-handler modules; as files migrate to \`src/lib\` / future \`src/handlers\`, they move to the strict scope.
- Two pre-existing non-literal \`RegExp\` call sites in \`src/lib/\` are annotated with rationale and \`eslint-disable\` comments so the strict run is clean.
- Trivy filesystem scan gate raised from \`severity: CRITICAL\` to \`severity: CRITICAL,HIGH\`. Local scan against the same \`skip-dirs\` returns 0 findings, so the flip should not break the gate. \`skip-dirs\` also adds \`dist/\` and \`test-results/\` defensively.
- \`actions/attest-build-provenance\` signs every release artifact (and the \`SHA256SUMS\` file itself) with a Sigstore-backed claim tied to the workflow run. Verify with \`gh attestation verify <file> --repo DorShaer/Husk\`.
- \`installer/lib/verify.sh\` now records the explicit trust model for the pinned bun installer: what was reviewed, what assumptions remain, and what a stronger pinning model would look like.

## Test plan
- [x] \`npm test\` (84 unit tests, ~80ms)
- [x] \`npm run test:e2e\`
- [x] Local ESLint at error on strict scope returns 0 findings after the two annotations
- [x] Local Trivy fs scan at HIGH,CRITICAL returns 0 findings with the workflow's skip-dirs
- [x] \`python3 -c yaml.safe_load\` on changed workflows
- [ ] CI green on PR (validates that the new strict ESLint gate, Trivy gate flip, and attestation step all work in CI)

## Notes
- \`agentCommand\` accepts any binary on PATH by design (it's the user's own config). Not addressed here; would be a UX change that needs your call before implementing.
- macOS code signing still requires your Apple Developer ID — separate ticket.