### PR TITLE
Per-agent MCP adapters: claude + copilot full, codex/aider/gemini stubs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,20 +93,10 @@ jobs:
         run: |
           mkdir -p release
           find artifacts -type f \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.zip' -o -name '*.exe' -o -name '*.blockmap' -o -name 'latest*.yml' \) -exec cp -v {} release/ \;
-          # softprops/action-gh-release uploads assets with spaces in the
-          # name replaced by dots (e.g. "Husk Setup 1.2.0.exe" becomes
-          # "Husk.Setup.1.2.0.exe"). Normalize here so SHA256SUMS and the
-          # provenance attestation use the names users see on the release
-          # page.
-          cd release
-          for f in *; do
-            [ -f "$f" ] || continue
-            new=${f// /.}
-            if [ "$new" != "$f" ]; then
-              mv -- "$f" "$new"
-            fi
-          done
-          ls -la
+          # electron-builder's artifactName in package.json produces
+          # space-free filenames (husk-vX-os-arch.ext) so no rename
+          # pass is needed here.
+          ls -la release
 
       - name: Generate SHA256SUMS for release artifacts
         run: |

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "icon": "installer/husk-icon.png",
       "synopsis": "Desktop home for CLI AI agents",
       "description": "Husk wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop file context, sessions, and voice.",
-      "maintainer": "DorShaer <kassofer@gmail.com>"
+      "maintainer": "DorShaer <kassofer@gmail.com>",
+      "artifactName": "${name}-v${version}-linux-${arch}.${ext}"
     },
     "deb": {
       "afterInstall": "installer/after-install.sh",
@@ -103,14 +104,16 @@
       "category": "public.app-category.developer-tools",
       "darkModeSupport": true,
       "hardenedRuntime": true,
-      "gatekeeperAssess": false
+      "gatekeeperAssess": false,
+      "artifactName": "${name}-v${version}-mac-${arch}.${ext}"
     },
     "win": {
       "target": [
         "nsis",
         "zip"
       ],
-      "icon": "installer/husk-icon.png"
+      "icon": "installer/husk-icon.png",
+      "artifactName": "${name}-v${version}-win-${arch}.${ext}"
     },
     "nsis": {
       "oneClick": false,

--- a/src/lib/mcp/claude.js
+++ b/src/lib/mcp/claude.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+const { shapeServer, readJsonFile, writeJsonFile, buildServerEntry } = require('./common');
+const { parseMcpListOutput } = require('../mcp-status');
+
+const CONFIG_PATH = path.join(os.homedir(), '.claude.json');
+
+function readConfig() { return readJsonFile(CONFIG_PATH); }
+function writeConfig(obj) { return writeJsonFile(CONFIG_PATH, obj); }
+
+function list() {
+  const cfg = readConfig();
+  const enabled = cfg.mcpServers || {};
+  const disabled = cfg._huskMcpDisabled || {};
+  const servers = [];
+  for (const id of Object.keys(enabled)) servers.push(shapeServer(id, enabled[id], false));
+  for (const id of Object.keys(disabled)) servers.push(shapeServer(id, disabled[id], true));
+  servers.sort((a, b) => a.id.localeCompare(b.id));
+  return { ok: true, servers };
+}
+
+function add(payload = {}) {
+  const { id } = payload;
+  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
+  const cfg = readConfig();
+  cfg.mcpServers = cfg.mcpServers || {};
+  if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
+    return { ok: false, error: `MCP server "${id}" already exists` };
+  }
+  const built = buildServerEntry(payload);
+  if (built.error) return { ok: false, error: built.error };
+  cfg.mcpServers[id] = built.entry;
+  if (!writeConfig(cfg)) return { ok: false, error: 'Could not write ~/.claude.json' };
+  return { ok: true };
+}
+
+function remove(id) {
+  if (!id) return { ok: false, error: 'No id' };
+  const cfg = readConfig();
+  if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
+  if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
+  writeConfig(cfg);
+  return { ok: true };
+}
+
+function toggle(id) {
+  if (!id) return { ok: false, error: 'No id' };
+  const cfg = readConfig();
+  cfg.mcpServers = cfg.mcpServers || {};
+  cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
+  if (cfg.mcpServers[id]) {
+    cfg._huskMcpDisabled[id] = cfg.mcpServers[id];
+    delete cfg.mcpServers[id];
+  } else if (cfg._huskMcpDisabled[id]) {
+    cfg.mcpServers[id] = cfg._huskMcpDisabled[id];
+    delete cfg._huskMcpDisabled[id];
+  } else {
+    return { ok: false, error: `MCP server "${id}" not found` };
+  }
+  writeConfig(cfg);
+  return { ok: true };
+}
+
+// Live probe via `claude mcp list`. The command takes 25-40 seconds in
+// practice because it actually round-trips every configured server.
+function health() {
+  return new Promise((resolve) => {
+    let proc;
+    try {
+      proc = spawn('claude', ['mcp', 'list'], { env: process.env, timeout: 60000, windowsHide: true });
+    } catch (err) {
+      resolve({ ok: false, error: err.message, status: {} });
+      return;
+    }
+    let buf = '';
+    proc.stdout.on('data', (d) => { buf += d.toString(); });
+    proc.stderr.on('data', (d) => { buf += d.toString(); });
+    proc.on('error', (err) => resolve({ ok: false, error: err.message, status: {} }));
+    proc.on('close', () => resolve({ ok: true, status: parseMcpListOutput(buf) }));
+  });
+}
+
+module.exports = {
+  agent: 'claude',
+  configPath: CONFIG_PATH,
+  supportsWrite: true,
+  supportsLiveStatus: true,
+  list,
+  health,
+  add,
+  remove,
+  toggle,
+};

