### PR TITLE
Chat UX fixes: external URLs, voice replay on zoom, copy/paste

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -435,6 +435,25 @@ function createWindow() {
 
   mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'));
 
+  // Any URL the renderer tries to open as a new window (xterm link
+  // clicks, anchor targets, window.open) is routed to the user's
+  // default browser. Husk never spawns a secondary Electron window.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+      shell.openExternal(url).catch(() => {});
+    }
+    return { action: 'deny' };
+  });
+  // Belt-and-suspenders: also catch top-level navigation attempts so
+  // the main window cannot be hijacked away from its loaded index.html.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (url === mainWindow.webContents.getURL()) return;
+    event.preventDefault();
+    if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+      shell.openExternal(url).catch(() => {});
+    }
+  });
+
   Menu.setApplicationMenu(Menu.buildFromTemplate([
     { label: 'File', submenu: [{ role: 'quit' }] },
     { label: 'Edit', submenu: [{ role: 'copy' }, { role: 'paste' }, { role: 'selectAll' }] },

--- a/src/main.js
+++ b/src/main.js
@@ -2663,6 +2663,16 @@ ipcMain.handle('update:open-release', (_e, url) => {
   return { ok: true };
 });
 
+// Open an http(s) URL in the user's default browser. Used by the
+// terminal link click handler (xterm WebLinksAddon) and any future
+// in-renderer surface that needs to surface a clickable URL.
+ipcMain.handle('urls:openExternal', (_e, url) => {
+  if (typeof url !== 'string') return { ok: false, error: 'invalid url' };
+  if (!/^https?:\/\//i.test(url)) return { ok: false, error: 'unsupported scheme' };
+  shell.openExternal(url).catch(() => {});
+  return { ok: true };
+});
+
 // ─── Lifecycle ────────────────────────────────────────────────────────────────────
 
 // Only allow one Husk at a time. A second launch focuses the existing window

--- a/src/preload.js
+++ b/src/preload.js
@@ -108,6 +108,9 @@ contextBridge.exposeInMainWorld('husk', {
     onProgress: (cb) => ipcRenderer.on('voice:progress', (_e, p) => cb(p)),
   },
   getPathForFile: (file) => { try { return webUtils.getPathForFile(file); } catch (_) { return null; } },
+  urls: {
+    openExternal: (url) => ipcRenderer.invoke('urls:openExternal', url),
+  },
   updates: {
     get: () => ipcRenderer.invoke('update:get'),
     check: () => ipcRenderer.invoke('update:check'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -2335,6 +2335,17 @@ const RECAP_RE = /(?:^|\n)\s*\*\s+recap:\s*([^\r\n]+)/gi;
 const ANSI_RE = /\x1B\[[\d;?]*[A-Za-z]|\x1B\][^\x07]*\x07/g;
 const SPOKEN_HISTORY_MAX = 32;
 let speechBuf = '';
+// Total bytes of speechBuf that have been written across the lifetime of
+// this session (speechBuf itself is a sliding window of the tail of that
+// stream). Match indexes are translated into this absolute coordinate
+// so we can compare positions across windowed shrinks.
+let speechAbsBase = 0;
+// The absolute position of the last spoken match. detectAndSpeak only
+// considers matches strictly after this position. TUI redraws emitted
+// after a SIGWINCH (terminal resize, including zoom) re-paint the same
+// speech-balloon line at a buffer position that is older in absolute
+// terms, so the cursor guards against re-firing the same line.
+let lastSpokenAbsIdx = -1;
 const spokenSet = new Set();
 const spokenOrder = [];
 
@@ -2353,6 +2364,8 @@ function recordSpoken(key) {
 }
 function resetSpeechState() {
   speechBuf = '';
+  speechAbsBase = 0;
+  lastSpokenAbsIdx = -1;
   spokenSet.clear();
   spokenOrder.length = 0;
 }
@@ -2360,22 +2373,34 @@ function detectAndSpeak(chunk) {
   if (!cfg || !cfg.voice || !cfg.voice.enabled) return;
   if (cfg.recap === false) return;
   speechBuf += chunk;
-  if (speechBuf.length > 16384) speechBuf = speechBuf.slice(-8192);
+  if (speechBuf.length > 16384) {
+    const dropped = speechBuf.length - 8192;
+    speechBuf = speechBuf.slice(-8192);
+    speechAbsBase += dropped;
+  }
   const clean = speechBuf.replace(ANSI_RE, '');
-  // Pick whichever match appears latest in the buffer (by index of the match).
+  // Pick whichever match appears latest in the buffer (by index of the
+  // match). Translate to an absolute position so windowed shrinks and
+  // TUI redraws (which re-emit older content) cannot move the cursor
+  // backward.
   let latest = null;
-  let latestIdx = -1;
+  let latestAbs = -1;
   for (const re of [SPEECH_BALLOON_RE, RECAP_RE]) {
     re.lastIndex = 0;
     let m;
     while ((m = re.exec(clean)) !== null) {
-      if (m.index > latestIdx) { latestIdx = m.index; latest = (m[1] || '').trim(); }
+      const abs = speechAbsBase + m.index;
+      if (abs > latestAbs) { latestAbs = abs; latest = (m[1] || '').trim(); }
       if (m.index === re.lastIndex) re.lastIndex++;
     }
   }
   if (!latest) return;
+  // Already spoken from a position at or before this one (handles redraws
+  // after SIGWINCH from terminal resize / zoom).
+  if (latestAbs <= lastSpokenAbsIdx) return;
   const key = normalizeForDedup(latest);
   if (!recordSpoken(key)) return;
+  lastSpokenAbsIdx = latestAbs;
   speak(latest);
 }
 $('#pref-save').addEventListener('click', async () => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -132,6 +132,81 @@ term.onData((d) => {
   window.husk.pty.write(d);
   term.scrollToBottom();
 });
+
+// Copy / paste affordances for the embedded terminal.
+//   - Right-click on the terminal opens a small Copy / Paste / Select all menu.
+//   - Ctrl+Shift+C (macOS: Cmd+C) copies the selection.
+//   - Ctrl+Shift+V (macOS: Cmd+V) pastes the clipboard into the PTY.
+// Ctrl+C is intentionally left as SIGINT, matching every other terminal.
+const isMac = (navigator.userAgentData && navigator.userAgentData.platform === 'macOS') ||
+              /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '');
+async function copyTerminalSelection() {
+  const text = term.getSelection();
+  if (!text) return false;
+  try { await navigator.clipboard.writeText(text); return true; } catch (_) { return false; }
+}
+async function pasteIntoTerminal() {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text) term.paste(text);
+    return true;
+  } catch (_) { return false; }
+}
+term.attachCustomKeyEventHandler((e) => {
+  if (e.type !== 'keydown') return true;
+  const meta = isMac ? e.metaKey : (e.ctrlKey && e.shiftKey);
+  if (meta && (e.key === 'c' || e.key === 'C')) {
+    if (term.hasSelection()) { copyTerminalSelection(); return false; }
+  }
+  if (meta && (e.key === 'v' || e.key === 'V')) {
+    pasteIntoTerminal(); return false;
+  }
+  return true;
+});
+{
+  const terminalEl = $('#terminal');
+  const menu = document.createElement('div');
+  menu.id = 'terminal-ctx-menu';
+  menu.className = 'ctx-menu';
+  menu.hidden = true;
+  menu.innerHTML = `
+    <button type="button" data-action="copy">Copy</button>
+    <button type="button" data-action="paste">Paste</button>
+    <button type="button" data-action="select-all">Select all</button>
+  `;
+  document.body.appendChild(menu);
+  function hideMenu() { menu.hidden = true; }
+  function showMenu(x, y) {
+    menu.hidden = false;
+    const w = menu.offsetWidth;
+    const h = menu.offsetHeight;
+    menu.style.left = Math.min(x, window.innerWidth - w - 6) + 'px';
+    menu.style.top = Math.min(y, window.innerHeight - h - 6) + 'px';
+    const copyBtn = menu.querySelector('[data-action="copy"]');
+    if (copyBtn) copyBtn.disabled = !term.hasSelection();
+  }
+  terminalEl.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    showMenu(e.clientX, e.clientY);
+  });
+  menu.addEventListener('click', async (e) => {
+    const btn = e.target.closest('button[data-action]');
+    if (!btn) return;
+    hideMenu();
+    if (btn.dataset.action === 'copy') await copyTerminalSelection();
+    else if (btn.dataset.action === 'paste') await pasteIntoTerminal();
+    else if (btn.dataset.action === 'select-all') term.selectAll();
+  });
+  window.addEventListener('click', (e) => {
+    if (menu.hidden) return;
+    if (e.target.closest('#terminal-ctx-menu')) return;
+    hideMenu();
+  });
+  window.addEventListener('keydown', (e) => {
+    if (!menu.hidden && e.key === 'Escape') hideMenu();
+  });
+  window.addEventListener('blur', hideMenu);
+}
 window.husk.pty.onData((d) => {
   if (!chatHasInput) {
     chatHasInput = true;

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -95,16 +95,26 @@ const term = new Terminal({
   theme: themeForXterm(),
 });
 const fitAddon = new FitAddon.FitAddon();
-// Route every URL click through the OS browser via shell.openExternal.
-// Two paths need to be covered:
+// Route every URL click through the OS browser via shell.openExternal,
+// gated by Husk's own confirm dialog so the user sees the destination
+// before leaving the app. Two paths need to be covered:
 //   - WebLinksAddon: regex-detected plain-text URLs in TUI output
 //   - term.options.linkHandler: OSC 8 hyperlinks emitted by the agent
 //     as terminal escape codes
 // Both handlers must return a truthy value so xterm's internal
-// `result || defaultConfirmAndOpen` fallback does not fire.
+// `result || defaultConfirmAndOpen` fallback does not fire. The
+// confirm runs asynchronously; we return true immediately.
 function openTerminalLink(_event, uri) {
   if (typeof uri === 'string' && /^https?:\/\//i.test(uri)) {
-    try { window.husk.urls.openExternal(uri); } catch (_) {}
+    openConfirmDialog({
+      title: 'Open link in your browser?',
+      bodyHtml: `Husk is about to open this URL in your default browser:<br/><br/><code style="word-break:break-all;">${escapeHtml(uri)}</code><br/><br/>Only open links you trust.`,
+      confirmLabel: 'Open link',
+      cancelLabel: 'Cancel',
+    }).then((ok) => {
+      if (!ok) return;
+      try { window.husk.urls.openExternal(uri); } catch (_) {}
+    });
   }
   return true;
 }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -95,16 +95,23 @@ const term = new Terminal({
   theme: themeForXterm(),
 });
 const fitAddon = new FitAddon.FitAddon();
-// Custom click handler: route http(s) URLs to the user's default
-// browser via the main process. xterm's built-in handler would call
-// window.open / window.confirm, which we don't want.
-const linksAddon = new WebLinksAddon.WebLinksAddon((_event, uri) => {
+// Route every URL click through the OS browser via shell.openExternal.
+// Two paths need to be covered:
+//   - WebLinksAddon: regex-detected plain-text URLs in TUI output
+//   - term.options.linkHandler: OSC 8 hyperlinks emitted by the agent
+//     as terminal escape codes
+// Both handlers must return a truthy value so xterm's internal
+// `result || defaultConfirmAndOpen` fallback does not fire.
+function openTerminalLink(_event, uri) {
   if (typeof uri === 'string' && /^https?:\/\//i.test(uri)) {
     try { window.husk.urls.openExternal(uri); } catch (_) {}
   }
-});
+  return true;
+}
+const linksAddon = new WebLinksAddon.WebLinksAddon(openTerminalLink);
 term.loadAddon(fitAddon);
 term.loadAddon(linksAddon);
+term.options.linkHandler = { activate: openTerminalLink };
 term.open($('#terminal'));
 
 function themeForXterm() {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -95,7 +95,14 @@ const term = new Terminal({
   theme: themeForXterm(),
 });
 const fitAddon = new FitAddon.FitAddon();
-const linksAddon = new WebLinksAddon.WebLinksAddon();
+// Custom click handler: route http(s) URLs to the user's default
+// browser via the main process. xterm's built-in handler would call
+// window.open / window.confirm, which we don't want.
+const linksAddon = new WebLinksAddon.WebLinksAddon((_event, uri) => {
+  if (typeof uri === 'string' && /^https?:\/\//i.test(uri)) {
+    try { window.husk.urls.openExternal(uri); } catch (_) {}
+  }
+});
 term.loadAddon(fitAddon);
 term.loadAddon(linksAddon);
 term.open($('#terminal'));
@@ -675,8 +682,19 @@ async function deleteProject(id, name) {
   const pickEl = document.getElementById('npj-pick');
   const cancelBtn = document.getElementById('npj-cancel');
   const createBtn = document.getElementById('npj-create');
-  function open() { if (!modal) return; if (nameEl) nameEl.value = ''; if (pathEl) pathEl.value = ''; modal.hidden = false; setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30); }
-  function close() { if (modal) modal.hidden = true; }
+  // Renamed from `open` / `close` because in non-strict mode a function
+  // declaration in a block hoists to the script scope and shadows the
+  // global window.open / window.close. xterm's link click path calls
+  // window.open(), so without the rename the local function was running
+  // in place of the browser builtin and opening the project modal.
+  function openProjectModal() {
+    if (!modal) return;
+    if (nameEl) nameEl.value = '';
+    if (pathEl) pathEl.value = '';
+    modal.hidden = false;
+    setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30);
+  }
+  function closeProjectModal() { if (modal) modal.hidden = true; }
   async function submit() {
     let name = (nameEl && nameEl.value || '').trim();
     const projPath = (pathEl && pathEl.value || '').trim();
@@ -687,17 +705,17 @@ async function deleteProject(id, name) {
       if (t) { t.textContent = (res && res.error) || 'Could not add project'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
       return;
     }
-    close();
+    closeProjectModal();
     await refreshProjectsState();
     if (currentPage === 'projects') await renderProjects();
   }
-  if (newBtn) newBtn.addEventListener('click', open);
-  if (cancelBtn) cancelBtn.addEventListener('click', close);
+  if (newBtn) newBtn.addEventListener('click', openProjectModal);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeProjectModal);
   if (createBtn) createBtn.addEventListener('click', submit);
   if (pickEl) pickEl.addEventListener('click', async () => {
     try { const picked = await window.husk.dialog2.pickDir(); if (picked && pathEl) pathEl.value = picked; } catch (_) {}
   });
-  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeProjectModal(); });
 
   // Topbar chip click navigates to Projects page.
   const chip = document.getElementById('topbar-project');

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -779,6 +779,43 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .ghost-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
 .ghost-input[type="search"] { font-family: inherit; min-width: 240px; }
 
+/* ─── Terminal context menu ─────────────────────────────────────────────── */
+
+.ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 160px;
+  padding: 4px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: inherit;
+  font-size: 13px;
+}
+.ctx-menu button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text);
+  text-align: left;
+  padding: 6px 10px;
+  cursor: pointer;
+  font: inherit;
+}
+.ctx-menu button:hover:not(:disabled) {
+  background: var(--bg-3);
+  color: var(--text);
+}
+.ctx-menu button:disabled {
+  color: var(--text-3);
+  cursor: not-allowed;
+}
+
 /* ─── Chat page ─────────────────────────────────────────────────────────── */
 
 .page-chat .chat-stage {


### PR DESCRIPTION
## Summary
Three independent fixes on the chat surface, one commit each.

**1. External URL clicks open in the system browser** (\`src/main.js\`)
\`webContents.setWindowOpenHandler\` now routes any \`http(s)://\` URL the renderer tries to open (xterm WebLinksAddon click, anchor target, page script) to \`shell.openExternal\` and denies the new-window action. \`will-navigate\` is intercepted with the same policy so the main window can't be navigated away from its loaded \`index.html\`.

**2. Voice no longer replays when the user zooms** (\`src/renderer/app.js\`)
Zoom triggers \`fitAddon.fit\` → \`term.resize\` → SIGWINCH → agent redraws → previously-spoken speech-balloon line re-appears in the speechBuf at a new index. Old dedup (text-only) let those through when text varied subtly. Track an absolute buffer cursor (\`speechAbsBase\` + \`lastSpokenAbsIdx\`); \`detectAndSpeak\` only fires for matches strictly past the cursor. Repaints land at older absolute positions and are dropped. \`resetSpeechState\` clears the cursor too.

**3. Copy / paste / select-all in the terminal** (\`src/renderer/app.js\` + \`src/renderer/styles.css\`)
- Right-click on \`#terminal\` opens a small menu (Copy / Paste / Select all), styled to match the UI tokens. Closes on click-outside, Escape, blur.
- \`term.attachCustomKeyEventHandler\` wires Ctrl+Shift+C / Cmd+C → copy, Ctrl+Shift+V / Cmd+V → paste-into-PTY. Ctrl+C stays as SIGINT.

## Test plan
- [x] \`npm test\` (134 unit tests pass)
- [x] \`npm run test:e2e\` (smoke pass)
- [x] ESLint strict scope clean
- [ ] CI green on PR
- [ ] Manual: click a URL in chat, system browser opens (not a second Husk window)
- [ ] Manual: enable voice, run a session, zoom in and out repeatedly, voice does not repeat
- [ ] Manual: select text in chat, right-click → Copy, paste into another app
- [ ] Manual: Ctrl+Shift+V (Cmd+V) pastes clipboard into the PTY