### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
         #   gh attestation verify <file> --repo DorShaer/Husk
         # This also protects SHA256SUMS itself, so an attacker who
         # swaps a release asset cannot silently rewrite the sums file.
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: 'release/*'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -302,7 +302,7 @@ jobs:
 
       - name: Trivy filesystem scan
         # Pinned by SHA (do not move to @master). Bumps go through dependabot.
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -315,7 +315,7 @@ jobs:
 
       - name: Trivy JSON (always)
         if: always()
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,13 +59,24 @@ jobs:
       - name: Run Gitleaks
         run: |
           mkdir -p security-reports
-          # On the first push of a new branch github.event.before is the
-          # all-zeros sha, which makes the diff range invalid. Detect
-          # that and scan the whole repo instead, same as the PR path.
+          # github.event.before is unreliable in two cases:
+          #   - first push of a new branch: it is the all-zeros sha
+          #   - force-push: it points to a now-orphaned sha that may
+          #     not be reachable from the current HEAD
+          # In either case the diff range is invalid and gitleaks
+          # exits non-zero. Fall back to a full-repo scan, which is
+          # the same path the pull_request event takes.
           BEFORE='${{ github.event.before }}'
+          HEAD='${{ github.sha }}'
           ZERO_SHA='0000000000000000000000000000000000000000'