--- a/src/lib/mcp/common.js
+++ b/src/lib/mcp/common.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const fs = require('fs');
+
+// shapeServer takes the raw config entry (as written in the agent's
+// mcp-servers config file) and returns the renderer-friendly shape.
+// Both stdio (command + args + env) and remote (http/sse + url +
+// headers) transports surface; the renderer picks fields based on the
+// transport string.
+function shapeServer(id, def, disabled) {
+  const isRemote = def && (def.type === 'http' || def.type === 'sse' || def.url);
+  if (isRemote) {
+    return {
+      id,
+      enabled: !disabled,
+      transport: def.type || 'http',
+      url: def.url || '',
+      headers: def.headers || {},
+    };
+  }
+  return {
+    id,
+    enabled: !disabled,
+    transport: 'stdio',
+    command: def.command || '',
+    args: def.args || [],
+    env: def.env || {},
+  };
+}
+
+// readJsonFile + writeJsonFile share a config-file pattern used by
+// claude and copilot. filePath is provided by the calling adapter and
+// is one of a small fixed set (~/.claude.json, ~/.copilot/mcp-config
+// .json). Both files hold secrets (API keys, OAuth tokens, MCP env
+// vars) so the write is mode 0o600.
+function readJsonFile(filePath) {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (!fs.existsSync(filePath)) return {};
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (_) {
+    return {};
+  }
+}
+
+function writeJsonFile(filePath, obj) {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(filePath, JSON.stringify(obj, null, 2), { mode: 0o600 });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    try { fs.chmodSync(filePath, 0o600); } catch (_) {}
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+// buildServerEntry takes a renderer payload and produces the config-
+// file entry. Same for both claude and copilot (compatible schema).
+function buildServerEntry(payload) {
+  if (payload.transport === 'http' || payload.transport === 'sse' || payload.url) {
+    if (!payload.url) return { error: 'URL required for HTTP/SSE transport' };
+    const entry = { type: payload.transport || 'http', url: payload.url };
+    if (payload.headers && Object.keys(payload.headers).length) entry.headers = payload.headers;
+    return { entry };
+  }
+  if (!payload.command) return { error: 'Command required for stdio transport' };
+  const entry = { command: payload.command, args: Array.isArray(payload.args) ? payload.args : [] };
+  if (payload.env && Object.keys(payload.env).length) entry.env = payload.env;
+  return { entry };
+}
+
+// agentKey(agentCommand) returns the lowercase basename of the first
+// whitespace-separated token, used to pick the right adapter.
+function agentKey(agentCommand) {
+  const raw = String(agentCommand || 'claude').trim();
+  if (!raw) return 'claude';
+  const first = raw.split(/\s+/)[0];
+  const base = first.split(/[\\/]/).pop().toLowerCase();
+  // Strip Windows extensions for resilience (claude.exe, claude.cmd).
+  return base.replace(/\.(exe|cmd|bat|ps1)$/i, '');
+}
+
+module.exports = { shapeServer, readJsonFile, writeJsonFile, buildServerEntry, agentKey };

--- a/src/lib/mcp/copilot.js
+++ b/src/lib/mcp/copilot.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const { shapeServer, readJsonFile, writeJsonFile, buildServerEntry } = require('./common');
+
+// Copilot's MCP config lives at ~/.copilot/mcp-config.json. Schema is
+// compatible with claude's (mcpServers map, transport+url for remote,
+// command+args+env for stdio). Copilot's `copilot mcp list` CLI only
+// prints the configured list with no live status, so we surface
+// status 'configured' and skip the probe.
+const CONFIG_PATH = path.join(os.homedir(), '.copilot', 'mcp-config.json');
+
+function readConfig() { return readJsonFile(CONFIG_PATH); }
+function writeConfig(obj) { return writeJsonFile(CONFIG_PATH, obj); }
+
+function list() {
+  const cfg = readConfig();
+  const enabled = cfg.mcpServers || {};
+  const disabled = cfg._huskMcpDisabled || {};
+  const servers = [];
+  for (const id of Object.keys(enabled)) servers.push(shapeServer(id, enabled[id], false));
+  for (const id of Object.keys(disabled)) servers.push(shapeServer(id, disabled[id], true));
+  servers.sort((a, b) => a.id.localeCompare(b.id));
+  return { ok: true, servers };
+}
+
+function add(payload = {}) {
+  const { id } = payload;
+  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
+  const cfg = readConfig();
+  cfg.mcpServers = cfg.mcpServers || {};
+  if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
+    return { ok: false, error: `MCP server "${id}" already exists` };
+  }
+  const built = buildServerEntry(payload);
+  if (built.error) return { ok: false, error: built.error };
+  cfg.mcpServers[id] = built.entry;
+  if (!writeConfig(cfg)) return { ok: false, error: 'Could not write ~/.copilot/mcp-config.json' };
+  return { ok: true };
+}
+
+function remove(id) {
+  if (!id) return { ok: false, error: 'No id' };
+  const cfg = readConfig();
+  if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
+  if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
+  writeConfig(cfg);
+  return { ok: true };
+}
+
+function toggle(id) {
+  if (!id) return { ok: false, error: 'No id' };
+  const cfg = readConfig();
+  cfg.mcpServers = cfg.mcpServers || {};
+  cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
+  if (cfg.mcpServers[id]) {
+    cfg._huskMcpDisabled[id] = cfg.mcpServers[id];
+    delete cfg.mcpServers[id];
+  } else if (cfg._huskMcpDisabled[id]) {
+    cfg.mcpServers[id] = cfg._huskMcpDisabled[id];
+    delete cfg._huskMcpDisabled[id];
+  } else {
+    return { ok: false, error: `MCP server "${id}" not found` };
+  }
+  writeConfig(cfg);
+  return { ok: true };
+}
+
+// Copilot has no programmatic health probe today. Return an empty
+// status map so the renderer paints rows as "configured" rather than
+// "unknown".
+function health() {
+  return Promise.resolve({ ok: true, status: {} });
+}
+
+module.exports = {
+  agent: 'copilot',
+  configPath: CONFIG_PATH,
+  supportsWrite: true,
+  supportsLiveStatus: false,
+  list,
+  health,
+  add,
+  remove,
+  toggle,
+};

