### PR TITLE
Release v2.0.1: lock DevTools in packaged builds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -431,6 +431,11 @@ function createWindow() {
       nodeIntegration: false,
       sandbox: false,
       zoomFactor: 1.0,
+      // DevTools available when running from source (./run.sh, npm start)
+      // so the maintainer can debug, locked in shipped builds so end users
+      // cannot open the inspector via F12, Ctrl+Shift+I, the View menu,
+      // or programmatic openDevTools.
+      devTools: !app.isPackaged,
     },
   });
 
@@ -455,18 +460,18 @@ function createWindow() {
     }
   });
 
+  // The View submenu drops the DevTools toggle in shipped builds so the
+  // menu does not advertise an entry that webPreferences.devTools:false
+  // would silently no-op.
+  const viewSubmenu = [
+    { role: 'reload' },
+    ...(app.isPackaged ? [] : [{ role: 'toggleDevTools', accelerator: 'F12' }, { type: 'separator' }]),
+    { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' },
+  ];
   Menu.setApplicationMenu(Menu.buildFromTemplate([
     { label: 'File', submenu: [{ role: 'quit' }] },
     { label: 'Edit', submenu: [{ role: 'copy' }, { role: 'paste' }, { role: 'selectAll' }] },
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' },
-        { role: 'toggleDevTools', accelerator: 'F12' },
-        { type: 'separator' },
-        { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' },
-      ],
-    },
+    { label: 'View', submenu: viewSubmenu },
     { label: 'Window', submenu: [{ role: 'minimize' }, { role: 'close' }] },
   ]));
 


### PR DESCRIPTION
## Summary
Patch release on top of v2.0.0. One change.

- \`webPreferences.devTools\` is now \`!app.isPackaged\` in the main BrowserWindow, so shipped builds (.deb / .dmg / .exe / .AppImage) cannot open DevTools via F12, Ctrl+Shift+I (Cmd+Opt+I), the View menu, or programmatic openDevTools. Source-tree runs (\`./run.sh\`, \`npm start\`) keep DevTools.
- The View > Toggle DevTools menu item is dropped in packaged builds so it does not surface an entry that the flag silences.

## Test plan
- [x] CI green on PR #27
- [ ] CI green on this release PR
- [ ] After merge + tag v2.0.1: install the .AppImage / .deb / .dmg / .exe, F12 does nothing, no Toggle DevTools entry in the View menu