+          USE_RANGE=0
           if [ "${{ github.event_name }}" = "push" ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$ZERO_SHA" ]; then
-            gitleaks detect --config .gitleaks.toml --log-opts="$BEFORE..${{ github.sha }}" --report-format=json --report-path=security-reports/gitleaks-report.json
+            if git merge-base --is-ancestor "$BEFORE" "$HEAD" 2>/dev/null; then
+              USE_RANGE=1
+            fi
+          fi
+          if [ "$USE_RANGE" = "1" ]; then
+            gitleaks detect --config .gitleaks.toml --log-opts="$BEFORE..$HEAD" --report-format=json --report-path=security-reports/gitleaks-report.json
           else
             gitleaks detect --config .gitleaks.toml --report-format=json --report-path=security-reports/gitleaks-report.json
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -29,8 +29,8 @@ jobs:
     timeout-minutes: 10
     needs: unit
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -4,19 +4,40 @@
 // linear ordering, and edge resolution. No Electron, no fs, no spawn. The
 // IPC handlers in main.js wrap these for the renderer.
 
-// agentCommand is the binary spawned for a step. Today it is the user's
-// own config (typed in the workflow editor) so the trust gate is the
-// same as config.agentCommand: only the renderer that already controls
-// the workflows JSON can write it. Before this field accepts a workflow
-// imported from any non-local source (template marketplace, shared URL,
-// pasted JSON drop), add an allowlist check here against a known set of
-// agent binaries plus a "Custom" opt-in confirmation.
+// Workflow nodes are intended to invoke one of the supported agent CLIs.
+// The allowlist below pins the agentCommand basename to that set. Update
+// this list when a new agent CLI is added to KNOWN_AGENTS in main.js.
+const ALLOWED_AGENT_COMMANDS = new Set([
+  'claude',
+  'copilot',
+  'codex',
+  'aider',
+  'gemini',
+]);
+
+// isAllowedAgentCommand(value) returns true when the first whitespace-
+// separated token's basename (case-insensitive) is in the allowlist.
+function isAllowedAgentCommand(value) {
+  if (typeof value !== 'string') return false;
+  const first = value.trim().split(/\s+/)[0];
+  if (!first) return false;
+  const base = first.split(/[\\/]/).pop().toLowerCase();
+  return ALLOWED_AGENT_COMMANDS.has(base);
+}
+
+// agentCommand is the binary executeWorkflow spawns for a step. Values
+// whose first token's basename is not in ALLOWED_AGENT_COMMANDS are
+// dropped to null here. executeWorkflow then falls back to the user's
+// config.agentCommand, which is independently checked against the same
+// allowlist at run time.
 function sanitizeNode(n) {
   n = n || {};
+  const raw = String(n.agentCommand || '').slice(0, 128);
+  const agentCommand = (raw && isAllowedAgentCommand(raw)) ? raw : null;
   return {
     id: n.id || `node-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
     name: String(n.name || 'Step').slice(0, 64),
-    agentCommand: String(n.agentCommand || '').slice(0, 128) || null,
+    agentCommand,
     prompt: String(n.prompt || '').slice(0, 8192),
     passContext: ['full', 'last50', 'none'].includes(n.passContext) ? n.passContext : 'full',
     x: Number.isFinite(n.x) ? n.x : 0,
@@ -155,6 +176,8 @@ function wfResolveNext(graph, node, output, byId) {
 }
 
 module.exports = {
+  ALLOWED_AGENT_COMMANDS,
+  isAllowedAgentCommand,
   sanitizeNode,
   sanitizeEdge,
   sanitizeGraph,

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ const {
   wfIsAiRouted,
   wfRouteInstruction,
   wfResolveNext,
+  isAllowedAgentCommand,
 } = wfLib;
 
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
@@ -1370,6 +1371,21 @@ async function executeWorkflow(event, workflow, run) {
     wfEmit(event, 'wf:node:start', { runId: run.id, nodeId: node.id });
 
     const cmd = (step.agentCommand || config.agentCommand || 'claude').trim().split(/\s+/)[0];
+
+    // The resolved cmd may come from step.agentCommand (already
+    // checked by sanitizeNode) or from config.agentCommand. Apply the
+    // same allowlist here so both paths agree.
+    if (!isAllowedAgentCommand(cmd)) {
+      wfEmit(event, 'wf:node:activity', {
+        runId: run.id,
+        nodeId: node.id,
+        kind: 'error',
+        text: `Step "${node.name}" needs one of ${Array.from(wfLib.ALLOWED_AGENT_COMMANDS).join(', ')}; got "${cmd}".`,
+      });
+      wfEmit(event, 'wf:node:done', { runId: run.id, nodeId: node.id, ok: false });
+      wfEmit(event, 'wf:run:done', { runId: run.id, ok: false, error: 'unsupported_agent_command' });
+      return;
+    }
 
     let prompt = step.prompt;
     if (previousOutput) {

--- a/src/main.js
+++ b/src/main.js
@@ -435,6 +435,25 @@ function createWindow() {
 
   mainWindow.loadFile(path.join(__dirname, 'renderer', 'index.html'));
 
+  // Any URL the renderer tries to open as a new window (xterm link
+  // clicks, anchor targets, window.open) is routed to the user's
+  // default browser. Husk never spawns a secondary Electron window.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+      shell.openExternal(url).catch(() => {});
+    }
+    return { action: 'deny' };
+  });
+  // Belt-and-suspenders: also catch top-level navigation attempts so
+  // the main window cannot be hijacked away from its loaded index.html.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (url === mainWindow.webContents.getURL()) return;
+    event.preventDefault();
+    if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+      shell.openExternal(url).catch(() => {});
+    }
+  });
+
   Menu.setApplicationMenu(Menu.buildFromTemplate([
     { label: 'File', submenu: [{ role: 'quit' }] },
     { label: 'Edit', submenu: [{ role: 'copy' }, { role: 'paste' }, { role: 'selectAll' }] },

--- a/src/main.js
+++ b/src/main.js
@@ -2663,6 +2663,16 @@ ipcMain.handle('update:open-release', (_e, url) => {
   return { ok: true };
 });
 
+// Open an http(s) URL in the user's default browser. Used by the
+// terminal link click handler (xterm WebLinksAddon) and any future
+// in-renderer surface that needs to surface a clickable URL.
+ipcMain.handle('urls:openExternal', (_e, url) => {
+  if (typeof url !== 'string') return { ok: false, error: 'invalid url' };
+  if (!/^https?:\/\//i.test(url)) return { ok: false, error: 'unsupported scheme' };
+  shell.openExternal(url).catch(() => {});
+  return { ok: true };
+});
+
 // ─── Lifecycle ────────────────────────────────────────────────────────────────────
 
 // Only allow one Husk at a time. A second launch focuses the existing window

--- a/src/preload.js
+++ b/src/preload.js
@@ -108,6 +108,9 @@ contextBridge.exposeInMainWorld('husk', {
     onProgress: (cb) => ipcRenderer.on('voice:progress', (_e, p) => cb(p)),
   },
   getPathForFile: (file) => { try { return webUtils.getPathForFile(file); } catch (_) { return null; } },
+  urls: {
+    openExternal: (url) => ipcRenderer.invoke('urls:openExternal', url),
+  },
   updates: {
     get: () => ipcRenderer.invoke('update:get'),
     check: () => ipcRenderer.invoke('update:check'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -2335,6 +2335,17 @@ const RECAP_RE = /(?:^|\n)\s*\*\s+recap:\s*([^\r\n]+)/gi;
 const ANSI_RE = /\x1B\[[\d;?]*[A-Za-z]|\x1B\][^\x07]*\x07/g;
 const SPOKEN_HISTORY_MAX = 32;
 let speechBuf = '';
+// Total bytes of speechBuf that have been written across the lifetime of
+// this session (speechBuf itself is a sliding window of the tail of that
+// stream). Match indexes are translated into this absolute coordinate
+// so we can compare positions across windowed shrinks.
+let speechAbsBase = 0;
+// The absolute position of the last spoken match. detectAndSpeak only
+// considers matches strictly after this position. TUI redraws emitted
+// after a SIGWINCH (terminal resize, including zoom) re-paint the same
+// speech-balloon line at a buffer position that is older in absolute
+// terms, so the cursor guards against re-firing the same line.
+let lastSpokenAbsIdx = -1;
 const spokenSet = new Set();
 const spokenOrder = [];
 
@@ -2353,6 +2364,8 @@ function recordSpoken(key) {
 }
 function resetSpeechState() {
   speechBuf = '';
+  speechAbsBase = 0;
+  lastSpokenAbsIdx = -1;
   spokenSet.clear();
   spokenOrder.length = 0;
 }
@@ -2360,22 +2373,34 @@ function detectAndSpeak(chunk) {
   if (!cfg || !cfg.voice || !cfg.voice.enabled) return;
   if (cfg.recap === false) return;
   speechBuf += chunk;
-  if (speechBuf.length > 16384) speechBuf = speechBuf.slice(-8192);
+  if (speechBuf.length > 16384) {
+    const dropped = speechBuf.length - 8192;
+    speechBuf = speechBuf.slice(-8192);
+    speechAbsBase += dropped;
+  }
   const clean = speechBuf.replace(ANSI_RE, '');
-  // Pick whichever match appears latest in the buffer (by index of the match).
+  // Pick whichever match appears latest in the buffer (by index of the
+  // match). Translate to an absolute position so windowed shrinks and
+  // TUI redraws (which re-emit older content) cannot move the cursor
+  // backward.
   let latest = null;
-  let latestIdx = -1;
+  let latestAbs = -1;
   for (const re of [SPEECH_BALLOON_RE, RECAP_RE]) {
     re.lastIndex = 0;
     let m;
     while ((m = re.exec(clean)) !== null) {
-      if (m.index > latestIdx) { latestIdx = m.index; latest = (m[1] || '').trim(); }
+      const abs = speechAbsBase + m.index;
+      if (abs > latestAbs) { latestAbs = abs; latest = (m[1] || '').trim(); }
       if (m.index === re.lastIndex) re.lastIndex++;
     }
   }
   if (!latest) return;
+  // Already spoken from a position at or before this one (handles redraws
+  // after SIGWINCH from terminal resize / zoom).
+  if (latestAbs <= lastSpokenAbsIdx) return;
   const key = normalizeForDedup(latest);
   if (!recordSpoken(key)) return;
+  lastSpokenAbsIdx = latestAbs;
   speak(latest);
 }
 $('#pref-save').addEventListener('click', async () => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -132,6 +132,81 @@ term.onData((d) => {
   window.husk.pty.write(d);
   term.scrollToBottom();
 });
+
+// Copy / paste affordances for the embedded terminal.
+//   - Right-click on the terminal opens a small Copy / Paste / Select all menu.
+//   - Ctrl+Shift+C (macOS: Cmd+C) copies the selection.
+//   - Ctrl+Shift+V (macOS: Cmd+V) pastes the clipboard into the PTY.
+// Ctrl+C is intentionally left as SIGINT, matching every other terminal.
+const isMac = (navigator.userAgentData && navigator.userAgentData.platform === 'macOS') ||
+              /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent || '');
+async function copyTerminalSelection() {
+  const text = term.getSelection();
+  if (!text) return false;
+  try { await navigator.clipboard.writeText(text); return true; } catch (_) { return false; }
+}
+async function pasteIntoTerminal() {
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text) term.paste(text);
+    return true;
+  } catch (_) { return false; }
+}
+term.attachCustomKeyEventHandler((e) => {
+  if (e.type !== 'keydown') return true;
+  const meta = isMac ? e.metaKey : (e.ctrlKey && e.shiftKey);
+  if (meta && (e.key === 'c' || e.key === 'C')) {
+    if (term.hasSelection()) { copyTerminalSelection(); return false; }
+  }
+  if (meta && (e.key === 'v' || e.key === 'V')) {
+    pasteIntoTerminal(); return false;
+  }
+  return true;
+});
+{
+  const terminalEl = $('#terminal');
+  const menu = document.createElement('div');
+  menu.id = 'terminal-ctx-menu';
+  menu.className = 'ctx-menu';
+  menu.hidden = true;
+  menu.innerHTML = `
+    <button type="button" data-action="copy">Copy</button>
+    <button type="button" data-action="paste">Paste</button>
+    <button type="button" data-action="select-all">Select all</button>
+  `;
+  document.body.appendChild(menu);
+  function hideMenu() { menu.hidden = true; }
+  function showMenu(x, y) {
+    menu.hidden = false;
+    const w = menu.offsetWidth;
+    const h = menu.offsetHeight;
+    menu.style.left = Math.min(x, window.innerWidth - w - 6) + 'px';
+    menu.style.top = Math.min(y, window.innerHeight - h - 6) + 'px';
+    const copyBtn = menu.querySelector('[data-action="copy"]');
+    if (copyBtn) copyBtn.disabled = !term.hasSelection();
+  }
+  terminalEl.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    showMenu(e.clientX, e.clientY);
+  });
+  menu.addEventListener('click', async (e) => {
+    const btn = e.target.closest('button[data-action]');
+    if (!btn) return;
+    hideMenu();
+    if (btn.dataset.action === 'copy') await copyTerminalSelection();
+    else if (btn.dataset.action === 'paste') await pasteIntoTerminal();
+    else if (btn.dataset.action === 'select-all') term.selectAll();
+  });
+  window.addEventListener('click', (e) => {
+    if (menu.hidden) return;
+    if (e.target.closest('#terminal-ctx-menu')) return;
+    hideMenu();
+  });
+  window.addEventListener('keydown', (e) => {
+    if (!menu.hidden && e.key === 'Escape') hideMenu();
+  });
+  window.addEventListener('blur', hideMenu);
+}
 window.husk.pty.onData((d) => {
   if (!chatHasInput) {
     chatHasInput = true;

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -95,16 +95,26 @@ const term = new Terminal({
   theme: themeForXterm(),
 });
 const fitAddon = new FitAddon.FitAddon();
-// Route every URL click through the OS browser via shell.openExternal.
-// Two paths need to be covered:
+// Route every URL click through the OS browser via shell.openExternal,
+// gated by Husk's own confirm dialog so the user sees the destination
+// before leaving the app. Two paths need to be covered:
 //   - WebLinksAddon: regex-detected plain-text URLs in TUI output
 //   - term.options.linkHandler: OSC 8 hyperlinks emitted by the agent
 //     as terminal escape codes
 // Both handlers must return a truthy value so xterm's internal
-// `result || defaultConfirmAndOpen` fallback does not fire.
+// `result || defaultConfirmAndOpen` fallback does not fire. The
+// confirm runs asynchronously; we return true immediately.
 function openTerminalLink(_event, uri) {
   if (typeof uri === 'string' && /^https?:\/\//i.test(uri)) {
-    try { window.husk.urls.openExternal(uri); } catch (_) {}
+    openConfirmDialog({
+      title: 'Open link in your browser?',
+      bodyHtml: `Husk is about to open this URL in your default browser:<br/><br/><code style="word-break:break-all;">${escapeHtml(uri)}</code><br/><br/>Only open links you trust.`,
+      confirmLabel: 'Open link',
+      cancelLabel: 'Cancel',
+    }).then((ok) => {
+      if (!ok) return;
+      try { window.husk.urls.openExternal(uri); } catch (_) {}
+    });
   }
   return true;
 }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -95,16 +95,23 @@ const term = new Terminal({
   theme: themeForXterm(),
 });
 const fitAddon = new FitAddon.FitAddon();
-// Custom click handler: route http(s) URLs to the user's default
-// browser via the main process. xterm's built-in handler would call
-// window.open / window.confirm, which we don't want.
-const linksAddon = new WebLinksAddon.WebLinksAddon((_event, uri) => {
+// Route every URL click through the OS browser via shell.openExternal.
+// Two paths need to be covered:
+//   - WebLinksAddon: regex-detected plain-text URLs in TUI output
+//   - term.options.linkHandler: OSC 8 hyperlinks emitted by the agent
+//     as terminal escape codes
+// Both handlers must return a truthy value so xterm's internal
+// `result || defaultConfirmAndOpen` fallback does not fire.
+function openTerminalLink(_event, uri) {
   if (typeof uri === 'string' && /^https?:\/\//i.test(uri)) {
     try { window.husk.urls.openExternal(uri); } catch (_) {}
   }
-});
+  return true;
+}
+const linksAddon = new WebLinksAddon.WebLinksAddon(openTerminalLink);
 term.loadAddon(fitAddon);
 term.loadAddon(linksAddon);
+term.options.linkHandler = { activate: openTerminalLink };
 term.open($('#terminal'));
 
 function themeForXterm() {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -95,7 +95,14 @@ const term = new Terminal({
   theme: themeForXterm(),
 });
 const fitAddon = new FitAddon.FitAddon();
-const linksAddon = new WebLinksAddon.WebLinksAddon();
+// Custom click handler: route http(s) URLs to the user's default
+// browser via the main process. xterm's built-in handler would call
+// window.open / window.confirm, which we don't want.
+const linksAddon = new WebLinksAddon.WebLinksAddon((_event, uri) => {
+  if (typeof uri === 'string' && /^https?:\/\//i.test(uri)) {
+    try { window.husk.urls.openExternal(uri); } catch (_) {}
+  }
+});
 term.loadAddon(fitAddon);
 term.loadAddon(linksAddon);
 term.open($('#terminal'));
@@ -675,8 +682,19 @@ async function deleteProject(id, name) {
   const pickEl = document.getElementById('npj-pick');
   const cancelBtn = document.getElementById('npj-cancel');
   const createBtn = document.getElementById('npj-create');
-  function open() { if (!modal) return; if (nameEl) nameEl.value = ''; if (pathEl) pathEl.value = ''; modal.hidden = false; setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30); }
-  function close() { if (modal) modal.hidden = true; }
+  // Renamed from `open` / `close` because in non-strict mode a function
+  // declaration in a block hoists to the script scope and shadows the
+  // global window.open / window.close. xterm's link click path calls
+  // window.open(), so without the rename the local function was running
+  // in place of the browser builtin and opening the project modal.
+  function openProjectModal() {
+    if (!modal) return;
+    if (nameEl) nameEl.value = '';
+    if (pathEl) pathEl.value = '';
+    modal.hidden = false;
+    setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30);
+  }
+  function closeProjectModal() { if (modal) modal.hidden = true; }
   async function submit() {
     let name = (nameEl && nameEl.value || '').trim();
     const projPath = (pathEl && pathEl.value || '').trim();
@@ -687,17 +705,17 @@ async function deleteProject(id, name) {
       if (t) { t.textContent = (res && res.error) || 'Could not add project'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
       return;
     }
-    close();
+    closeProjectModal();
     await refreshProjectsState();
     if (currentPage === 'projects') await renderProjects();
   }
-  if (newBtn) newBtn.addEventListener('click', open);
-  if (cancelBtn) cancelBtn.addEventListener('click', close);
+  if (newBtn) newBtn.addEventListener('click', openProjectModal);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeProjectModal);
   if (createBtn) createBtn.addEventListener('click', submit);
   if (pickEl) pickEl.addEventListener('click', async () => {
     try { const picked = await window.husk.dialog2.pickDir(); if (picked && pathEl) pathEl.value = picked; } catch (_) {}
   });
-  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeProjectModal(); });
 
   // Topbar chip click navigates to Projects page.
   const chip = document.getElementById('topbar-project');

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -779,6 +779,43 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .ghost-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
 .ghost-input[type="search"] { font-family: inherit; min-width: 240px; }
 
+/* ─── Terminal context menu ─────────────────────────────────────────────── */
+
+.ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 160px;
+  padding: 4px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: inherit;
+  font-size: 13px;
+}
+.ctx-menu button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text);
+  text-align: left;
+  padding: 6px 10px;
+  cursor: pointer;
+  font: inherit;
+}
+.ctx-menu button:hover:not(:disabled) {
+  background: var(--bg-3);
+  color: var(--text);
+}
+.ctx-menu button:disabled {
+  color: var(--text-3);
+  cursor: not-allowed;
+}
+
 /* ─── Chat page ─────────────────────────────────────────────────────────── */
 
 .page-chat .chat-stage {

--- a/test/unit/workflow-graph.test.js
+++ b/test/unit/workflow-graph.test.js
@@ -18,13 +18,71 @@ test('sanitizeNode: clamps prompt to 8192 chars', () => {
 });
 
 test('sanitizeNode: clamps agentCommand to 128 chars', () => {
-  const n = wf.sanitizeNode({ agentCommand: 'c'.repeat(500) });
+  // First token must be an allowed agent name for sanitizeNode to keep
+  // the value at all (see allowlist tests below). Use claude with a
+  // long flag tail so the result is both clamped and preserved.
+  const n = wf.sanitizeNode({ agentCommand: 'claude ' + 'x'.repeat(500) });
   assert.equal(n.agentCommand.length, 128);
+  assert.equal(n.agentCommand.startsWith('claude '), true);
 });
 
 test('sanitizeNode: empty agentCommand becomes null', () => {
   const n = wf.sanitizeNode({ agentCommand: '' });
   assert.equal(n.agentCommand, null);
+});
+
+test('sanitizeNode: agentCommand outside the allowlist becomes null', () => {
+  for (const bad of ['sh', 'bash', 'dash', 'zsh', 'fish', 'python', 'python3', 'perl', 'ruby', 'node', '/bin/sh', '/usr/local/bin/bash', 'sh script.sh', '../sh']) {
+    const n = wf.sanitizeNode({ agentCommand: bad });
+    assert.equal(n.agentCommand, null, `expected null for input ${JSON.stringify(bad)}`);
+  }
+});
+
+test('sanitizeNode: known agent commands are preserved', () => {
+  for (const good of ['claude', 'copilot', 'codex', 'aider', 'gemini']) {
+    const n = wf.sanitizeNode({ agentCommand: good });
+    assert.equal(n.agentCommand, good);
+  }
+});
+
+test('sanitizeNode: known agent with flags is preserved', () => {
+  const n = wf.sanitizeNode({ agentCommand: 'claude --print --verbose' });
+  assert.equal(n.agentCommand, 'claude --print --verbose');
+});
+
+test('sanitizeNode: known agent at an absolute path is preserved', () => {
+  const n = wf.sanitizeNode({ agentCommand: '/opt/homebrew/bin/claude' });
+  assert.equal(n.agentCommand, '/opt/homebrew/bin/claude');
+});
+
+test('sanitizeNode: allowlist comparison is case-insensitive on basename', () => {
+  const n = wf.sanitizeNode({ agentCommand: 'CLAUDE' });
+  assert.equal(n.agentCommand, 'CLAUDE');
+});
+
+// ─── isAllowedAgentCommand direct ───────────────────────────────────────────
+
+test('isAllowedAgentCommand: returns true for every entry in the allowlist', () => {
+  for (const name of wf.ALLOWED_AGENT_COMMANDS) {
+    assert.equal(wf.isAllowedAgentCommand(name), true);
+  }
+});
+
+test('isAllowedAgentCommand: returns false for shells and interpreters', () => {
+  for (const bad of ['sh', 'bash', 'zsh', 'fish', 'python', 'node', 'ruby', 'perl', '']) {
+    assert.equal(wf.isAllowedAgentCommand(bad), false, bad);
+  }
+});
+
+test('isAllowedAgentCommand: returns false for non-string input', () => {
+  assert.equal(wf.isAllowedAgentCommand(null), false);
+  assert.equal(wf.isAllowedAgentCommand(undefined), false);
+  assert.equal(wf.isAllowedAgentCommand(42), false);
+});
+
+test('isAllowedAgentCommand: ignores arguments after the first token', () => {
+  assert.equal(wf.isAllowedAgentCommand('claude --any --thing'), true);
+  assert.equal(wf.isAllowedAgentCommand('sh --pretending-to-be-claude'), false);
 });
 
 test('sanitizeNode: invalid passContext falls back to full', () => {
@@ -274,4 +332,24 @@ test('wfRouteInstruction: includes all target names and END option', () => {
   const txt = wf.wfRouteInstruction(['A', 'B', 'C']);
   assert.match(txt, /A \| B \| C/);
   assert.match(txt, /ROUTE: END/);
+});
+
+// ─── Source-shape regression guard ──────────────────────────────────────────
+
+test('executeWorkflow in main.js gates the spawn behind isAllowedAgentCommand', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const text = fs.readFileSync(path.resolve(__dirname, '..', '..', 'src', 'main.js'), 'utf8');
+  const m = text.match(/async function executeWorkflow[\s\S]*?\n\}/);
+  assert.ok(m, 'executeWorkflow not found');
+  const body = m[0];
+
+  // The allowlist call must appear before the spawn call inside the
+  // body so a future edit cannot accidentally re-introduce an
+  // unconstrained spawn.
+  const guardAt = body.indexOf('isAllowedAgentCommand(cmd)');
+  const spawnAt = body.indexOf('spawn(cmd, args');
+  assert.ok(guardAt > -1, 'isAllowedAgentCommand(cmd) check missing in executeWorkflow');
+  assert.ok(spawnAt > -1, 'spawn(cmd, args, ...) not found in executeWorkflow');
+  assert.ok(guardAt < spawnAt, 'isAllowedAgentCommand check must precede the spawn call');
 });


### PR DESCRIPTION
## Summary
Major release. Bundles everything merged to development since v1.2.3.

### What is new for users
- **Chat: copy, paste, select-all in the terminal.** Right-click the terminal for a small menu, or use Ctrl+Shift+C / Ctrl+Shift+V (Cmd+C / Cmd+V on macOS). Ctrl+C stays as SIGINT.
- **Chat: external URLs open in your default browser.** Click any link in the agent output, confirm in Husk's own dialog, the browser opens. Plain-text URLs and OSC 8 hyperlinks are both covered.
- **Voice no longer replays on zoom.** The dedup tracks an absolute buffer cursor, so terminal redraws after SIGWINCH do not re-fire the spoken line.

### What is new under the hood
- **Workflows: \`agentCommand\` on workflow nodes is constrained to the supported agent CLI set** (\`claude\`, \`copilot\`, \`codex\`, \`aider\`, \`gemini\`). Anything else is dropped to null at sanitization time and refused at run time.
- **External URLs are routed through main** via a dedicated \`urls:openExternal\` IPC, gated by Husk's own confirm dialog.
- **CI hygiene:** every GitHub Actions reference is now pinned to a commit SHA with a version comment.
- **CI: Gitleaks survives force-push.** The diff range falls back to a full scan when \`github.event.before\` is unreachable.

### Carried forward from the v1.2.x series
SHA256SUMS + Sigstore build-provenance attestations on every release artifact. Installer scripts verify SHA-256 of fetched dependencies before running. macOS / Linux GUI launches inherit the user's shell \`PATH\` so agent CLIs are found. CodeQL alerts on \`main\` are 0.

### Known limitations
macOS code signing is still pending an Apple Developer ID. Bypass instructions are in the README.

## Test plan
- [x] PRs #21 and #25 CI green on their source branches and merged
- [ ] CI green on this release PR
- [ ] After merge: tag v2.0.0, release.yml builds installers + SHA256SUMS + provenance for all 3 platforms