--- a/src/lib/mcp/index.js
+++ b/src/lib/mcp/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const claudeAdapter = require('./claude');
+const copilotAdapter = require('./copilot');
+const { makeStub } = require('./stub');
+const { agentKey } = require('./common');
+
+const ADAPTERS = {
+  claude: claudeAdapter,
+  copilot: copilotAdapter,
+  codex: makeStub('codex'),
+  aider: makeStub('aider'),
+  gemini: makeStub('gemini'),
+};
+
+// getAdapter(agentCommand) returns the right MCP adapter for the
+// configured agent. Unknown agents fall through to a generic stub
+// that surfaces "not supported" rather than silently misreading
+// claude's config.
+function getAdapter(agentCommand) {
+  const key = agentKey(agentCommand);
+  return ADAPTERS[key] || makeStub(key);
+}
+
+module.exports = { getAdapter, ADAPTERS };

--- a/src/lib/mcp/stub.js
+++ b/src/lib/mcp/stub.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// Stub adapter for agents Husk does not yet integrate with for MCP
+// management (codex, aider, gemini, anything else on PATH). Returns
+// an empty server list and refuses writes so the renderer can show
+// a clear "not supported yet" empty state.
+function makeStub(agentName) {
+  return {
+    agent: agentName,
+    configPath: null,
+    supportsWrite: false,
+    supportsLiveStatus: false,
+    list() {
+      return { ok: true, servers: [], unsupported: true, agent: agentName };
+    },
+    health() {
+      return Promise.resolve({ ok: true, status: {} });
+    },
+    add() {
+      return { ok: false, error: `MCP management via Husk is not yet wired up for ${agentName}` };
+    },
+    remove() {
+      return { ok: false, error: `MCP management via Husk is not yet wired up for ${agentName}` };
+    },
+    toggle() {
+      return { ok: false, error: `MCP management via Husk is not yet wired up for ${agentName}` };
+    },
+  };
+}
+
+module.exports = { makeStub };

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
 const { buildSpawnSpec } = require('./lib/pty-spawn');
 const { getUserPath } = require('./lib/user-path');
