### PR TITLE
Lock DevTools in packaged builds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -431,6 +431,11 @@ function createWindow() {
       nodeIntegration: false,
       sandbox: false,
       zoomFactor: 1.0,
+      // DevTools available when running from source (./run.sh, npm start)
+      // so the maintainer can debug, locked in shipped builds so end users
+      // cannot open the inspector via F12, Ctrl+Shift+I, the View menu,
+      // or programmatic openDevTools.
+      devTools: !app.isPackaged,
     },
   });
 
@@ -455,18 +460,18 @@ function createWindow() {
     }
   });
 
+  // The View submenu drops the DevTools toggle in shipped builds so the
+  // menu does not advertise an entry that webPreferences.devTools:false
+  // would silently no-op.
+  const viewSubmenu = [
+    { role: 'reload' },
+    ...(app.isPackaged ? [] : [{ role: 'toggleDevTools', accelerator: 'F12' }, { type: 'separator' }]),
+    { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' },
+  ];
   Menu.setApplicationMenu(Menu.buildFromTemplate([
     { label: 'File', submenu: [{ role: 'quit' }] },
     { label: 'Edit', submenu: [{ role: 'copy' }, { role: 'paste' }, { role: 'selectAll' }] },
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' },
-        { role: 'toggleDevTools', accelerator: 'F12' },
-        { type: 'separator' },
-        { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' },
-      ],
-    },
+    { label: 'View', submenu: viewSubmenu },
     { label: 'Window', submenu: [{ role: 'minimize' }, { role: 'close' }] },
   ]));
 


### PR DESCRIPTION
## Summary
Sets \`webPreferences.devTools\` to \`!app.isPackaged\` in the main \`BrowserWindow\`. In shipped \`.deb\` / \`.dmg\` / \`.exe\` / \`.AppImage\` binaries DevTools cannot be opened via F12, Ctrl+Shift+I (Cmd+Opt+I), the View menu, or programmatic \`webContents.openDevTools\`. Source-tree runs (\`./run.sh\`, \`npm start\`) keep DevTools for maintainer debugging.

Also drops the **View > Toggle DevTools** item from the application menu in packaged builds so the menu does not surface an entry that the flag silences.

## Test plan
- [x] \`npm test\` (134 unit tests pass)
- [x] \`npm run test:e2e\` (smoke pass)
- [x] \`node --check src/main.js\`
- [ ] CI green on PR
- [ ] Manual after merge + v2.0.1 release: install the artifact, F12 / Ctrl+Shift+I do nothing, View menu has no Toggle DevTools entry