### PR TITLE
Make gitleaks diff range robust to force-push

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,13 +59,24 @@ jobs:
       - name: Run Gitleaks
         run: |
           mkdir -p security-reports
-          # On the first push of a new branch github.event.before is the
-          # all-zeros sha, which makes the diff range invalid. Detect
-          # that and scan the whole repo instead, same as the PR path.
+          # github.event.before is unreliable in two cases:
+          #   - first push of a new branch: it is the all-zeros sha
+          #   - force-push: it points to a now-orphaned sha that may
+          #     not be reachable from the current HEAD
+          # In either case the diff range is invalid and gitleaks
+          # exits non-zero. Fall back to a full-repo scan, which is
+          # the same path the pull_request event takes.
           BEFORE='${{ github.event.before }}'
+          HEAD='${{ github.sha }}'
           ZERO_SHA='0000000000000000000000000000000000000000'
+          USE_RANGE=0
           if [ "${{ github.event_name }}" = "push" ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$ZERO_SHA" ]; then
-            gitleaks detect --config .gitleaks.toml --log-opts="$BEFORE..${{ github.sha }}" --report-format=json --report-path=security-reports/gitleaks-report.json
+            if git merge-base --is-ancestor "$BEFORE" "$HEAD" 2>/dev/null; then
+              USE_RANGE=1
+            fi
+          fi
+          if [ "$USE_RANGE" = "1" ]; then
+            gitleaks detect --config .gitleaks.toml --log-opts="$BEFORE..$HEAD" --report-format=json --report-path=security-reports/gitleaks-report.json
           else
             gitleaks detect --config .gitleaks.toml --report-format=json --report-path=security-reports/gitleaks-report.json
           fi


### PR DESCRIPTION
## Summary
The Gitleaks step in \`security.yml\` previously failed on any push whose \`github.event.before\` SHA was not reachable from the new HEAD (force-push case). The existing guard only handled the all-zeros first-push case.

Replace the guard with an \`is-ancestor\` check: only use the \`BEFORE..HEAD\` diff range when \`before\` is actually reachable from \`HEAD\`. Otherwise fall back to the full-repo scan that the \`pull_request\` path already uses.

## Test plan
- [x] YAML loads
- [ ] CI green on this PR