### PR TITLE
Constrain workflow node agentCommand + finish action-pin pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
         #   gh attestation verify <file> --repo DorShaer/Husk
         # This also protects SHA256SUMS itself, so an attacker who
         # swaps a release asset cannot silently rewrite the sums file.
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: 'release/*'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -302,7 +302,7 @@ jobs:
 
       - name: Trivy filesystem scan
         # Pinned by SHA (do not move to @master). Bumps go through dependabot.
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -315,7 +315,7 @@ jobs:
 
       - name: Trivy JSON (always)
         if: always()
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -29,8 +29,8 @@ jobs:
     timeout-minutes: 10
     needs: unit
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -4,19 +4,40 @@
 // linear ordering, and edge resolution. No Electron, no fs, no spawn. The
 // IPC handlers in main.js wrap these for the renderer.
 
-// agentCommand is the binary spawned for a step. Today it is the user's
-// own config (typed in the workflow editor) so the trust gate is the
-// same as config.agentCommand: only the renderer that already controls
-// the workflows JSON can write it. Before this field accepts a workflow
-// imported from any non-local source (template marketplace, shared URL,
-// pasted JSON drop), add an allowlist check here against a known set of
-// agent binaries plus a "Custom" opt-in confirmation.
+// Workflow nodes are intended to invoke one of the supported agent CLIs.
+// The allowlist below pins the agentCommand basename to that set. Update
+// this list when a new agent CLI is added to KNOWN_AGENTS in main.js.
+const ALLOWED_AGENT_COMMANDS = new Set([
+  'claude',
+  'copilot',
+  'codex',
+  'aider',
+  'gemini',
+]);
+
+// isAllowedAgentCommand(value) returns true when the first whitespace-
+// separated token's basename (case-insensitive) is in the allowlist.
+function isAllowedAgentCommand(value) {
+  if (typeof value !== 'string') return false;
+  const first = value.trim().split(/\s+/)[0];
+  if (!first) return false;
+  const base = first.split(/[\\/]/).pop().toLowerCase();
+  return ALLOWED_AGENT_COMMANDS.has(base);
+}
+
+// agentCommand is the binary executeWorkflow spawns for a step. Values
+// whose first token's basename is not in ALLOWED_AGENT_COMMANDS are
+// dropped to null here. executeWorkflow then falls back to the user's
+// config.agentCommand, which is independently checked against the same
+// allowlist at run time.
 function sanitizeNode(n) {
   n = n || {};
+  const raw = String(n.agentCommand || '').slice(0, 128);
+  const agentCommand = (raw && isAllowedAgentCommand(raw)) ? raw : null;
   return {
     id: n.id || `node-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
     name: String(n.name || 'Step').slice(0, 64),
-    agentCommand: String(n.agentCommand || '').slice(0, 128) || null,
+    agentCommand,
     prompt: String(n.prompt || '').slice(0, 8192),
     passContext: ['full', 'last50', 'none'].includes(n.passContext) ? n.passContext : 'full',
     x: Number.isFinite(n.x) ? n.x : 0,
@@ -155,6 +176,8 @@ function wfResolveNext(graph, node, output, byId) {
 }
 
 module.exports = {
+  ALLOWED_AGENT_COMMANDS,
+  isAllowedAgentCommand,
   sanitizeNode,
   sanitizeEdge,
   sanitizeGraph,

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ const {
   wfIsAiRouted,
   wfRouteInstruction,
   wfResolveNext,
+  isAllowedAgentCommand,
 } = wfLib;
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
@@ -1370,6 +1371,21 @@ async function executeWorkflow(event, workflow, run) {
     wfEmit(event, 'wf:node:start', { runId: run.id, nodeId: node.id });
 
     const cmd = (step.agentCommand || config.agentCommand || 'claude').trim().split(/\s+/)[0];
+
+    // The resolved cmd may come from step.agentCommand (already
+    // checked by sanitizeNode) or from config.agentCommand. Apply the
+    // same allowlist here so both paths agree.
+    if (!isAllowedAgentCommand(cmd)) {
+      wfEmit(event, 'wf:node:activity', {
+        runId: run.id,
+        nodeId: node.id,
+        kind: 'error',
+        text: `Step "${node.name}" needs one of ${Array.from(wfLib.ALLOWED_AGENT_COMMANDS).join(', ')}; got "${cmd}".`,
+      });
+      wfEmit(event, 'wf:node:done', { runId: run.id, nodeId: node.id, ok: false });
+      wfEmit(event, 'wf:run:done', { runId: run.id, ok: false, error: 'unsupported_agent_command' });
+      return;
+    }
 
     let prompt = step.prompt;
     if (previousOutput) {

--- a/test/unit/workflow-graph.test.js
+++ b/test/unit/workflow-graph.test.js
@@ -18,13 +18,71 @@ test('sanitizeNode: clamps prompt to 8192 chars', () => {
 });
 
 test('sanitizeNode: clamps agentCommand to 128 chars', () => {
-  const n = wf.sanitizeNode({ agentCommand: 'c'.repeat(500) });
+  // First token must be an allowed agent name for sanitizeNode to keep
+  // the value at all (see allowlist tests below). Use claude with a
+  // long flag tail so the result is both clamped and preserved.
+  const n = wf.sanitizeNode({ agentCommand: 'claude ' + 'x'.repeat(500) });
   assert.equal(n.agentCommand.length, 128);
+  assert.equal(n.agentCommand.startsWith('claude '), true);
 });
 
 test('sanitizeNode: empty agentCommand becomes null', () => {
   const n = wf.sanitizeNode({ agentCommand: '' });
   assert.equal(n.agentCommand, null);
+});
+
+test('sanitizeNode: agentCommand outside the allowlist becomes null', () => {
+  for (const bad of ['sh', 'bash', 'dash', 'zsh', 'fish', 'python', 'python3', 'perl', 'ruby', 'node', '/bin/sh', '/usr/local/bin/bash', 'sh script.sh', '../sh']) {
+    const n = wf.sanitizeNode({ agentCommand: bad });
+    assert.equal(n.agentCommand, null, `expected null for input ${JSON.stringify(bad)}`);
+  }
+});
+
+test('sanitizeNode: known agent commands are preserved', () => {
+  for (const good of ['claude', 'copilot', 'codex', 'aider', 'gemini']) {
+    const n = wf.sanitizeNode({ agentCommand: good });
+    assert.equal(n.agentCommand, good);
+  }
+});
+
+test('sanitizeNode: known agent with flags is preserved', () => {
+  const n = wf.sanitizeNode({ agentCommand: 'claude --print --verbose' });
+  assert.equal(n.agentCommand, 'claude --print --verbose');
+});
+
+test('sanitizeNode: known agent at an absolute path is preserved', () => {
+  const n = wf.sanitizeNode({ agentCommand: '/opt/homebrew/bin/claude' });
+  assert.equal(n.agentCommand, '/opt/homebrew/bin/claude');
+});
+
+test('sanitizeNode: allowlist comparison is case-insensitive on basename', () => {
+  const n = wf.sanitizeNode({ agentCommand: 'CLAUDE' });
+  assert.equal(n.agentCommand, 'CLAUDE');
+});
+
+// ─── isAllowedAgentCommand direct ───────────────────────────────────────────
+
+test('isAllowedAgentCommand: returns true for every entry in the allowlist', () => {
+  for (const name of wf.ALLOWED_AGENT_COMMANDS) {
+    assert.equal(wf.isAllowedAgentCommand(name), true);
+  }
+});
+
+test('isAllowedAgentCommand: returns false for shells and interpreters', () => {
+  for (const bad of ['sh', 'bash', 'zsh', 'fish', 'python', 'node', 'ruby', 'perl', '']) {
+    assert.equal(wf.isAllowedAgentCommand(bad), false, bad);
+  }
+});
+
+test('isAllowedAgentCommand: returns false for non-string input', () => {
+  assert.equal(wf.isAllowedAgentCommand(null), false);
+  assert.equal(wf.isAllowedAgentCommand(undefined), false);
+  assert.equal(wf.isAllowedAgentCommand(42), false);
+});
+
+test('isAllowedAgentCommand: ignores arguments after the first token', () => {
+  assert.equal(wf.isAllowedAgentCommand('claude --any --thing'), true);
+  assert.equal(wf.isAllowedAgentCommand('sh --pretending-to-be-claude'), false);
 });
 
 test('sanitizeNode: invalid passContext falls back to full', () => {
@@ -274,4 +332,24 @@ test('wfRouteInstruction: includes all target names and END option', () => {
   const txt = wf.wfRouteInstruction(['A', 'B', 'C']);
   assert.match(txt, /A \| B \| C/);
   assert.match(txt, /ROUTE: END/);
+});
+
+// ─── Source-shape regression guard ──────────────────────────────────────────
+
+test('executeWorkflow in main.js gates the spawn behind isAllowedAgentCommand', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const text = fs.readFileSync(path.resolve(__dirname, '..', '..', 'src', 'main.js'), 'utf8');
+  const m = text.match(/async function executeWorkflow[\s\S]*?\n\}/);
+  assert.ok(m, 'executeWorkflow not found');
+  const body = m[0];
+
+  // The allowlist call must appear before the spawn call inside the
+  // body so a future edit cannot accidentally re-introduce an
+  // unconstrained spawn.
+  const guardAt = body.indexOf('isAllowedAgentCommand(cmd)');
+  const spawnAt = body.indexOf('spawn(cmd, args');
+  assert.ok(guardAt > -1, 'isAllowedAgentCommand(cmd) check missing in executeWorkflow');
+  assert.ok(spawnAt > -1, 'spawn(cmd, args, ...) not found in executeWorkflow');
+  assert.ok(guardAt < spawnAt, 'isAllowedAgentCommand check must precede the spawn call');
 });


### PR DESCRIPTION
## Summary
- \`src/lib/workflow-graph.js\` gains an \`ALLOWED_AGENT_COMMANDS\` set (claude, copilot, codex, aider, gemini) and an \`isAllowedAgentCommand\` helper. \`sanitizeNode\` constrains a workflow node's \`agentCommand\` to that set; outside values drop to \`null\`. \`executeWorkflow\` applies the same allowlist on the resolved \`cmd\` before spawning, so both step-level and config-level paths agree. Matches the documented feature scope: workflow nodes were always meant to invoke one of the bundled agent CLIs.
- Pins three previously \`@vN\`-only action references in CI workflows to commit SHAs so every action follows the same \`SHA + # vN\` pattern that release.yml already uses for the rest:
  - \`actions/checkout@v4\` (tests.yml)
  - \`actions/setup-node@v4\` (tests.yml)
  - \`actions/attest-build-provenance@v2\` (release.yml)
  - Plus a \`# version\` comment on the existing Trivy SHA in security.yml for consistency.

## Test plan
- [x] 134 unit tests (10 new) pass locally
- [x] Electron smoke green
- [x] ESLint strict scope clean
- [ ] CI green on this PR