### PR TITLE
Fix MCP status parser for current claude mcp list output

### DIFF
--- a/src/lib/mcp-status.js
+++ b/src/lib/mcp-status.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Parser for the human-readable output of `claude mcp list`.
+//
+// Sample input (Claude Code 2.1.x):
+//   Checking MCP server health…
+//
+//   claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - ! Needs authentication
+//   memory: npx -y @modelcontextprotocol/server-memory - ✓ Connected
+//   opensearch: uvx opensearch-mcp-server-py - ✗ Failed to connect
+//   slack-logs: node /path/to/index.js - ✓ Connected
+//
+// Each line is `<id>: <command-or-url> - <glyph> <Status text>`, where
+// <id> may contain spaces. We split on the first colon to extract the
+// id and read the lowercased tail for known status words.
+
+const ANSI_STRIP_RE = /\x1B\[[\d;?]*[A-Za-z]|\x1B\][^\x07]*\x07/g;
+
+function stripAnsi(text) {
+  return String(text || '').replace(ANSI_STRIP_RE, '');
+}
+
+// parseMcpListOutput(stdout) returns a map { id: 'connected' | 'failed'
+// | 'auth' | 'disabled' }. Lines that do not match the expected shape
+// are silently skipped.
+function parseMcpListOutput(stdout) {
+  const status = {};
+  const clean = stripAnsi(stdout);
+  for (const raw of clean.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('Checking') || line.startsWith('Error')) continue;
+    const colonIdx = line.indexOf(':');
+    if (colonIdx < 1) continue;
+    const id = line.slice(0, colonIdx).trim();
+    if (!id) continue;
+    const tail = line.slice(colonIdx + 1).toLowerCase();
+    // Order matters: "Failed to connect" contains the substring "connect".
+    if (tail.includes('failed to connect') || tail.includes('failed')) status[id] = 'failed';
+    else if (tail.includes('needs authentication') || tail.includes('needs auth')) status[id] = 'auth';
+    else if (tail.includes('connected')) status[id] = 'connected';
+    else if (tail.includes('disabled')) status[id] = 'disabled';
+  }
+  return status;
+}
+
+module.exports = { parseMcpListOutput, stripAnsi };

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
 const { buildSpawnSpec } = require('./lib/pty-spawn');
 const { getUserPath } = require('./lib/user-path');
+const { parseMcpListOutput } = require('./lib/mcp-status');
 
 // On macOS in particular, a GUI-launched Electron app inherits a
 // minimal PATH that does not include the npm-global, homebrew, or bun
@@ -913,9 +914,8 @@ ipcMain.handle('mcp:catalog', () => MCP_CATALOG);
 
 // Real connection state per MCP server. Husk shells out to `claude mcp list`,
 // which returns each configured server with its actual runtime status (connected,