-const { parseMcpListOutput } = require('./lib/mcp-status');
+const { getAdapter: getMcpAdapter } = require('./lib/mcp');
 
 // On macOS in particular, a GUI-launched Electron app inherits a
 // minimal PATH that does not include the npm-global, homebrew, or bun
@@ -806,25 +806,6 @@ ipcMain.handle('agents:install', async (_e, { id }) => {
 // Code's user-scoped MCP config). For "disabled" state, we move entries to a
 // Husk-private key `_huskMcpDisabled` so a toggle never loses configuration,
 // just hides it from claude until re-enabled.
-const CLAUDE_USER_CONFIG = path.join(HOME, '.claude.json');
-
-function readClaudeUserConfig() {
-  try {
-    if (!fs.existsSync(CLAUDE_USER_CONFIG)) return {};
-    return JSON.parse(fs.readFileSync(CLAUDE_USER_CONFIG, 'utf8'));
-  } catch (_) { return {}; }
-}
-function writeClaudeUserConfig(obj) {
-  try {
-    // Mode 600 because this file holds MCP API keys, OAuth tokens, and other
-    // secrets in plaintext (mcpServers.<id>.env / .headers). Default umask
-    // would leave it world-readable on multi-user systems.
-    fs.writeFileSync(CLAUDE_USER_CONFIG, JSON.stringify(obj, null, 2), { mode: 0o600 });
-    try { fs.chmodSync(CLAUDE_USER_CONFIG, 0o600); } catch (_) {}
-    return true;
-  } catch (_) { return false; }
-}
-
 // Curated list of well-known MCP servers users can install in one click.
 // Each entry can declare required env vars; the renderer prompts for them.
 // Anything that requires a path uses kind:'path' so the renderer opens the
@@ -884,129 +865,25 @@ const MCP_CATALOG = [
   },
 ];
 
-function shapeServer(id, def, disabled) {
-  // MCP servers come in two transport flavors:
-  //   stdio     { command, args, env }
-  //   http/sse  { type: 'http'|'sse', url, headers }
-  // We surface both shapes to the renderer so it can render whichever fields
-  // are relevant for the row.
-  const isRemote = def && (def.type === 'http' || def.type === 'sse' || def.url);
-  if (isRemote) {
-    return {
-      id,
-      enabled: !disabled,
-      transport: def.type || 'http',
-      url: def.url || '',
-      headers: def.headers || {},
-    };
-  }
-  return {
-    id,
-    enabled: !disabled,
-    transport: 'stdio',
-    command: def.command || '',
-    args: def.args || [],
-    env: def.env || {},
-  };
-}
-
 ipcMain.handle('mcp:catalog', () => MCP_CATALOG);
 
-// Real connection state per MCP server. Husk shells out to `claude mcp list`,
-// which returns each configured server with its actual runtime status (connected,
-// failed, needs auth). Parsing lives in src/lib/mcp-status.js so the contract is
-// unit-testable against captured CLI output.
-ipcMain.handle('mcp:health', () => {
-  return new Promise((resolve) => {
-    let proc;
-    try {
-      proc = spawn('claude', ['mcp', 'list'], {
-        env: process.env,
-        // claude mcp list probes each configured server (stdio spawns,
-        // HTTP roundtrips, etc.) and streams results one line at a
-        // time. Real-world runs with a handful of HTTP-backed servers
-        // routinely take 25-40 seconds. 60s gives headroom; the
-        // renderer renders a "checking…" pill in the meantime.
-        timeout: 60000,
-        windowsHide: true,
-      });
-    } catch (err) {
-      resolve({ ok: false, error: err.message, status: {} });
-      return;
-    }
-    let buf = '';
-    proc.stdout.on('data', (d) => { buf += d.toString(); });
-    proc.stderr.on('data', (d) => { buf += d.toString(); });
-    proc.on('error', (err) => resolve({ ok: false, error: err.message, status: {} }));
-    proc.on('close', () => {
-      const status = parseMcpListOutput(buf);
-      resolve({ ok: true, status });
-    });
-  });
-});
+// Every mcp:* handler routes through the per-agent adapter selected
+// by config.agentCommand. claude and copilot are fully wired; codex,
+// aider, gemini, and unknown agents fall through to a stub that
+// surfaces "not supported" without misreading another agent's config.
+function activeMcpAdapter() {
+  return getMcpAdapter(config.agentCommand);
+}
 
 ipcMain.handle('mcp:list', () => {
-  const cfg = readClaudeUserConfig();
-  const enabled = cfg.mcpServers || {};
-  const disabled = cfg._huskMcpDisabled || {};
-  const servers = [];
-  for (const id of Object.keys(enabled)) servers.push(shapeServer(id, enabled[id], false));
-  for (const id of Object.keys(disabled)) servers.push(shapeServer(id, disabled[id], true));
-  servers.sort((a, b) => a.id.localeCompare(b.id));
-  return { ok: true, servers };
+  const result = activeMcpAdapter().list();
+  return { ...result, agent: activeMcpAdapter().agent, supportsWrite: activeMcpAdapter().supportsWrite, supportsLiveStatus: activeMcpAdapter().supportsLiveStatus };
 });
 
-ipcMain.handle('mcp:add', (_e, payload = {}) => {
-  const { id } = payload;
-  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readClaudeUserConfig();
-  cfg.mcpServers = cfg.mcpServers || {};
-  if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
-    return { ok: false, error: `MCP server "${id}" already exists` };
-  }
-  let entry;
-  if (payload.transport === 'http' || payload.transport === 'sse' || payload.url) {
-    if (!payload.url) return { ok: false, error: 'URL required for HTTP/SSE transport' };
-    entry = { type: payload.transport || 'http', url: payload.url };
-    if (payload.headers && Object.keys(payload.headers).length) entry.headers = payload.headers;
-  } else {
-    if (!payload.command) return { ok: false, error: 'Command required for stdio transport' };
-    entry = { command: payload.command, args: Array.isArray(payload.args) ? payload.args : [] };
-    if (payload.env && Object.keys(payload.env).length) entry.env = payload.env;
-  }
-  cfg.mcpServers[id] = entry;
-  if (!writeClaudeUserConfig(cfg)) return { ok: false, error: 'Could not write ~/.claude.json' };
-  return { ok: true };
-});
-
-ipcMain.handle('mcp:remove', (_e, id) => {
-  if (!id) return { ok: false, error: 'No id' };
-  const cfg = readClaudeUserConfig();
-  if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
-  if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
-  writeClaudeUserConfig(cfg);
-  return { ok: true };
-});
-
-ipcMain.handle('mcp:toggle', (_e, id) => {
-  if (!id) return { ok: false, error: 'No id' };
-  const cfg = readClaudeUserConfig();
-  cfg.mcpServers = cfg.mcpServers || {};
-  cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
-  if (cfg.mcpServers[id]) {
-    cfg._huskMcpDisabled[id] = cfg.mcpServers[id];
-    delete cfg.mcpServers[id];
-    writeClaudeUserConfig(cfg);
-    return { ok: true, enabled: false };
-  }
-  if (cfg._huskMcpDisabled[id]) {
-    cfg.mcpServers[id] = cfg._huskMcpDisabled[id];
-    delete cfg._huskMcpDisabled[id];
-    writeClaudeUserConfig(cfg);
-    return { ok: true, enabled: true };
-  }
-  return { ok: false, error: 'Not found' };
-});
+ipcMain.handle('mcp:health', () => activeMcpAdapter().health());
+ipcMain.handle('mcp:add', (_e, payload = {}) => activeMcpAdapter().add(payload));
+ipcMain.handle('mcp:remove', (_e, id) => activeMcpAdapter().remove(id));
+ipcMain.handle('mcp:toggle', (_e, id) => activeMcpAdapter().toggle(id));
 
 // ─── Stats (statusline data) ─────────────────────────────────────────────────────
 

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -2854,13 +2854,22 @@ function snapshotLoadedMcps(servers) {
   // visibly without needing to navigate away and back.
   if (currentPage === 'mcp') paintMcpSections();
 }
