### PR TITLE
release: install-from-repo agent flow + sidebar polish

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -588,6 +588,27 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
       } catch (_) {}
     }
   }
+  // Active-profile repoRoot wins over agentCwd / activeProject, but loses to
+  // an explicit overrideCwd (e.g. Resume re-entering a session). This is what
+  // makes agents installed from a repo land in the right working directory:
+  // relative paths inside the agent's prompt (e.g. `skills/<test_id>.md`)
+  // resolve against the cloned repo, regardless of which CLI is active.
+  try {
+    const activeIds = Array.isArray(config.activeProfileIds)
+      ? config.activeProfileIds
+      : (config.activeProfileId ? [config.activeProfileId] : []);
+    if (activeIds.length && Array.isArray(config.profiles)) {
+      for (const id of activeIds) {
+        const prof = config.profiles.find((p) => p && p.id === id);
+        if (prof && prof.repoRoot && typeof prof.repoRoot === 'string') {
+          if (fs.existsSync(prof.repoRoot) && fs.statSync(prof.repoRoot).isDirectory()) {
+            cwd = prof.repoRoot;
+            break;
+          }
+        }
+      }
+    }
+  } catch (_) {}
   if (overrideCwd) {
     try {
       if (fs.existsSync(overrideCwd) && fs.statSync(overrideCwd).isDirectory()) {
@@ -1501,6 +1522,227 @@ ipcMain.handle('profiles:importAgents', (_e, payload = {}) => {
   config = nextConfig;
   try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 }); } catch (_) {}
   return { ok: true, imported: importedIds.length, importedIds };
+});
+
+// ─── Install-from-repo flow ───────────────────────────────────────────────
+//
+// Lets a user point Husk at a cloned "agent pack" repo (e.g. support-ai-suite)
+// whose layout is:
+//   <repoRoot>/agents/<agent>.md      Claude-style subagent definitions
+//   <repoRoot>/skills/<test_id>.md    skill library the agents reference
+//
+// Install does three things, each individually toggleable from the renderer:
+//   1) Copy each picked agent .md into ~/.claude/agents/ so Claude Code can
+//      invoke it natively via the Task tool.
+//   2) Inject each picked agent body into <repoRoot>/.github/copilot-
+//      instructions.md inside HUSK-AGENTS markers so GitHub Copilot CLI
+//      picks it up natively when launched in that directory.
+//   3) Create a Husk profile per picked agent stamped with repoRoot. The
+//      spawnPty cwd resolver consumes that field so the active CLI runs
+//      inside the repo, which makes the agent's relative `skills/<id>.md`
+//      reads resolve.
+//
+// The renderer is expected to call repoAgents:pickDir first (or pass an
+// already-known root), then repoAgents:scan to populate the picker, then
+// repoAgents:install with the user's selection.
+
+const HUSK_AGENTS_START = '<!-- HUSK-AGENTS:START -->';
+const HUSK_AGENTS_END = '<!-- HUSK-AGENTS:END -->';
+
+ipcMain.handle('repoAgents:pickDir', async () => {
+  const r = await dialog.showOpenDialog(mainWindow, {
+    title: 'Select an agent-pack repository',
+    properties: ['openDirectory'],
+  });
+  return r.canceled || !r.filePaths.length ? null : r.filePaths[0];
+});
+
+ipcMain.handle('repoAgents:scan', (_e, payload = {}) => {
+  const root = String((payload && payload.root) || '').trim();
+  if (!root || !path.isAbsolute(root)) {
+    return { ok: false, error: 'absolute path required' };
+  }
+  try {
+    if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+      return { ok: false, error: 'directory does not exist' };
+    }
+    const agentsDir = path.join(root, 'agents');
+    const skillsDir = path.join(root, 'skills');
+    const copilotPath = path.join(root, '.github', 'copilot-instructions.md');
+    const existingProfileNames = new Set(
+      getProfiles().map((p) => String(p.name || '').toLowerCase())
+    );
+    const agents = [];
+    if (fs.existsSync(agentsDir) && fs.statSync(agentsDir).isDirectory()) {
+      for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+        try {
+          const fp = path.join(agentsDir, entry.name);
+          const text = fs.readFileSync(fp, 'utf8');
+          const parsed = parseAgentMd(text);
+          const name = (parsed.name || entry.name.replace(/\.md$/, '')).slice(0, 64);
+          agents.push({
+            filename: entry.name,
+            name,
+            description: (parsed.description || '').slice(0, 256),
+            bodyLength: (parsed.body || '').length,
+            alreadyInClaude: fs.existsSync(path.join(CLAUDE_DIR, 'agents', entry.name)),
+            alreadyImported: existingProfileNames.has(name.toLowerCase()),
+          });
+        } catch (_) {}
+      }
+      agents.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    let copilotPreview = null;
+    let copilotHasUserContent = false;
+    if (fs.existsSync(copilotPath)) {
+      try {
+        const existing = fs.readFileSync(copilotPath, 'utf8');
+        const startIdx = existing.indexOf(HUSK_AGENTS_START);
+        const endIdx = existing.indexOf(HUSK_AGENTS_END);
+        const userPart = startIdx >= 0 && endIdx > startIdx
+          ? (existing.slice(0, startIdx) + existing.slice(endIdx + HUSK_AGENTS_END.length))
+          : existing;
+        copilotHasUserContent = userPart.trim().length > 0;
+        copilotPreview = existing.slice(0, 400);
+      } catch (_) {}
+    }
+    return {
+      ok: true,
+      root,
+      agents,
+      hasSkillsDir: fs.existsSync(skillsDir) && fs.statSync(skillsDir).isDirectory(),
+      copilotInstructionsPath: copilotPath,
+      copilotInstructionsExists: fs.existsSync(copilotPath),
+      copilotHasUserContent,
+      copilotPreview,
+    };
+  } catch (err) { return { ok: false, error: err.message }; }
+});
+
+function renderHuskAgentsBlock(picked) {
+  // picked: [{ name, body }]
+  const lines = [
+    HUSK_AGENTS_START,
+    '<!-- Managed by Husk. Edits inside this block are overwritten on the',
+    '     next install-from-repo run. Edit content outside the markers freely. -->',
+    '',
+  ];
+  for (const item of picked) {
+    lines.push(`# Agent: ${item.name}`);
+    lines.push('');
+    lines.push(item.body.trim());
+    lines.push('');
+  }
+  lines.push(HUSK_AGENTS_END);
+  return lines.join('\n');
+}
+
+ipcMain.handle('repoAgents:install', (_e, payload = {}) => {
+  const root = String((payload && payload.root) || '').trim();
+  const picks = Array.isArray(payload && payload.picks) ? payload.picks : [];
+  const installToClaudeAgents = payload.installToClaudeAgents !== false;
+  const writeCopilotInstructions = payload.writeCopilotInstructions !== false;
+  const activate = !!payload.activate;
+  if (!root || !path.isAbsolute(root)) return { ok: false, error: 'absolute path required' };
+  if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
+    return { ok: false, error: 'directory does not exist' };
+  }
+  if (!picks.length) return { ok: false, error: 'nothing selected' };
+  const agentsDir = path.join(root, 'agents');
+  const claudeAgentsDir = path.join(CLAUDE_DIR, 'agents');
+  try { fs.mkdirSync(claudeAgentsDir, { recursive: true }); } catch (_) {}
+  const list = getProfiles().slice();
+  const importedIds = [];
+  const copiedToClaude = [];
+  const copilotBlocks = [];
+  for (const pick of picks) {
+    const fname = String((pick && pick.filename) || '');
+    if (!fname.endsWith('.md') || fname.includes('/') || fname.includes('\\') || fname.includes('..')) continue;
+    const src = path.join(agentsDir, fname);
+    if (!fs.existsSync(src)) continue;
+    try {
+      const text = fs.readFileSync(src, 'utf8');
+      const parsed = parseAgentMd(text);
+      const name = (parsed.name || fname.replace(/\.md$/, '')).slice(0, 64);
+      if (installToClaudeAgents) {
+        const dest = path.join(claudeAgentsDir, fname);
+        try { fs.copyFileSync(src, dest); copiedToClaude.push(dest); } catch (_) {}
+      }
+      if (writeCopilotInstructions) {
+        copilotBlocks.push({ name, body: parsed.body || '' });
+      }
+      const id = `profile-imp-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      list.push({
+        id,
+        name,
+        description: (parsed.description || '').slice(0, 256),
+        systemPrompt: (parsed.body || '').slice(0, 4096),
+        autoSelect: false,
+        builtin: false,
+        repoRoot: root,
+        sourceFilename: fname,
+      });
+      importedIds.push(id);
+    } catch (_) {}
+  }
+  let copilotInstructionsPath = null;
+  if (writeCopilotInstructions && copilotBlocks.length) {
+    try {
+      const dotGithub = path.join(root, '.github');
+      fs.mkdirSync(dotGithub, { recursive: true });
+      copilotInstructionsPath = path.join(dotGithub, 'copilot-instructions.md');
+      let existing = '';
+      try { existing = fs.readFileSync(copilotInstructionsPath, 'utf8'); } catch (_) {}
+      const startIdx = existing.indexOf(HUSK_AGENTS_START);
+      const endIdx = existing.indexOf(HUSK_AGENTS_END);
+      let before, after;
+      if (startIdx >= 0 && endIdx > startIdx) {
+        before = existing.slice(0, startIdx).replace(/\s+$/, '');
+        after = existing.slice(endIdx + HUSK_AGENTS_END.length).replace(/^\s+/, '');
+      } else {
+        before = existing.replace(/\s+$/, '');
+        after = '';
+      }
+      const block = renderHuskAgentsBlock(copilotBlocks);
+      const parts = [];
+      if (before) parts.push(before);
+      parts.push(block);
+      if (after) parts.push(after);
+      fs.writeFileSync(copilotInstructionsPath, parts.join('\n\n') + '\n', { mode: 0o644 });
+    } catch (err) {
+      // Surface the failure but do not abort the import — the Claude side
+      // and the Husk profiles still landed; the user can retry the Copilot
+      // write or paste the snippet manually.
+      return {
+        ok: true,
+        imported: importedIds.length,
+        importedIds,
+        copiedToClaude,
+        copilotInstructionsPath,
+        copilotWriteError: err.message,
+        partial: true,
+      };
+    }
+  }
+  let nextConfig = { ...config, profiles: list };
+  if (activate && importedIds.length) {
+    const prevActive = Array.isArray(config.activeProfileIds)
+      ? config.activeProfileIds
+      : (config.activeProfileId ? [config.activeProfileId] : []);
+    const active = prevActive.slice();
+    for (const id of importedIds) { if (!active.includes(id)) active.push(id); }
+    nextConfig = { ...nextConfig, activeProfileIds: active, activeProfileId: active[0] || null };
+  }
+  config = nextConfig;
+  try { fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), { mode: 0o600 }); } catch (_) {}
+  return {
+    ok: true,
+    imported: importedIds.length,
+    importedIds,
+    copiedToClaude,
+    copilotInstructionsPath,
+  };
 });
 
 ipcMain.handle('profiles:create', (_e, payload = {}) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -87,6 +87,11 @@ contextBridge.exposeInMainWorld('husk', {
     listImportableAgents: () => ipcRenderer.invoke('profiles:listImportableAgents'),
     importAgents: (picks, activate) => ipcRenderer.invoke('profiles:importAgents', { picks, activate: !!activate }),
   },
+  repoAgents: {
+    pickDir: () => ipcRenderer.invoke('repoAgents:pickDir'),
+    scan: (root) => ipcRenderer.invoke('repoAgents:scan', { root }),
+    install: (opts) => ipcRenderer.invoke('repoAgents:install', opts || {}),
+  },
   mcp: {
     catalog: () => ipcRenderer.invoke('mcp:catalog'),
     list: () => ipcRenderer.invoke('mcp:list'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1373,6 +1373,7 @@ function paintAgents() {
         ${p.builtin ? '<span class="agent-card-builtin">Built-in</span>' : ''}
       </div>
       ${p.description ? `<div class="agent-card-desc">${escapeHtml(p.description)}</div>` : ''}
+      ${p.repoRoot ? `<div class="agent-card-repo" title="${escapeAttr(p.repoRoot)}">cwd: ${escapeHtml(p.repoRoot.replace(/^\/home\/[^/]+/, '~'))}</div>` : ''}
       ${p.systemPrompt ? `<div class="agent-card-prompt">${escapeHtml(p.systemPrompt)}</div>` : ''}
     </div>
   `;
@@ -1662,6 +1663,176 @@ $('#ai-close') && $('#ai-close').addEventListener('click', closeAgentsImportModa
 $('#ai-cancel') && $('#ai-cancel').addEventListener('click', closeAgentsImportModal);
 $('#ai-confirm') && $('#ai-confirm').addEventListener('click', confirmAgentsImport);
 $('#agents-import-modal') && $('#agents-import-modal').addEventListener('click', (e) => { if (e.target === $('#agents-import-modal')) closeAgentsImportModal(); });
+
+// ─── Install agents from a cloned repo ───────────────────────────────────────────
+// The repo is expected to ship agents/*.md (Claude-style frontmatter) and
+// optionally skills/*.md. Husk copies each picked agent to ~/.claude/agents/
+// (Claude path), writes the body into <repo>/.github/copilot-instructions.md
+// inside HUSK-AGENTS markers (Copilot path), and stamps the resulting Husk
+// profile with repoRoot. spawnPty consumes repoRoot as the cwd, so the agent's
+// relative skills/<test_id>.md reads resolve when the chat launches.
+let lastRepoScan = null;
+function openRepoAgentsModal() {
+  const modal = $('#repo-agents-modal');
+  if (!modal) return;
+  if ($('#ra-root')) $('#ra-root').value = '';
+  if ($('#ra-list')) $('#ra-list').innerHTML = '';
+  const status = $('#ra-status');
+  if (status) { status.hidden = true; status.textContent = ''; status.className = 'ra-status'; }
+  const confirmBtn = $('#ra-confirm');
+  if (confirmBtn) { confirmBtn.disabled = true; confirmBtn.textContent = 'Install 0 agents'; }
+  if ($('#ra-claude')) $('#ra-claude').checked = true;
+  if ($('#ra-copilot')) $('#ra-copilot').checked = true;
+  if ($('#ra-activate')) $('#ra-activate').checked = true;
+  lastRepoScan = null;
+  modal.hidden = false;
+  setTimeout(() => { try { $('#ra-root').focus(); } catch (_) {} }, 0);
+}
+function closeRepoAgentsModal() {
+  const m = $('#repo-agents-modal');
+  if (m) m.hidden = true;
+}
+function setRepoStatus(text, kind) {
+  const el = $('#ra-status');
+  if (!el) return;
+  if (!text) { el.hidden = true; el.textContent = ''; el.className = 'ra-status'; return; }
+  el.hidden = false;
+  el.textContent = text;
+  el.className = 'ra-status' + (kind ? ' ra-status-' + kind : '');
+}
+async function browseForRepoRoot() {
+  const picked = await window.husk.repoAgents.pickDir();
+  if (!picked) return;
+  if ($('#ra-root')) $('#ra-root').value = picked;
+  await scanRepoRoot(picked);
+}
+async function scanRepoRoot(root) {
+  const listEl = $('#ra-list');
+  const confirmBtn = $('#ra-confirm');
+  if (!listEl || !confirmBtn) return;
+  setRepoStatus('Scanning…');
+  // eslint-disable-next-line no-unsanitized/property -- static loading placeholder
+  listEl.innerHTML = `<div class="ai-empty">Looking for agents/*.md…</div>`;
+  confirmBtn.disabled = true;
+  confirmBtn.textContent = 'Install 0 agents';
+  const res = await window.husk.repoAgents.scan(root);
+  if (!res || !res.ok) {
+    setRepoStatus(res && res.error ? res.error : 'Scan failed', 'error');
+    // eslint-disable-next-line no-unsanitized/property -- error from local fs read, no html
+    listEl.innerHTML = `<div class="ai-empty">${escapeHtml((res && res.error) || 'Could not scan that folder')}</div>`;
+    lastRepoScan = null;
+    return;
+  }
+  lastRepoScan = res;
+  const skillsNote = res.hasSkillsDir
+    ? `Found <code>${escapeHtml(root.replace(/\/+$/, ''))}/skills/</code> — agents that read <code>skills/&lt;id&gt;.md</code> will work after install.`
+    : `No <code>skills/</code> directory at this root. Agents will install but any <code>skills/&lt;id&gt;.md</code> read will fail until you add one.`;
+  const copilotNote = res.copilotInstructionsExists
+    ? (res.copilotHasUserContent
+        ? `<code>.github/copilot-instructions.md</code> already exists with content. Husk only modifies the HUSK-AGENTS block; everything outside is preserved.`
+        : `<code>.github/copilot-instructions.md</code> already exists but is effectively empty. Husk will rewrite the HUSK-AGENTS block.`)
+    : `<code>.github/copilot-instructions.md</code> will be created.`;
+  // eslint-disable-next-line no-unsanitized/property -- both branches use escapeHtml on dynamic parts
+  setRepoStatus('');
+  const statusEl = $('#ra-status');
+  if (statusEl) {
+    statusEl.hidden = false;
+    statusEl.className = 'ra-status ra-status-info';
+    // eslint-disable-next-line no-unsanitized/property -- static + escapeHtml above
+    statusEl.innerHTML = `<div>${skillsNote}</div><div>${copilotNote}</div>`;
+  }
+  if (!res.agents.length) {
+    // eslint-disable-next-line no-unsanitized/property -- static html
+    listEl.innerHTML = `<div class="ai-empty">No <code>agents/*.md</code> files in that folder.</div>`;
+    return;
+  }
+  const checkIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>`;
+  // eslint-disable-next-line no-unsanitized/property -- every interpolation escaped
+  listEl.innerHTML = res.agents.map((a) => {
+    const pill = a.alreadyImported
+      ? `<span class="ai-row-pill">Already imported</span>`
+      : (a.alreadyInClaude ? `<span class="ai-row-source">in ~/.claude/agents</span>` : '');
+    if (a.alreadyImported) {
+      return `
+        <div class="ai-row-done">
+          <span class="ai-check-box-done" aria-hidden="true">${checkIcon}</span>
+          <div class="ai-row-body">
+            <div class="ai-row-name">${escapeHtml(a.name)}<span class="ai-row-source">${escapeHtml(a.filename)}</span></div>
+            ${a.description ? `<div class="ai-row-desc">${escapeHtml(a.description)}</div>` : ''}
+          </div>
+          ${pill}
+        </div>
+      `;
+    }
+    return `
+      <label class="ai-row">
+        <input type="checkbox" class="ai-check ra-pick" data-file="${escapeAttr(a.filename)}" />
+        <span class="ai-check-box" aria-hidden="true"></span>
+        <div class="ai-row-body">
+          <div class="ai-row-name">${escapeHtml(a.name)}<span class="ai-row-source">${escapeHtml(a.filename)}</span></div>
+          ${a.description ? `<div class="ai-row-desc">${escapeHtml(a.description)}</div>` : ''}
+        </div>
+        ${pill}
+      </label>
+    `;
+  }).join('');
+  const updateCount = () => {
+    const n = listEl.querySelectorAll('.ra-pick:checked').length;
+    confirmBtn.disabled = n === 0;
+    confirmBtn.textContent = `Install ${n} agent${n !== 1 ? 's' : ''}`;
+  };
+  listEl.querySelectorAll('.ra-pick').forEach((el) => el.addEventListener('change', updateCount));
+  updateCount();
+}
+async function confirmRepoAgentsInstall() {
+  if (!lastRepoScan || !lastRepoScan.ok) return;
+  const root = lastRepoScan.root;
+  const listEl = $('#ra-list');
+  if (!listEl) return;
+  const picks = Array.from(listEl.querySelectorAll('.ra-pick:checked')).map((el) => ({ filename: el.dataset.file }));
+  if (!picks.length) return;
+  const btn = $('#ra-confirm');
+  if (btn) { btn.disabled = true; btn.textContent = 'Installing…'; }
+  const installToClaudeAgents = !!($('#ra-claude') && $('#ra-claude').checked);
+  const writeCopilotInstructions = !!($('#ra-copilot') && $('#ra-copilot').checked);
+  const activate = !!($('#ra-activate') && $('#ra-activate').checked);
+  const res = await window.husk.repoAgents.install({
+    root, picks, installToClaudeAgents, writeCopilotInstructions, activate,
+  });
+  if (!res || !res.ok) {
+    toast((res && res.error) || 'Install failed', 'error');
+    if (btn) btn.disabled = false;
+    return;
+  }
+  if (res.copilotWriteError) {
+    toast(`Imported ${res.imported}, but Copilot instructions write failed: ${res.copilotWriteError}`, 'error');
+  } else {
+    const parts = [`Installed ${res.imported} agent${res.imported !== 1 ? 's' : ''}`];
+    if (installToClaudeAgents && res.copiedToClaude && res.copiedToClaude.length) parts.push(`copied to ~/.claude/agents/`);
+    if (writeCopilotInstructions && res.copilotInstructionsPath) parts.push(`Copilot instructions written`);
+    if (activate) parts.push('activated');
+    toast(parts.join(' · '), 'success');
+  }
+  closeRepoAgentsModal();
+  profilesCache = await window.husk.profiles.list();
+  if (activate) cfg = await window.husk.config.get();
+  paintAgents();
+  updateAgentBanner();
+  updateActiveChatProfile();
+}
+$('#btn-install-from-repo') && $('#btn-install-from-repo').addEventListener('click', openRepoAgentsModal);
+$('#ra-close') && $('#ra-close').addEventListener('click', closeRepoAgentsModal);
+$('#ra-cancel') && $('#ra-cancel').addEventListener('click', closeRepoAgentsModal);
+$('#ra-browse') && $('#ra-browse').addEventListener('click', browseForRepoRoot);
+$('#ra-confirm') && $('#ra-confirm').addEventListener('click', confirmRepoAgentsInstall);
+$('#ra-root') && $('#ra-root').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    const v = ($('#ra-root').value || '').trim();
+    if (v) scanRepoRoot(v);
+  }
+});
+$('#repo-agents-modal') && $('#repo-agents-modal').addEventListener('click', (e) => { if (e.target === $('#repo-agents-modal')) closeRepoAgentsModal(); });
 $('#agent-modal-close') && $('#agent-modal-close').addEventListener('click', closeAgentModal);
 $('#agent-modal-cancel') && $('#agent-modal-cancel').addEventListener('click', closeAgentModal);
 $('#agent-modal-save') && $('#agent-modal-save').addEventListener('click', saveAgentModal);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -71,15 +71,8 @@
 
     <!-- Topbar -->
     <header id="topbar">
-      <button class="topbar-sidebar-btn" id="rail-toggle" title="Toggle sidebar" aria-label="Toggle sidebar">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="3" y="4" width="18" height="16" rx="2.5"/>
-          <line x1="9" y1="4" x2="9" y2="20"/>
-        </svg>
-      </button>
       <div class="brand">
         <img class="logo-img" src="assets/husk-logo.png" alt="Husk" />
-        <span class="brand-text">HUSK</span>
       </div>
       <button class="topbar-project" id="topbar-project" title="Active project (click to switch)" hidden>
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/></svg>
@@ -97,6 +90,15 @@
     <!-- Main: rail + page area -->
     <main id="main">
       <aside id="rail" class="rail">
+
+        <!-- Sidebar collapse / expand. Right-aligned when expanded, centered when collapsed. -->
+        <div class="rail-top">
+          <button class="rail-toggle-btn" id="rail-toggle" title="Toggle sidebar" aria-label="Toggle sidebar">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M15 18l-6-6 6-6"/>
+            </svg>
+          </button>
+        </div>
 
         <!-- Tool selector: which CLI is active. No section label to avoid confusing with LLM "agents". -->
         <div class="rail-section rail-section-tool">
@@ -369,6 +371,10 @@
               <span class="page-sub">saved configurations that shape how the AI works for a task</span>
             </div>
             <div class="page-head-right">
+              <button class="ghost-btn" id="btn-install-from-repo" title="Install an agent pack from a cloned repo">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/><path d="M12 11v6M9 14l3 3 3-3"/></svg>
+                Install from repo
+              </button>
               <button class="ghost-btn" id="btn-import-agents">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M5 19h14"/></svg>
                 Import
@@ -408,6 +414,44 @@
               </label>
               <button class="ghost-btn" id="ai-cancel">Cancel</button>
               <button class="btn-primary" id="ai-confirm" disabled>Import 0 agents</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- INSTALL AGENTS FROM REPO MODAL -->
+        <div id="repo-agents-modal" class="modal" hidden>
+          <div class="modal-card modal-card-md">
+            <div class="modal-head">
+              <h2 class="modal-title">Install agent pack from repo</h2>
+              <button class="modal-close" id="ra-close" aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+              <p class="ra-hint">Point Husk at a cloned repo (e.g. <code>support-ai-suite</code>) that ships an <code>agents/</code> directory. Picked agents are copied to <code>~/.claude/agents/</code> for Claude Code and written into <code>.github/copilot-instructions.md</code> for GitHub Copilot. Each Husk profile is stamped with the repo path so the active CLI launches there — that's what makes the agent's relative <code>skills/&lt;test_id&gt;.md</code> reads resolve.</p>
+              <div class="ra-pathrow">
+                <input type="text" id="ra-root" class="ra-root" placeholder="/path/to/agent-pack-repo" autocomplete="off" spellcheck="false" />
+                <button class="ghost-btn" id="ra-browse">Browse…</button>
+              </div>
+              <div id="ra-status" class="ra-status" hidden></div>
+              <div id="ra-list" class="ai-list"></div>
+            </div>
+            <div class="modal-foot ra-foot">
+              <label class="ai-foot-toggle" title="Copy each picked agent file to ~/.claude/agents/ so Claude Code picks them up natively">
+                <input type="checkbox" id="ra-claude" class="ai-check" checked />
+                <span class="ai-check-box" aria-hidden="true"></span>
+                Copy to ~/.claude/agents/
+              </label>
+              <label class="ai-foot-toggle" title="Write the agent bodies into .github/copilot-instructions.md inside HUSK-AGENTS markers (existing content outside the markers is preserved)">
+                <input type="checkbox" id="ra-copilot" class="ai-check" checked />
+                <span class="ai-check-box" aria-hidden="true"></span>
+                Write Copilot instructions
+              </label>
+              <label class="ai-foot-toggle" title="Activate imported agents for the next chat session">
+                <input type="checkbox" id="ra-activate" class="ai-check" checked />
+                <span class="ai-check-box" aria-hidden="true"></span>
+                Activate after install
+              </label>
+              <button class="ghost-btn" id="ra-cancel">Cancel</button>
+              <button class="btn-primary" id="ra-confirm" disabled>Install 0 agents</button>
             </div>
           </div>
         </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -197,39 +197,21 @@ body {
 
 #topbar {
   display: flex; align-items: center; gap: 14px;
-  padding: 0 14px 0 10px;
+  /* Left padding lands the 40px logo's horizontal center at x=36px, which
+     is the center of the collapsed rail's 72px column (16 + 20 = 36). The
+     logo column therefore reads as a continuation of the rail when collapsed. */
+  padding: 0 14px 0 16px;
   border-bottom: 1px solid var(--line);
   background: var(--bg);
   box-shadow: var(--hl-top);
   -webkit-app-region: drag;
 }
-.topbar-sidebar-btn {
-  -webkit-app-region: no-drag;
-  width: 32px; height: 32px; flex: 0 0 auto;
-  background: transparent; border: 0;
-  border-radius: var(--radius-md);
-  color: var(--text-3); cursor: pointer;
-  display: inline-flex; align-items: center; justify-content: center;
-  transition: background var(--motion-fast) var(--ease), color var(--motion-fast) var(--ease);
-}
-.topbar-sidebar-btn svg { width: 17px; height: 17px; display: block; }
-.topbar-sidebar-btn:hover { background: var(--bg-2); color: var(--text); }
-body[data-rail="collapsed"] .topbar-sidebar-btn { color: var(--text-2); }
-.brand { display: flex; align-items: center; gap: 12px; -webkit-app-region: no-drag; }
+.brand { display: flex; align-items: center; -webkit-app-region: no-drag; }
 .logo-img {
-  width: 26px; height: 26px;
+  width: 40px; height: 40px;
   display: block;
   user-select: none;
   -webkit-user-drag: none;
-}
-.brand-text {
-  font-family: 'Titan One', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-weight: 400;
-  font-size: 22px;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: var(--accent);
 }
 .topbar-spacer { flex: 1; -webkit-app-region: drag; min-height: 32px; }
 
@@ -383,10 +365,30 @@ body[data-rail="expanded"] .rail { width: 220px; }
   pointer-events: none;
   opacity: 0.9;
 }
-/* Inline sidebar-toggle button. Sits inside the rail, top-right, looks like
-   a proper sidebar icon (Notion / Linear convention). Replaces the floating
-   off-rail circle that read as a UI artifact. */
-/* rail-top removed - toggle lives in #topbar as .topbar-sidebar-btn */
+/* Sidebar collapse / expand control. Sits at the top of the rail itself
+   (Notion / Linear / Twitch convention) instead of in the topbar. Right-aligned
+   while expanded, centered when collapsed so it always sits inside the column. */
+.rail-top {
+  display: flex;
+  padding: 0 4px 8px;
+  min-height: 32px;
+}
+body[data-rail="expanded"] .rail-top { justify-content: flex-end; }
+body[data-rail="collapsed"] .rail-top { justify-content: center; padding: 0 0 8px; }
+.rail-toggle-btn {
+  width: 32px; height: 32px;
+  background: transparent; border: 0;
+  border-radius: var(--radius-md);
+  color: var(--text-3); cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background var(--motion-fast) var(--ease), color var(--motion-fast) var(--ease);
+}
+.rail-toggle-btn:hover { background: var(--bg-2); color: var(--text); }
+.rail-toggle-btn svg {
+  width: 18px; height: 18px; display: block;
+  transition: transform var(--motion-base) var(--ease);
+}
+body[data-rail="collapsed"] .rail-toggle-btn svg { transform: rotate(180deg); }
 .rail-nav { display: flex; flex-direction: column; gap: 2px; }
 .rail-spacer { flex: 1; }
 .rail-item {
@@ -1566,6 +1568,52 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   white-space: nowrap;
 }
 
+/* Install-agents-from-repo modal: path row + status banner. */
+.ra-hint {
+  font-size: 12.5px; color: var(--text-2);
+  line-height: 1.55; margin: 0 0 12px;
+}
+.ra-hint code {
+  font-family: 'JetBrains Mono', monospace; font-size: 11.5px;
+  padding: 1px 5px; border-radius: 4px;
+  background: var(--bg-2); color: var(--text);
+}
+.ra-pathrow {
+  display: flex; gap: 8px; align-items: stretch;
+  margin-bottom: 10px;
+}
+.ra-root {
+  flex: 1;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font-family: 'JetBrains Mono', monospace; font-size: 12px;
+  padding: 8px 10px;
+  outline: 0;
+  transition: border-color 0.12s var(--ease);
+}
+.ra-root:focus { border-color: var(--accent); }
+.ra-status {
+  font-size: 12px; line-height: 1.5;
+  padding: 8px 10px; border-radius: var(--radius-md);
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  color: var(--text-2);
+  margin-bottom: 10px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.ra-status code {
+  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  padding: 1px 4px; border-radius: 3px;
+  background: var(--bg-3); color: var(--text);
+}
+.ra-status.ra-status-info { border-left: 3px solid var(--accent); }
+.ra-status.ra-status-error { border-left: 3px solid var(--rose); color: var(--text); }
+/* The footer of the repo-install modal has three toggles + two buttons —
+   let it wrap on narrow window widths rather than stretching off-screen. */
+.modal-foot.ra-foot { flex-wrap: wrap; gap: 10px; }
+
 /* Active-for-next-session banner with one chip per active agent. */
 .agents-active-banner {
   display: flex; align-items: center; gap: 16px;
@@ -1679,6 +1727,20 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
   overflow: hidden;
   margin: 0;
+}
+/* Repo binding: shown only when the profile was install-from-repo. Conveys
+   "this agent's relative paths resolve against this directory" — that is
+   what spawnPty actually does with the repoRoot field. */
+.agent-card-repo {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px; color: var(--text-3);
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  align-self: flex-start;
+  max-width: 100%;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 /* Prompt preview: muted italic, 2-line clamp. */
 .agent-card-prompt {
@@ -3135,7 +3197,6 @@ kbd {
     box-shadow: var(--shadow);
   }
   .topbar-spacer { min-height: 32px; }
-  .brand-text { font-size: 26px; }
 }
 
 /* Print: should never happen in this app but kill animations defensively. */


### PR DESCRIPTION
## Summary

Sync `main` with `development`. One commit:

- **feat(agents): install agent pack from a cloned repo.** New "Install from repo" button on the Agents page. Pick a cloned agent-pack repo (e.g. `support-ai-suite`), select which `agents/*.md` to install, and Husk does three things, each individually toggleable: (1) copies each picked `.md` to `~/.claude/agents/` so Claude Code picks it up as a subagent natively, (2) writes each body into `<root>/.github/copilot-instructions.md` inside `HUSK-AGENTS` markers (existing content outside the markers is preserved) so GitHub Copilot CLI picks it up natively, (3) creates a Husk profile per pick stamped with `repoRoot` + `sourceFilename`. `spawnPty` now consumes the active profile's `repoRoot` as the working directory, so the launched CLI runs inside the repo and the agent's relative `skills/<id>.md` reads resolve. New IPCs: `repoAgents:pickDir` / `repoAgents:scan` / `repoAgents:install`, surfaced as `window.husk.repoAgents`. Agent cards show a small repo chip when `repoRoot` is set.
- **sidebar polish.** HUSK wordmark removed from the topbar (logo only, 40 px, shifted right so its center lands on the collapsed rail column center at x=36). Collapse/expand toggle moved out of the topbar into a new `rail-top` row at the top of the rail itself — right-aligned when expanded, centered when collapsed, single chevron that rotates 180° via CSS keyed off `body[data-rail]`. `id="rail-toggle"` kept so the existing click handler still wires up untouched.

## Test plan

- [x] `node --check` on every edited JS file (main, preload, renderer)
- [x] Install flow walked end-to-end against `support-ai-suite`: picked bappsec-agent → file landed in `~/.claude/agents/`, instructions block landed in `.github/copilot-instructions.md` inside markers with pre-existing content preserved, Husk profile created with `repoRoot` set
- [x] Activating the imported profile and starting a chat launches the CLI with cwd = repoRoot so `skills/<id>.md` resolves
- [x] Sidebar collapse/expand still works; toggle position matches reference; logo center sits on the collapsed-column center