### PR TITLE
Release v1.2.3: CodeQL hygiene

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ const { spawn, spawnSync } = require('child_process');
 const pty = require('node-pty');
 
 const { shJoin } = require('./lib/shell-quote');
-const { resolveInside, isInside } = require('./lib/path-confine');
+const { resolveInside } = require('./lib/path-confine');
 const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
 const { buildSpawnSpec } = require('./lib/pty-spawn');
@@ -30,13 +30,9 @@ try {
   if (userPath) process.env.PATH = userPath;
 } catch (_) {}
 const {
-  sanitizeNode,
-  sanitizeEdge,
   sanitizeGraph,
   migrateWorkflow,
   graphToOrderedSteps,
-  wfEdgeMatches,
-  wfPickNextEdge,
   wfIsAiRouted,
   wfRouteInstruction,
   wfResolveNext,

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -30,12 +30,11 @@ function openConfirmDialog({ title = 'Are you sure?', bodyHtml = '', confirmLabe
     if (!modal || !titleEl || !bodyEl || !okBtn || !cancelBtn) {
       // Fallback when the modal elements are not in the DOM (early boot
       // race). window.confirm displays plain text, so extract the text
-      // content of bodyHtml through an inert template element. The
-      // template is parsed but never rendered, no resource loads fire,
-      // and reading textContent collapses the markup to its text nodes.
-      const tpl = document.createElement('template');
-      tpl.innerHTML = bodyHtml;
-      const plain = (tpl.content && tpl.content.textContent) || '';
+      // content of bodyHtml via DOMParser, which parses into a fresh
+      // inert document (no resource loads, no scripts). textContent on
+      // the parsed body collapses the markup to its text nodes.
+      const parsed = new DOMParser().parseFromString(String(bodyHtml || ''), 'text/html');
+      const plain = (parsed.body && parsed.body.textContent) || '';
       resolve(window.confirm(title + '\n\n' + plain));
       return;
     }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -28,7 +28,15 @@ function openConfirmDialog({ title = 'Are you sure?', bodyHtml = '', confirmLabe
     const okBtn = document.getElementById('confirm-ok');
     const cancelBtn = document.getElementById('confirm-cancel');
     if (!modal || !titleEl || !bodyEl || !okBtn || !cancelBtn) {
-      resolve(window.confirm(title + '\n\n' + bodyHtml.replace(/<[^>]*>?/g, '')));
+      // Fallback when the modal elements are not in the DOM (early boot
+      // race). window.confirm displays plain text, so extract the text
+      // content of bodyHtml through an inert template element. The
+      // template is parsed but never rendered, no resource loads fire,
+      // and reading textContent collapses the markup to its text nodes.
+      const tpl = document.createElement('template');
+      tpl.innerHTML = bodyHtml;
+      const plain = (tpl.content && tpl.content.textContent) || '';
+      resolve(window.confirm(title + '\n\n' + plain));
       return;
     }
     titleEl.textContent = title;


### PR DESCRIPTION
## Summary
Carries PR #22 from development to main so the CodeQL alerts on the default branch close.

- \`src/renderer/app.js\`: \`openConfirmDialog\` fallback uses \`DOMParser\` to extract plain text from the body before handing to \`window.confirm\`. Closes alert #13.
- \`src/main.js\`: drops five destructured local names that had no callers (only comment references). Closes alerts #14-#18.

Total diff: 2 files, +9 / -6.

## Test plan
- [x] CI green on PR #22 (the source PR into development)
- [ ] CI green on this release PR
- [ ] After merge: tag v1.2.3, release.yml builds installers + SHA256SUMS + provenance for all 3 platforms
- [ ] After release: CodeQL re-scan on main closes the 6 open alerts