### PR TITLE
Inherit user shell PATH at startup on macOS and Linux

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,8 +59,13 @@ jobs:
       - name: Run Gitleaks
         run: |
           mkdir -p security-reports
-          if [ "${{ github.event_name }}" = "push" ]; then
-            gitleaks detect --config .gitleaks.toml --log-opts="${{ github.event.before }}..${{ github.sha }}" --report-format=json --report-path=security-reports/gitleaks-report.json
+          # On the first push of a new branch github.event.before is the
+          # all-zeros sha, which makes the diff range invalid. Detect
+          # that and scan the whole repo instead, same as the PR path.
+          BEFORE='${{ github.event.before }}'
+          ZERO_SHA='0000000000000000000000000000000000000000'
+          if [ "${{ github.event_name }}" = "push" ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$ZERO_SHA" ]; then
+            gitleaks detect --config .gitleaks.toml --log-opts="$BEFORE..${{ github.sha }}" --report-format=json --report-path=security-reports/gitleaks-report.json
           else
             gitleaks detect --config .gitleaks.toml --report-format=json --report-path=security-reports/gitleaks-report.json
           fi

--- a/src/lib/user-path.js
+++ b/src/lib/user-path.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// Read the PATH the user's login shell would see, so that a GUI-launched
+// Electron app inherits the same binary search list as a Terminal
+// session. macOS in particular hands GUI-launched apps a minimal PATH
+// (/usr/bin:/bin:/usr/sbin:/sbin) that misses npm-global, homebrew, and
+// bun install directories where users keep their agent CLIs.
+
+const MARKER_START = '__HUSK_PATH_START__';
+const MARKER_END = '__HUSK_PATH_END__';
+
+// Pure parser. Given the stdout of a marker-wrapped echo, return the
+// PATH between the markers or null if either marker is missing or the
+// extracted value does not look like a PATH (must contain a separator).
+function parseShellPathOutput(stdout) {
+  if (typeof stdout !== 'string' || !stdout) return null;
+  const start = stdout.lastIndexOf(MARKER_START);
+  const end = stdout.lastIndexOf(MARKER_END);
+  if (start === -1 || end === -1 || end <= start) return null;
+  const value = stdout.slice(start + MARKER_START.length, end).trim();
+  if (!value || value.indexOf(':') === -1) return null;
+  return value;
+}
+
+// Orchestrator. runShell is injected so tests can exercise the logic
+// without spawning a real process. Returns the PATH string on success,
+// null when augmentation is not applicable or fails. The shell command
+// is a fixed string that never interpolates external input.
+function getUserPath({ platform, env, runShell }) {
+  if (platform !== 'darwin' && platform !== 'linux') return null;
+  const e = env || {};
+  const shell = (typeof e.SHELL === 'string' && e.SHELL) ? e.SHELL : '/bin/zsh';
+  const cmd = `echo "${MARKER_START}$PATH${MARKER_END}"`;
+  let result;
+  try {
+    result = runShell(shell, ['-ilc', cmd]);
+  } catch (_) {
+    return null;
+  }
+  if (!result || typeof result.stdout !== 'string') return null;
+  return parseShellPathOutput(result.stdout);
+}
+
+module.exports = { parseShellPathOutput, getUserPath, MARKER_START, MARKER_END };

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const pty = require('node-pty');
 
 const { shJoin } = require('./lib/shell-quote');
@@ -14,6 +14,21 @@ const { resolveInside, isInside } = require('./lib/path-confine');
 const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
 const { buildSpawnSpec } = require('./lib/pty-spawn');
+const { getUserPath } = require('./lib/user-path');
+
+// On macOS in particular, a GUI-launched Electron app inherits a
+// minimal PATH that does not include the npm-global, homebrew, or bun
+// install directories where users keep their agent CLIs. Read the
+// user's actual shell PATH once at startup so subsequent spawns can
+// find their binaries.
+try {
+  const userPath = getUserPath({
+    platform: process.platform,
+    env: process.env,
+    runShell: (shell, args) => spawnSync(shell, args, { encoding: 'utf8', timeout: 5000 }),
+  });
+  if (userPath) process.env.PATH = userPath;
+} catch (_) {}
 const {
   sanitizeNode,
   sanitizeEdge,

--- a/test/unit/user-path.test.js
+++ b/test/unit/user-path.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseShellPathOutput,
+  getUserPath,
+  MARKER_START,
+  MARKER_END,
+} = require('../../src/lib/user-path');
+
+function wrap(p) {
+  return `${MARKER_START}${p}${MARKER_END}\n`;
+}
+
+// ─── parseShellPathOutput ────────────────────────────────────────────────────
+
+test('parseShellPathOutput: extracts PATH between markers', () => {
+  assert.equal(
+    parseShellPathOutput(wrap('/usr/local/bin:/usr/bin:/bin')),
+    '/usr/local/bin:/usr/bin:/bin',
+  );
+});
+
+test('parseShellPathOutput: ignores chatter before the markers', () => {
+  const out = `Welcome to zsh\nLoading completions...\n${wrap('/opt/homebrew/bin:/usr/bin')}`;
+  assert.equal(parseShellPathOutput(out), '/opt/homebrew/bin:/usr/bin');
+});
+
+test('parseShellPathOutput: ignores chatter after the markers', () => {
+  const out = `${wrap('/usr/local/bin:/usr/bin')}some leftover output\n`;
+  assert.equal(parseShellPathOutput(out), '/usr/local/bin:/usr/bin');
+});
+
+test('parseShellPathOutput: trims whitespace inside the marker block', () => {
+  const out = `${MARKER_START}   /usr/bin:/bin   ${MARKER_END}`;
+  assert.equal(parseShellPathOutput(out), '/usr/bin:/bin');
+});
+
+test('parseShellPathOutput: returns null when both markers are missing', () => {
+  assert.equal(parseShellPathOutput('/usr/bin:/bin'), null);
+});
+
+test('parseShellPathOutput: returns null when only the start marker is present', () => {
+  assert.equal(parseShellPathOutput(`${MARKER_START}/usr/bin:/bin`), null);
+});
+
+test('parseShellPathOutput: returns null when only the end marker is present', () => {
+  assert.equal(parseShellPathOutput(`/usr/bin:/bin${MARKER_END}`), null);
+});
+
+test('parseShellPathOutput: returns null when extracted value has no separator', () => {
+  assert.equal(parseShellPathOutput(wrap('justonebinary')), null);
+});
+
+test('parseShellPathOutput: returns null on empty extracted value', () => {
+  assert.equal(parseShellPathOutput(`${MARKER_START}${MARKER_END}`), null);
+});
+
+test('parseShellPathOutput: returns null for non-string input', () => {
+  assert.equal(parseShellPathOutput(null), null);
+  assert.equal(parseShellPathOutput(undefined), null);
+  assert.equal(parseShellPathOutput(42), null);
+  assert.equal(parseShellPathOutput(''), null);
+});
+
+test('parseShellPathOutput: when both markers appear multiple times, uses the last pair', () => {
+  const out = `${wrap('/stale/path:/old')}${wrap('/real/path:/cur')}`;
+  assert.equal(parseShellPathOutput(out), '/real/path:/cur');
+});
+
+// ─── getUserPath ─────────────────────────────────────────────────────────────
+
+test('getUserPath: skips augmentation on win32', () => {
+  const got = getUserPath({
+    platform: 'win32',
+    env: { SHELL: '/bin/zsh' },
+    runShell: () => { throw new Error('should not be called'); },
+  });
+  assert.equal(got, null);
+});
+
+test('getUserPath: skips augmentation on an unknown platform', () => {
+  const got = getUserPath({
+    platform: 'freebsd',
+    env: { SHELL: '/bin/sh' },
+    runShell: () => { throw new Error('should not be called'); },
+  });
+  assert.equal(got, null);
+});
+
+test('getUserPath: uses $SHELL when present', () => {
+  let calledShell = null;
+  const runShell = (shell) => {
+    calledShell = shell;
+    return { stdout: wrap('/usr/local/bin:/usr/bin') };
+  };
+  getUserPath({ platform: 'darwin', env: { SHELL: '/bin/bash' }, runShell });
+  assert.equal(calledShell, '/bin/bash');
+});
+
+test('getUserPath: falls back to /bin/zsh when $SHELL is absent', () => {
+  let calledShell = null;
+  const runShell = (shell) => {
+    calledShell = shell;
+    return { stdout: wrap('/usr/bin:/bin') };
+  };
+  getUserPath({ platform: 'darwin', env: {}, runShell });
+  assert.equal(calledShell, '/bin/zsh');
+});
+
+test('getUserPath: invokes login + interactive + command shell flags', () => {
+  let calledArgs = null;
+  const runShell = (_shell, args) => {
+    calledArgs = args;
+    return { stdout: wrap('/x:/y') };
+  };
+  getUserPath({ platform: 'darwin', env: { SHELL: '/bin/zsh' }, runShell });
+  assert.equal(calledArgs[0], '-ilc');
+  assert.match(calledArgs[1], new RegExp(MARKER_START));
+  assert.match(calledArgs[1], new RegExp(MARKER_END));
+});
+
+test('getUserPath: returns the parsed PATH on success', () => {
+  const runShell = () => ({ stdout: wrap('/home/me/bin:/usr/bin') });
+  assert.equal(getUserPath({ platform: 'darwin', env: {}, runShell }), '/home/me/bin:/usr/bin');
+});
+
+test('getUserPath: returns null when runShell throws', () => {
+  const runShell = () => { throw new Error('spawn failed'); };
+  assert.equal(getUserPath({ platform: 'darwin', env: {}, runShell }), null);
+});
+
+test('getUserPath: returns null when stdout has no markers', () => {
+  const runShell = () => ({ stdout: '/usr/bin:/bin\n' });
+  assert.equal(getUserPath({ platform: 'darwin', env: {}, runShell }), null);
+});
+
+test('getUserPath: returns null when runShell yields no stdout', () => {
+  assert.equal(
+    getUserPath({ platform: 'darwin', env: {}, runShell: () => ({}) }),
+    null,
+  );
+});
+
+test('getUserPath: works on linux too', () => {
+  const runShell = () => ({ stdout: wrap('/home/me/bin:/usr/bin') });
+  assert.equal(getUserPath({ platform: 'linux', env: {}, runShell }), '/home/me/bin:/usr/bin');
+});
+
+test('getUserPath: the shell command does not interpolate any env value', () => {
+  let captured = null;
+  const runShell = (_shell, args) => {
+    captured = args[args.length - 1];
+    return { stdout: wrap('/u/b') };
+  };
+  getUserPath({
+    platform: 'darwin',
+    env: { SHELL: '/bin/zsh', FOO: 'bar;evil', PATH: 'unused' },
+    runShell,
+  });
+  const expected = `echo "${MARKER_START}$PATH${MARKER_END}"`;
+  assert.equal(captured, expected);
+});


### PR DESCRIPTION
## Summary
GUI-launched Electron apps on macOS get a minimal \`PATH\` that excludes the npm-global / homebrew / bun directories where users keep their agent CLIs. Result today: an installed user opens Husk, the right panel shows \"Claude 2.1.129\" (read from disk), but \`spawnPty\` ends with \`/bin/sh: claude: command not found\`. Workaround was to type the absolute path into Preferences.

New \`src/lib/user-path.js\` asks the user's \`\$SHELL\` (login + interactive) to print its PATH between unique markers, parses the result, and \`main.js\` replaces \`process.env.PATH\` once at startup. Marker-anchored parsing tolerates rc-file chatter, motd, and completion noise.

The shell command is a fixed literal — no external value is interpolated into it. Tests cover every branch of the parser plus the orchestrator with a mocked \`runShell\`.

First PR on the new \`development\` integration branch.

## Test plan
- [x] \`npm test\` — 124 unit tests (22 new), all green
- [x] \`npm run test:e2e\` — Electron smoke green
- [x] ESLint strict scope clean on \`src/lib/\`
- [ ] CI green on PR