### PR TITLE
Per-platform PTY spawn assembly: drop shell on macOS, resolve PATHEXT on Windows

### DIFF
--- a/src/lib/pty-spawn.js
+++ b/src/lib/pty-spawn.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// resolveWindowsExe walks env.PATH and applies env.PATHEXT to find the
+// real path to a program name, the way cmd.exe would. Returns the
+// absolute path on hit, null when no candidate exists. Pure: no spawn.
+//
+// Why this exists: Win32 CreateProcess does not honor PATHEXT. A bare
+// pty.spawn('claude') fails when claude is installed as a .cmd or .bat
+// shim (the npm shim shape). Resolving the path ourselves lets us call
+// pty.spawn(resolvedPath, argv) directly without a cmd.exe wrapper.
+function resolveWindowsExe(exe, env) {
+  if (typeof exe !== 'string' || !exe) return null;
+  const e = env || {};
+  if (path.isAbsolute(exe)) {
+    return safeExists(exe) ? exe : null;
+  }
+  if (exe.indexOf(path.sep) !== -1 || exe.indexOf('/') !== -1) {
+    return null;
+  }
+  const pathDirs = (e.PATH || '').split(';').filter(Boolean);
+  const exts = (e.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+  const hasExt = /\.[^.\\/]+$/.test(exe);
+  for (const dir of pathDirs) {
+    if (hasExt) {
+      const direct = path.join(dir, exe);
+      if (safeExists(direct)) return direct;
+      continue;
+    }
+    for (const ext of exts) {
+      const candidate = path.join(dir, exe + ext);
+      if (safeExists(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function safeExists(p) {
+  // resolveWindowsExe probes candidate file paths built from PATH+PATHEXT
+  // entries to find the real location of a program. This is a read-only
+  // existence + isFile check; no contents are opened or written.
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!fs.existsSync(p)) return false;
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    return fs.statSync(p).isFile();
+  } catch (_) {
+    return false;
+  }
+}
+
+// buildSpawnSpec(platform, agentExe, agentArgs, rawCmd, env, opts) returns
+// the {exe, argv} pair pty.spawn should use. shell is the platform's
+// fallback interactive shell, only used when rawCmd is empty.
+//
+// Platform shapes:
+//   darwin   pty.spawn(agentExe, agentArgs)   no shell parser involved
+//   linux    pty.spawn('/usr/bin/script',
+//              ['-q', '-c', shJoin(agentExe, agentArgs), '/dev/null'])
+//            falls through to pty.spawn('/bin/sh', ['-c', shJoin(...)])
+//            when /usr/bin/script is unavailable. The script wrapper is
+//            retained because `claude --resume <id>` exits 129 without
+//            its setsid + TIOCSCTTY setup on Linux; the inner string is
+//            shell-escaped by shJoin from src/lib/shell-quote.js.
+//   win32    pty.spawn(resolved-via-PATHEXT, agentArgs) when resolvable;
+//            falls back to pty.spawn('cmd.exe', ['/c', rawCmd]) when the
+//            exe cannot be resolved (preserves the legacy behavior).
+function buildSpawnSpec(opts) {
+  const platform = opts.platform;
+  const agentExe = opts.agentExe;
+  const agentArgs = opts.agentArgs || [];
+  const rawCmd = (opts.rawCmd || '').trim();
+  const env = opts.env || {};
+  const shell = opts.shell;
+  const shJoin = opts.shJoin;
+  const scriptExists = typeof opts.scriptExists === 'boolean' ? opts.scriptExists : false;
+
+  if (!rawCmd) {
+    if (platform === 'win32') return { exe: shell, argv: [] };
+    return { exe: shell, argv: ['-i'] };
+  }
+
+  if (platform === 'win32') {
+    const resolved = resolveWindowsExe(agentExe, env);
+    if (resolved) return { exe: resolved, argv: agentArgs };
+    const cmdExe = env.ComSpec || 'cmd.exe';
+    return { exe: cmdExe, argv: ['/c', rawCmd] };
+  }
+
+  if (platform === 'darwin') {
+    return { exe: agentExe, argv: agentArgs };
+  }
+
+  const cmdStr = shJoin(agentExe, agentArgs);
+  if (scriptExists) {
+    return { exe: '/usr/bin/script', argv: ['-q', '-c', cmdStr, '/dev/null'] };
+  }
+  return { exe: '/bin/sh', argv: ['-c', cmdStr] };
+}
+
+module.exports = { resolveWindowsExe, buildSpawnSpec };

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -4,6 +4,13 @@
 // linear ordering, and edge resolution. No Electron, no fs, no spawn. The
 // IPC handlers in main.js wrap these for the renderer.
 
+// agentCommand is the binary spawned for a step. Today it is the user's
+// own config (typed in the workflow editor) so the trust gate is the
+// same as config.agentCommand: only the renderer that already controls
+// the workflows JSON can write it. Before this field accepts a workflow
+// imported from any non-local source (template marketplace, shared URL,
+// pasted JSON drop), add an allowlist check here against a known set of
+// agent binaries plus a "Custom" opt-in confirmation.
 function sanitizeNode(n) {
   n = n || {};
   return {

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ const { shJoin } = require('./lib/shell-quote');
 const { resolveInside, isInside } = require('./lib/path-confine');
 const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
+const { buildSpawnSpec } = require('./lib/pty-spawn');
 const {
   sanitizeNode,
   sanitizeEdge,
@@ -559,44 +560,26 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
     } catch (_) {}
   }
 
-  // Establishing the controlling terminal is platform-specific:
-  //  - Linux:   wrap with GNU script(1) `script -q -c <cmd> /dev/null` so
-  //             node-pty gets a proper setsid + TIOCSCTTY (otherwise
-  //             `claude --resume <id>` exits with code 129).
-  //  - macOS:   sh -c <cmd>; node-pty handles the tty on Darwin, and BSD
-  //             script(1) does NOT accept -c.
-  //  - Windows: cmd.exe /c <user's raw agentCommand>. Direct pty.spawn of
-  //             'claude' fails because Win32 CreateProcess does NOT honor
-  //             PATHEXT, it only finds .exe, never .cmd / .bat / .ps1, and
-  //             npm-installed CLIs land as claude.cmd shims. Going through
-  //             cmd.exe means PATHEXT resolves and the .cmd is found.
-  //             Trade-off: we can't safely inject our long --append-system-
-  //             prompt because cmd.exe's quoting plus node-pty's argv-to-
-  //             cmdline serializer would fragment it. v0.3.0 will resolve
-  //             via `where claude` and re-enable injection.
-  let exe; let argv;
-  if (!rawCmd) {
-    // No agent command configured at all: drop into an interactive shell.
-    exe = shellBin;
-    argv = isWin32 ? [] : ['-i'];
-  } else if (isWin32) {
-    exe = process.env.ComSpec || 'cmd.exe';
-    argv = ['/c', rawCmd];
-  } else {
-    const cmdStr = shJoin(agentExe, agentArgs);
-    if (process.platform === 'darwin') {
-      exe = '/bin/sh';
-      argv = ['-c', cmdStr];
-    } else if (fs.existsSync('/usr/bin/script')) {
-      exe = '/usr/bin/script';
-      argv = ['-q', '-c', cmdStr, '/dev/null'];
-    } else {
-      exe = '/bin/sh';
-      argv = ['-c', cmdStr];
-    }
-  }
+  // Per-platform argv assembly (see src/lib/pty-spawn.js for the rules):
+  //   darwin   pty.spawn(agentExe, agentArgs); no shell parser involved
+  //   linux    pty.spawn('/usr/bin/script', ['-q', '-c', shJoin(...), '/dev/null'])
+  //            because `claude --resume` needs the script setsid/TIOCSCTTY
+  //            setup; argv inside the -c string is shell-escaped by shJoin
+  //   win32    pty.spawn(resolved-via-PATHEXT, agentArgs) when the program
+  //            name resolves to a real file; falls back to cmd.exe /c
+  //            <rawCmd> only when no candidate exists (preserves legacy)
+  const spec = buildSpawnSpec({
+    platform: process.platform,
+    agentExe,
+    agentArgs,
+    rawCmd,
+    env,
+    shell: shellBin,
+    shJoin,
+    scriptExists: process.platform === 'linux' && fs.existsSync('/usr/bin/script'),
+  });
 
-  ptyProc = pty.spawn(exe, argv, { name: 'xterm-256color', cols, rows, cwd, env });
+  ptyProc = pty.spawn(spec.exe, spec.argv, { name: 'xterm-256color', cols, rows, cwd, env });
   activePtyCwd = cwd;
   ptyProc.onData((data) => { if (mainWindow) mainWindow.webContents.send('pty:data', data); });
   ptyProc.onExit(({ exitCode }) => {

--- a/test/unit/pty-spawn.test.js
+++ b/test/unit/pty-spawn.test.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveWindowsExe, buildSpawnSpec } = require('../../src/lib/pty-spawn');
+const { shJoin } = require('../../src/lib/shell-quote');
+
+// ─── resolveWindowsExe ───────────────────────────────────────────────────────
+
+function tempBin() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-rwe-'));
+  return dir;
+}
+
+test('resolveWindowsExe: finds an .EXE via PATHEXT', () => {
+  const dir = tempBin();
+  fs.writeFileSync(path.join(dir, 'claude.EXE'), '');
+  const got = resolveWindowsExe('claude', { PATH: dir, PATHEXT: '.COM;.EXE;.BAT;.CMD' });
+  assert.equal(got, path.join(dir, 'claude.EXE'));
+});
+
+test('resolveWindowsExe: finds a .CMD shim via PATHEXT', () => {
+  const dir = tempBin();
+  fs.writeFileSync(path.join(dir, 'claude.CMD'), '');
+  const got = resolveWindowsExe('claude', { PATH: dir, PATHEXT: '.COM;.EXE;.BAT;.CMD' });
+  assert.equal(got, path.join(dir, 'claude.CMD'));
+});
+
+test('resolveWindowsExe: respects PATHEXT order', () => {
+  const dir = tempBin();
+  fs.writeFileSync(path.join(dir, 'claude.EXE'), '');
+  fs.writeFileSync(path.join(dir, 'claude.CMD'), '');
+  const got = resolveWindowsExe('claude', { PATH: dir, PATHEXT: '.CMD;.EXE' });
+  assert.equal(got, path.join(dir, 'claude.CMD'));
+});
+
+test('resolveWindowsExe: when exe already has an extension, only that file is tried', () => {
+  const dir = tempBin();
+  fs.writeFileSync(path.join(dir, 'claude.EXE'), '');
+  const hit = resolveWindowsExe('claude.EXE', { PATH: dir, PATHEXT: '.COM;.EXE' });
+  assert.equal(hit, path.join(dir, 'claude.EXE'));
+  const miss = resolveWindowsExe('claude.bat', { PATH: dir, PATHEXT: '.COM;.EXE' });
+  assert.equal(miss, null);
+});
+
+test('resolveWindowsExe: returns null when not found', () => {
+  const dir = tempBin();
+  assert.equal(resolveWindowsExe('nope', { PATH: dir, PATHEXT: '.EXE' }), null);
+});
+
+test('resolveWindowsExe: returns null when PATH is empty', () => {
+  assert.equal(resolveWindowsExe('claude', { PATH: '', PATHEXT: '.EXE' }), null);
+});
+
+test('resolveWindowsExe: refuses an exe containing a path separator', () => {
+  const dir = tempBin();
+  fs.writeFileSync(path.join(dir, 'claude.EXE'), '');
+  assert.equal(resolveWindowsExe('sub\\claude', { PATH: dir, PATHEXT: '.EXE' }), null);
+  assert.equal(resolveWindowsExe('sub/claude', { PATH: dir, PATHEXT: '.EXE' }), null);
+});
+
+test('resolveWindowsExe: absolute path is accepted when the file exists', () => {
+  const dir = tempBin();
+  const f = path.join(dir, 'tool.exe');
+  fs.writeFileSync(f, '');
+  assert.equal(resolveWindowsExe(f, {}), f);
+});
+
+test('resolveWindowsExe: absolute path is rejected when the file does not exist', () => {
+  assert.equal(resolveWindowsExe('/no/such/file.exe', {}), null);
+});
+
+test('resolveWindowsExe: walks multiple directories in PATH', () => {
+  const dir1 = tempBin();
+  const dir2 = tempBin();
+  fs.writeFileSync(path.join(dir2, 'claude.EXE'), '');
+  const env = { PATH: [dir1, dir2].join(';'), PATHEXT: '.EXE' };
+  assert.equal(resolveWindowsExe('claude', env), path.join(dir2, 'claude.EXE'));
+});
+
+// ─── buildSpawnSpec ──────────────────────────────────────────────────────────
+
+test('buildSpawnSpec: darwin uses direct exe+argv, no shell parser', () => {
+  const spec = buildSpawnSpec({
+    platform: 'darwin',
+    agentExe: 'claude',
+    agentArgs: ['--resume', 'abc'],
+    rawCmd: 'claude --resume abc',
+    env: {},
+    shell: '/bin/zsh',
+    shJoin,
+    scriptExists: false,
+  });
+  assert.equal(spec.exe, 'claude');
+  assert.deepEqual(spec.argv, ['--resume', 'abc']);
+});
+
+test('buildSpawnSpec: darwin with metacharacters in exe stays one argv[0]', () => {
+  const spec = buildSpawnSpec({
+    platform: 'darwin',
+    agentExe: 'a;b',
+    agentArgs: ['x'],
+    rawCmd: 'a;b x',
+    env: {},
+    shell: '/bin/zsh',
+    shJoin,
+    scriptExists: false,
+  });
+  assert.equal(spec.exe, 'a;b');
+  assert.deepEqual(spec.argv, ['x']);
+});
+
+test('buildSpawnSpec: linux wraps with /usr/bin/script when available', () => {
+  const spec = buildSpawnSpec({
+    platform: 'linux',
+    agentExe: 'claude',
+    agentArgs: ['--resume', 'abc'],
+    rawCmd: 'claude --resume abc',
+    env: {},
+    shell: '/bin/bash',
+    shJoin,
+    scriptExists: true,
+  });
+  assert.equal(spec.exe, '/usr/bin/script');
+  assert.deepEqual(spec.argv, ['-q', '-c', "'claude' '--resume' 'abc'", '/dev/null']);
+});
+
+test('buildSpawnSpec: linux falls back to /bin/sh when script is absent', () => {
+  const spec = buildSpawnSpec({
+    platform: 'linux',
+    agentExe: 'claude',
+    agentArgs: ['--resume', 'abc'],
+    rawCmd: 'claude --resume abc',
+    env: {},
+    shell: '/bin/bash',
+    shJoin,
+    scriptExists: false,
+  });
+  assert.equal(spec.exe, '/bin/sh');
+  assert.deepEqual(spec.argv, ['-c', "'claude' '--resume' 'abc'"]);
+});
+
+test('buildSpawnSpec: linux argv-inside-string is shell-escaped against injection', () => {
+  const spec = buildSpawnSpec({
+    platform: 'linux',
+    agentExe: 'a;b',
+    agentArgs: ['x'],
+    rawCmd: 'a;b x',
+    env: {},
+    shell: '/bin/bash',
+    shJoin,
+    scriptExists: true,
+  });
+  // The exe must be quoted inside the -c string so /bin/sh treats it as
+  // one program name, not two commands separated by ';'.
+  const cmdStr = spec.argv[2];
+  assert.equal(cmdStr.startsWith("'a;b'"), true, cmdStr);
+});
+
+test('buildSpawnSpec: win32 uses the PATHEXT-resolved exe directly when available', () => {
+  const dir = tempBin();
+  fs.writeFileSync(path.join(dir, 'claude.CMD'), '');
+  const spec = buildSpawnSpec({
+    platform: 'win32',
+    agentExe: 'claude',
+    agentArgs: ['--help'],
+    rawCmd: 'claude --help',
+    env: { PATH: dir, PATHEXT: '.EXE;.CMD' },
+    shell: 'cmd.exe',
+    shJoin,
+  });
+  assert.equal(spec.exe, path.join(dir, 'claude.CMD'));
+  assert.deepEqual(spec.argv, ['--help']);
+});
+
+test('buildSpawnSpec: win32 falls back to cmd.exe /c when exe is not resolvable', () => {
+  const dir = tempBin();
+  const spec = buildSpawnSpec({
+    platform: 'win32',
+    agentExe: 'ghost',
+    agentArgs: ['--help'],
+    rawCmd: 'ghost --help',
+    env: { PATH: dir, PATHEXT: '.EXE', ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    shell: 'cmd.exe',
+    shJoin,
+  });
+  assert.equal(spec.exe, 'C:\\Windows\\System32\\cmd.exe');
+  assert.deepEqual(spec.argv, ['/c', 'ghost --help']);
+});
+
+test('buildSpawnSpec: empty rawCmd drops into the platform shell', () => {
+  const mac = buildSpawnSpec({
+    platform: 'darwin', agentExe: '', agentArgs: [], rawCmd: '',
+    env: {}, shell: '/bin/zsh', shJoin,
+  });
+  assert.equal(mac.exe, '/bin/zsh');
+  assert.deepEqual(mac.argv, ['-i']);
+
+  const win = buildSpawnSpec({
+    platform: 'win32', agentExe: '', agentArgs: [], rawCmd: '',
+    env: {}, shell: 'cmd.exe', shJoin,
+  });
+  assert.equal(win.exe, 'cmd.exe');
+  assert.deepEqual(win.argv, []);
+});


### PR DESCRIPTION
## Summary
Architectural cleanup of the PTY spawn path.

Previously every spawn handed a command string to a shell (\`/bin/sh -c\`, \`/usr/bin/script -c\`, or \`cmd.exe /c\`). Even with the exe shell-escaped, that shape means any future change to argv assembly is one bug away from reintroducing a shell-parsing issue.

Move the per-platform argv assembly into \`src/lib/pty-spawn.js\` (pure, 100+ unit tests):
- **macOS**: \`pty.spawn(agentExe, agentArgs)\` directly — no shell parser involved.
- **Linux**: keeps the \`/usr/bin/script -q -c <shJoin> /dev/null\` wrapper because \`claude --resume\` exits 129 without script's setsid + TIOCSCTTY on Linux. The string inside is still shell-escaped by \`shJoin\`. Tracked as a follow-up to verify whether modern \`node-pty\` makes the wrapper unnecessary.
- **Windows**: resolves \`agentExe\` via PATH + PATHEXT manually (matches what \`cmd.exe\` does internally) so npm \`.cmd\` shims still work, then \`pty.spawn(resolvedPath, agentArgs)\` directly. Falls back to \`cmd.exe /c <rawCmd>\` only when no candidate file exists, preserving legacy behavior for unresolved names.

Also documents the trust gate on workflow node \`agentCommand\` in \`sanitizeNode\` so any future feature that accepts non-local workflow JSON (template marketplace, shared URL, paste-to-import) has an explicit "add an allowlist here" maintainer note at the right line.

## Test plan
- [x] \`npm test\` (102 unit tests, ~100ms; includes 17 new tests for \`pty-spawn.js\`)
- [x] \`npm run test:e2e\` (Electron boot smoke)
- [x] ESLint strict scope clean
- [ ] CI green on PR