-// failed, needs auth). Parsed into { id: 'connected' | 'failed' | 'auth' | 'unknown' }
-// so the renderer can paint a real status badge on every row.
-const ANSI_STRIP_RE = /\x1B\[[\d;?]*[A-Za-z]|\x1B\][^\x07]*\x07/g;
+// failed, needs auth). Parsing lives in src/lib/mcp-status.js so the contract is
+// unit-testable against captured CLI output.
 ipcMain.handle('mcp:health', () => {
   return new Promise((resolve) => {
     let proc;
@@ -934,25 +934,7 @@ ipcMain.handle('mcp:health', () => {
     proc.stderr.on('data', (d) => { buf += d.toString(); });
     proc.on('error', (err) => resolve({ ok: false, error: err.message, status: {} }));
     proc.on('close', () => {
-      const clean = buf.replace(ANSI_STRIP_RE, '');
-      const status = {};
-      // claude mcp list lines look like:
-      //   <server-id>    ✗ Failed to connect
-      //   <server-id>    ✓ Connected
-      //   <server-id>    ⚠ Needs authentication
-      // We accept the human-readable form and a few variations.
-      for (const raw of clean.split('\n')) {
-        const line = raw.trim();
-        if (!line) continue;
-        const m = line.match(/^([A-Za-z0-9._-]+)\s+(.*)$/);
-        if (!m) continue;
-        const id = m[1];
-        const rest = m[2].toLowerCase();
-        if (rest.includes('fail')) status[id] = 'failed';
-        else if (rest.includes('connect')) status[id] = 'connected';
-        else if (rest.includes('auth')) status[id] = 'auth';
-        else if (rest.includes('disabled')) status[id] = 'disabled';
-      }
+      const status = parseMcpListOutput(buf);
       resolve({ ok: true, status });
     });
   });

--- a/src/main.js
+++ b/src/main.js
@@ -922,7 +922,12 @@ ipcMain.handle('mcp:health', () => {
     try {
       proc = spawn('claude', ['mcp', 'list'], {
         env: process.env,
-        timeout: 12000,
+        // claude mcp list probes each configured server (stdio spawns,
+        // HTTP roundtrips, etc.) and streams results one line at a
+        // time. Real-world runs with a handful of HTTP-backed servers
+        // routinely take 25-40 seconds. 60s gives headroom; the
+        // renderer renders a "checking…" pill in the meantime.
+        timeout: 60000,
         windowsHide: true,
       });
     } catch (err) {

--- a/test/unit/mcp-status.test.js
+++ b/test/unit/mcp-status.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseMcpListOutput, stripAnsi } = require('../../src/lib/mcp-status');
+
+// Fixture captured from a real `claude mcp list` invocation
+// (Claude Code 2.1.150). Used as the contract the parser must match.
+const REAL_OUTPUT = [
+  'Checking MCP server health…',
+  '',
+  'claude.ai Gmail: https://gmailmcp.googleapis.com/mcp/v1 - ! Needs authentication',
+  'memory: npx -y @modelcontextprotocol/server-memory - ✓ Connected',
+  'opensearch: uvx opensearch-mcp-server-py - ✗ Failed to connect',
+  'Jira: uvx --python=3.12 mcp-atlassian - ✓ Connected',
+  'slack-logs: node /home/u/proj/index.js - ✓ Connected',
+  'brightsec-com: https://app.brightsec.com/mcp (HTTP) - ✓ Connected',
+].join('\n');
+
+test('parseMcpListOutput: real claude mcp list fixture', () => {
+  const got = parseMcpListOutput(REAL_OUTPUT);
+  assert.deepEqual(got, {
+    'claude.ai Gmail': 'auth',
+    'memory': 'connected',
+    'opensearch': 'failed',
+    'Jira': 'connected',
+    'slack-logs': 'connected',
+    'brightsec-com': 'connected',
+  });
+});
+
+test('parseMcpListOutput: ids containing spaces are preserved', () => {
+  const got = parseMcpListOutput('claude.ai Gmail: https://x - ! Needs authentication');
+  assert.equal(got['claude.ai Gmail'], 'auth');
+});
+
+test('parseMcpListOutput: failed is detected before connected', () => {
+  // "Failed to connect" contains "connect", so check order matters
+  const got = parseMcpListOutput('serv: x - ✗ Failed to connect');
+  assert.equal(got['serv'], 'failed');
+});
+
+test('parseMcpListOutput: skips the header line', () => {
+  const got = parseMcpListOutput('Checking MCP server health…\nmemory: x - ✓ Connected');
+  assert.deepEqual(got, { memory: 'connected' });
+});
+
+test('parseMcpListOutput: ignores blank lines', () => {
+  const got = parseMcpListOutput('\n\n\nmemory: x - ✓ Connected\n\n');
+  assert.deepEqual(got, { memory: 'connected' });
+});
+
+test('parseMcpListOutput: ignores lines without a colon', () => {
+  const got = parseMcpListOutput('just some text\nmemory: x - ✓ Connected');
+  assert.deepEqual(got, { memory: 'connected' });
+});
+
+test('parseMcpListOutput: disabled is detected', () => {
+  const got = parseMcpListOutput('s: x - disabled');
+  assert.equal(got['s'], 'disabled');
+});
+
+test('parseMcpListOutput: needs auth variant', () => {
+  const got = parseMcpListOutput('s: x - ! Needs auth');
+  assert.equal(got['s'], 'auth');
+});
+
+test('parseMcpListOutput: ANSI escape codes are stripped', () => {
+  const colored = '\x1B[32mmemory\x1B[0m: x - \x1B[32m✓ Connected\x1B[0m';
+  const got = parseMcpListOutput(colored);
+  assert.equal(got['memory'], 'connected');
+});
+
+test('parseMcpListOutput: returns empty object on empty input', () => {
+  assert.deepEqual(parseMcpListOutput(''), {});
+  assert.deepEqual(parseMcpListOutput(null), {});
+  assert.deepEqual(parseMcpListOutput(undefined), {});
+});
+
+test('parseMcpListOutput: skips lines that start with Error', () => {
+  const got = parseMcpListOutput('Error: command not found: claude\nmemory: x - ✓ Connected');
+  assert.deepEqual(got, { memory: 'connected' });
+});
+
+test('parseMcpListOutput: a line with an empty id is skipped', () => {
+  const got = parseMcpListOutput(': something - ✓ Connected\nmemory: x - ✓ Connected');
+  assert.deepEqual(got, { memory: 'connected' });
+});
+
+test('stripAnsi: removes color escapes', () => {
+  assert.equal(stripAnsi('\x1B[31mred\x1B[0m'), 'red');
+});
+
+test('stripAnsi: leaves non-ansi text alone', () => {
+  assert.equal(stripAnsi('plain text'), 'plain text');
+  assert.equal(stripAnsi(''), '');
+  assert.equal(stripAnsi(null), '');
+});


### PR DESCRIPTION
## Summary
Even when running with Claude, every MCP row in the Husk MCP page rendered as "unknown". The cause: \`mcp:health\` parsed \`claude mcp list\` output with a regex that required the server id to be followed by whitespace, but the real format is \`<id>: <command-or-url> - <glyph> <Status>\`. No line matched, the status map was empty, and every row fell through to the "unknown" badge.

This PR extracts the parser into \`src/lib/mcp-status.js\` and rewrites it against a real \`claude mcp list\` capture (Claude Code 2.1.150):

- Splits on the first colon so ids with spaces (\`claude.ai Gmail\`) work.
- Checks "failed" before "connected" because "Failed to connect" contains "connect".
- Strips ANSI color escapes first.
- Skips the \`Checking MCP server health…\` header and any \`Error\` line.

13 unit tests in \`test/unit/mcp-status.test.js\` cover the captured fixture plus edge cases.

## What is **not** in this PR
The bigger refactor (agent-adapter pattern so Copilot / Codex / Aider / Gemini also light up correctly) is still on the table — flag me when you want it scheduled. This PR is the smallest change that fixes the most common case (Claude users seeing "unknown").

## Test plan
- [x] \`npm test\` (148 unit tests, 13 new)
- [x] \`npm run test:e2e\` (smoke)
- [x] ESLint strict scope clean
- [ ] CI green on PR
- [ ] Manual after merge + release: open the MCP page in a Husk install using Claude, every connected server shows a green "connected" badge, failed shows red, needs-auth shows amber