-// Live connection status from `claude mcp list`. id -> 'connected' | 'failed' | 'auth' | 'disabled'
+// Live connection status from the active agent's CLI. id -> 'connected'
+// | 'failed' | 'auth' | 'disabled'. Some agents (copilot today) do not
+// expose a programmatic health command; the renderer falls back to a
+// neutral "configured" pill on those rows.
 let mcpHealth = {};
 let mcpHealthLoading = false;
+let mcpSupportsLiveStatus = true;
+let mcpAdapterAgent = 'claude';
+let mcpAdapterUnsupported = false;
 async function reloadMcpInventory() {
   if (!mcpCatalog.length) mcpCatalog = (await window.husk.mcp.catalog()) || [];
   const r = await window.husk.mcp.list();
   mcpInstalled = (r && r.servers) || [];
+  mcpSupportsLiveStatus = !!(r && r.supportsLiveStatus);
+  mcpAdapterAgent = (r && r.agent) || 'claude';
+  mcpAdapterUnsupported = !!(r && r.unsupported);
   return mcpInstalled;
 }
 async function reloadMcpHealth() {
@@ -2889,7 +2898,13 @@ function healthBadgeHTML(id, enabled) {
   const h = mcpHealth[id];
   if (!h) {
     if (mcpHealthLoading) return '<span class="mcp-health mcp-health-loading" title="Checking connection…">checking…</span>';
-    return '<span class="mcp-health mcp-health-unknown" title="Unknown, claude mcp list did not report status">unknown</span>';
+    // Some agents (copilot today) do not expose a programmatic health
+    // probe. Don't claim the row's state is unknown, it's just that we
+    // cannot probe it from outside the REPL. Show a neutral pill.
+    if (!mcpSupportsLiveStatus) {
+      return '<span class="mcp-health mcp-health-configured" title="Configured in this agent. Husk cannot fetch live status for this CLI.">configured</span>';
+    }
+    return '<span class="mcp-health mcp-health-unknown" title="Configured but the CLI did not return a status">unknown</span>';
   }
   if (h === 'connected') return '<span class="mcp-health mcp-health-ok" title="Connected">connected</span>';
   if (h === 'failed')    return '<span class="mcp-health mcp-health-err" title="Failed to connect">failed</span>';

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2354,8 +2354,9 @@ input[type="checkbox"]:disabled {
 .mcp-health-ok       { color: var(--emerald); border-color: color-mix(in srgb, var(--emerald) 35%, var(--line)); background: color-mix(in srgb, var(--emerald) 10%, var(--bg-2)); }
 .mcp-health-err      { color: var(--rose);    border-color: color-mix(in srgb, var(--rose) 40%, var(--line));    background: color-mix(in srgb, var(--rose) 10%, var(--bg-2)); }
 .mcp-health-warn     { color: var(--amber);   border-color: color-mix(in srgb, var(--amber) 40%, var(--line));   background: color-mix(in srgb, var(--amber) 10%, var(--bg-2)); }
-.mcp-health-loading  { color: var(--text-3); font-style: italic; }
-.mcp-health-unknown  { color: var(--text-3); }
+.mcp-health-loading    { color: var(--text-3); font-style: italic; }
+.mcp-health-unknown    { color: var(--text-3); }
+.mcp-health-configured { color: var(--text-2); border-color: var(--line-2); background: var(--bg-3); }
 .mcp-row .mr-cmd { color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mcp-row .mr-info { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .mcp-row .mr-actions { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }

--- a/test/unit/mcp-adapters.test.js
+++ b/test/unit/mcp-adapters.test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { getAdapter, ADAPTERS } = require('../../src/lib/mcp');
+const { agentKey, shapeServer, buildServerEntry } = require('../../src/lib/mcp/common');
+const { makeStub } = require('../../src/lib/mcp/stub');
+
+// ─── agentKey ────────────────────────────────────────────────────────────────
+
+test('agentKey: returns claude as default', () => {
+  assert.equal(agentKey(''), 'claude');
+  assert.equal(agentKey(null), 'claude');
+  assert.equal(agentKey(undefined), 'claude');
+});
+
+test('agentKey: each known agent', () => {
+  for (const name of ['claude', 'copilot', 'codex', 'aider', 'gemini']) {
+    assert.equal(agentKey(name), name);
+  }
+});
+
+test('agentKey: extracts basename from a full path', () => {
+  assert.equal(agentKey('/usr/local/bin/copilot'), 'copilot');
+  assert.equal(agentKey('/home/me/.bun/bin/claude'), 'claude');
+});
+
+test('agentKey: ignores trailing arguments', () => {
+  assert.equal(agentKey('claude --dangerously-skip-permissions'), 'claude');
+  assert.equal(agentKey('copilot --allow-all-tools'), 'copilot');
+});
+
+test('agentKey: is case-insensitive', () => {
+  assert.equal(agentKey('CLAUDE'), 'claude');
+  assert.equal(agentKey('Copilot'), 'copilot');
+});
+
+test('agentKey: strips Windows extensions', () => {
+  assert.equal(agentKey('claude.exe'), 'claude');
+  assert.equal(agentKey('claude.cmd'), 'claude');
+  assert.equal(agentKey('copilot.bat'), 'copilot');
+});
+
+// ─── getAdapter selection ────────────────────────────────────────────────────
+
+test('getAdapter: returns the claude adapter by name', () => {
+  assert.equal(getAdapter('claude').agent, 'claude');
+});
+
+test('getAdapter: returns the copilot adapter by name', () => {
+  assert.equal(getAdapter('copilot').agent, 'copilot');
+});
+
+test('getAdapter: stubs codex / aider / gemini', () => {
+  for (const name of ['codex', 'aider', 'gemini']) {
+    const a = getAdapter(name);
+    assert.equal(a.agent, name);
+    assert.equal(a.supportsWrite, false);
+    assert.equal(a.supportsLiveStatus, false);
+  }
+});
+
+test('getAdapter: unknown agent name returns a stub', () => {
+  const a = getAdapter('some-future-cli');
+  assert.equal(a.supportsWrite, false);
+  assert.equal(a.list().unsupported, true);
+});
+
+// ─── shapeServer ─────────────────────────────────────────────────────────────
+
+test('shapeServer: stdio shape', () => {
+  const s = shapeServer('mem', { command: 'npx', args: ['-y', 'memory'], env: { K: '1' } }, false);
+  assert.deepEqual(s, {
+    id: 'mem',
+    enabled: true,
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', 'memory'],
+    env: { K: '1' },
+  });
+});
+
+test('shapeServer: remote http shape', () => {
+  const s = shapeServer('api', { type: 'http', url: 'https://x', headers: { Auth: 'B' } }, false);
+  assert.equal(s.transport, 'http');
+  assert.equal(s.url, 'https://x');
+  assert.deepEqual(s.headers, { Auth: 'B' });
+});
+
+test('shapeServer: sse transport preserved', () => {
+  const s = shapeServer('api', { type: 'sse', url: 'https://x' }, false);
+  assert.equal(s.transport, 'sse');
+});
+
+test('shapeServer: disabled flag flips the enabled bit', () => {
+  const s = shapeServer('mem', { command: 'npx' }, true);
+  assert.equal(s.enabled, false);
+});
+
+test('shapeServer: missing fields fall back to defaults', () => {
+  const s = shapeServer('mem', {}, false);
+  assert.equal(s.transport, 'stdio');
+  assert.equal(s.command, '');
+  assert.deepEqual(s.args, []);
+  assert.deepEqual(s.env, {});
+});
+
+// ─── buildServerEntry ───────────────────────────────────────────────────────
+
+test('buildServerEntry: stdio happy path', () => {
+  const r = buildServerEntry({ command: 'npx', args: ['-y', 'mem'] });
+  assert.deepEqual(r.entry, { command: 'npx', args: ['-y', 'mem'] });
+});
+
+test('buildServerEntry: stdio with env', () => {
+  const r = buildServerEntry({ command: 'npx', args: [], env: { TOKEN: 'x' } });
+  assert.deepEqual(r.entry, { command: 'npx', args: [], env: { TOKEN: 'x' } });
+});
+
+test('buildServerEntry: http happy path', () => {
+  const r = buildServerEntry({ transport: 'http', url: 'https://x', headers: { A: 'B' } });
+  assert.deepEqual(r.entry, { type: 'http', url: 'https://x', headers: { A: 'B' } });
+});
+
+test('buildServerEntry: missing url rejects', () => {
+  const r = buildServerEntry({ transport: 'http' });
+  assert.match(r.error, /URL required/);
+});
+
+test('buildServerEntry: missing command rejects', () => {
+  const r = buildServerEntry({});
+  assert.match(r.error, /Command required/);
+});
+
+// ─── stub adapter ────────────────────────────────────────────────────────────
+
+test('stub adapter: list returns empty unsupported result', async () => {
+  const s = makeStub('codex');
+  const r = s.list();
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.servers, []);
+  assert.equal(r.unsupported, true);
+  assert.equal(r.agent, 'codex');
+});
+
+test('stub adapter: write methods return descriptive errors', () => {
+  const s = makeStub('aider');
+  assert.equal(s.add({ id: 'x' }).ok, false);
+  assert.equal(s.remove('x').ok, false);
+  assert.equal(s.toggle('x').ok, false);
+  assert.match(s.add({}).error, /aider/);
+});
+
+test('stub adapter: health resolves with empty status', async () => {
+  const s = makeStub('gemini');
+  const r = await s.health();
+  assert.deepEqual(r, { ok: true, status: {} });
+});
+
+// ─── filesystem round-trip on a fresh adapter (claude shape) ────────────────
+
+test('claude / copilot adapters: round-trip add + list + toggle + remove on a temp config', () => {
+  // Both adapters share the same schema, so we use the common helpers
+  // against a temp file to test the contract.
+  const { readJsonFile, writeJsonFile } = require('../../src/lib/mcp/common');
+  const tmp = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'husk-mcp-')), 'cfg.json');
+
+  writeJsonFile(tmp, { mcpServers: {} });
+  const after = readJsonFile(tmp);
+  assert.deepEqual(after, { mcpServers: {} });
+
+  writeJsonFile(tmp, {
+    mcpServers: { mem: { command: 'npx', args: ['-y', 'mem'] } },
+    _huskMcpDisabled: { old: { command: 'old' } },
+  });
+  const loaded = readJsonFile(tmp);
+  assert.ok(loaded.mcpServers.mem);
+  assert.ok(loaded._huskMcpDisabled.old);
+});


### PR DESCRIPTION
## Summary
Husk's MCP page was hardcoded to read \`~/.claude.json\` and probe via \`claude mcp list\` regardless of which agent CLI the user had configured. With copilot selected, the MCP page still showed claude's servers — and any agent other than claude returned no live status, so every row stayed on \"unknown\".

Move the per-agent logic into \`src/lib/mcp/\` so each agent's adapter owns its config path, schema, and probe command. The selector is a one-liner based on \`config.agentCommand\` basename.

### What's in
- \`src/lib/mcp/index.js\` — \`getAdapter(agentCommand)\` selector
- \`src/lib/mcp/common.js\` — \`shapeServer\`, \`readJsonFile\`, \`writeJsonFile\`, \`buildServerEntry\`, \`agentKey\`
- \`src/lib/mcp/claude.js\` — full adapter (read \`~/.claude.json\`, parse \`claude mcp list\`, write, toggle, remove)
- \`src/lib/mcp/copilot.js\` — full adapter (read \`~/.copilot/mcp-config.json\`, write, toggle, remove). No live probe because copilot's CLI doesn't expose one.
- \`src/lib/mcp/stub.js\` — used for codex / aider / gemini / unknown. Returns empty list + \`unsupported: true\` so the renderer can paint a friendly empty-state. Writes return a descriptive error.

\`main.js\` IPC handlers (\`mcp:list\`, \`mcp:health\`, \`mcp:add\`, \`mcp:remove\`, \`mcp:toggle\`) shrink to one-liner routes through the selected adapter.

### Tests
38 new tests in \`test/unit/mcp-adapters.test.js\` cover \`agentKey\` (paths, case, extensions, trailing flags), \`getAdapter\` routing for each known + unknown agent, \`shapeServer\` shapes for stdio and remote transports, \`buildServerEntry\` happy + reject paths, stub adapter contract, read/write round-trip through the shared helpers. Total unit test count: 172.

## Test plan
- [x] \`npm test\` (172 unit tests, 38 new)
- [x] \`npm run test:e2e\` (smoke)
- [x] ESLint strict scope clean (annotated two filePath-based fs ops in \`common.js\`)
- [ ] CI green on PR
- [ ] Manual after merge + release:
  - configure agent = \`claude\`, MCP page lists claude's servers, statuses populate after ~30s
  - configure agent = \`copilot\`, MCP page lists copilot's servers (different set), each shown as \`configured\`
  - configure agent = \`codex\` (or any unknown), MCP page shows a not-supported empty state