### PR TITLE
Adopt main + development branching model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, development, "dev/**"]
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, development]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ name: Security analysis
 # one, weekly on Sunday 02:00 UTC for drift detection, and on demand.
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, development, "dev/**"]
     paths:
       - '**.js'
       - '**.html'
@@ -15,7 +15,7 @@ on:
       - '.github/codeql/**'
       - '.gitleaks.toml'
   pull_request:
-    branches: [main, master, develop]
+    branches: [main, development]
   schedule:
     - cron: '0 2 * * 0'
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [main, "dev/**"]
+    branches: [main, development, "dev/**"]
   pull_request:
-    branches: [main, "dev/**"]
+    branches: [main, development]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ husk/
 - `installer/` holds OS-level install assets (icon for the desktop entry).
 - `install.sh` / `run.sh` / `uninstall.sh` are the entry-point scripts and stay at the repo root for easy `git clone && cd && ./install.sh`.
 
+## Branches
+
+- `main` carries released code. Tags `v*` are cut from here, the release workflow builds installers, and SHA256SUMS plus Sigstore build-provenance attestations ship alongside them.
+- `development` is the integration branch where active work lands. Feature branches use `dev/<short-name>` and open pull requests against `development`.
+- Releases merge `development` into `main`, then a `v<x>.<y>.<z>` tag triggers the release pipeline.
+- CI (lint, security scans, unit tests, Electron smoke) runs on every push and pull request to either long-lived branch.
+
 ## Configuration
 
 All settings live in `~/.config/husk/config.json` and are editable from the Preferences page:


### PR DESCRIPTION
## Summary
Bootstraps the two-branch flow you asked for:

- \`main\`: released code. \`v*\` tags cut from here. Release pipeline builds installers, SHA256SUMS, and Sigstore attestations.
- \`development\`: integration branch for active work. Feature branches use \`dev/<short-name>\` and open PRs into \`development\`. Releases merge \`development\` -> \`main\` and tag.

Workflow changes
- All three CI workflows (\`ci.yml\`, \`security.yml\`, \`tests.yml\`) now trigger on push and PR to both \`main\` and \`development\`, plus push to \`dev/**\` feature branches.
- Dropped the \`master\` and \`develop\` branch names that no branch in this repo actually uses.
- Added a Branches section to README so the flow is documented for contributors.

This PR itself uses the new flow: committed on \`development\`, targeting \`main\`.

## Test plan
- [x] All three workflow files load as valid YAML
- [ ] CI green on this PR (validates the new triggers actually fire on PRs into \`main\`)