### PR TITLE
release: preference toggle to enable/disable PAI

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -106,6 +106,12 @@ const DEFAULT_CONFIG = {
   voice: { enabled: false, name: 'en_US-amy-medium', rate: 1.0 },
   skipWelcome: false,
   recap: true,
+  // PAI is the bundled Claude-Code-only assistant framework Husk drops into
+  // ~/.claude/. Defaults to enabled so existing Claude users get it on
+  // first run, but Copilot-only users can switch it off to skip the
+  // bootstrap, kill the statusline tick, and drop the PAI/Algorithm
+  // reference from the Husk identity prompt.
+  paiEnabled: true,
   profiles: DEFAULT_PROFILES,
   activeProfileId: null,
 };
@@ -164,6 +170,9 @@ function refreshStatuslineCacheOnce() {
 }
 function startStatuslineRefresh() {
   if (statuslineTimer) return;
+  // statusline-command.sh is PAI's status feeder. Skip the tick entirely
+  // when the user has disabled PAI — no script, no caches, no need to run.
+  if (config.paiEnabled === false) return;
   // Kick off once on startup, then every 30s.
   refreshStatuslineCacheOnce();
   statuslineTimer = setInterval(refreshStatuslineCacheOnce, 30000);
@@ -328,6 +337,11 @@ function bootstrapHuskPromptsIfNeeded() {
 }
 
 function bootstrapPaiIfNeeded() {
+  // Hard opt-out: when the user has disabled PAI in Preferences, we do not
+  // touch ~/.claude/ on launch. Pre-existing files stay where they are
+  // (Husk never removes user files behind their back); the user can clean
+  // ~/.claude/{PAI,agents,skills,hooks}/ manually if they want.
+  if (config.paiEnabled === false) return;
   try {
     const claudeDir = path.join(HOME, '.claude');
 
@@ -551,9 +565,20 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
     // panel. Acceptable duplication, the user gets persistent trust,
     // skill-listing budget reverts to the claude default.
     const agentName = (config.agentName || 'Husk').replace(/[^A-Za-z0-9 _-]/g, '').slice(0, 40) || 'Husk';
-    const huskPromptParts = [
-      `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (not Atlas, not PAI, not Assistant). Use "🗣️ ${agentName}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
-    ];
+    // When PAI is enabled, point the model at PAI/Algorithm and the
+    // banner/TASK/CHANGE/VERIFY/recap conventions PAI's CLAUDE.md sets up.
+    // When PAI is off, keep only the lightweight Husk identity sentence and
+    // let claude follow its own (un-PAI) CLAUDE.md without our nudge.
+    const huskPromptParts = [];
+    if (config.paiEnabled === false) {
+      huskPromptParts.push(
+        `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (not Atlas, not Assistant). Use "🗣️ ${agentName}:" if you emit a speech-balloon line.`,
+      );
+    } else {
+      huskPromptParts.push(
+        `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (not Atlas, not PAI, not Assistant). Use "🗣️ ${agentName}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
+      );
+    }
     if (config.recap === false) {
       huskPromptParts.push(`The user has disabled recaps in Husk. Suppress any "* recap:" line and end-of-response summary footer for this session.`);
     }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -2484,6 +2484,7 @@ function bindPrefs() {
   $('#pref-agent-name').value = cfg.agentName || 'Husk';
   if ($('#pref-agent-cwd')) $('#pref-agent-cwd').value = cfg.agentCwd || '';
   $('#pref-recap').checked = cfg.recap !== false;
+  if ($('#pref-pai')) $('#pref-pai').checked = cfg.paiEnabled !== false;
   $('#pref-theme').value = cfg.theme || 'dark';
   $('#pref-rail').checked = !!cfg.railExpanded;
   $('#pref-root').value = cfg.treeRoot || '';
@@ -2745,6 +2746,13 @@ $('#pref-hidden').addEventListener('change', async (e) => {
 $('#pref-recap').addEventListener('change', async (e) => {
   cfg = await window.husk.config.set({ recap: e.target.checked });
   toast(`Recap ${cfg.recap ? 'enabled' : 'disabled'} · restart agent to apply`, 'success');
+});
+$('#pref-pai') && $('#pref-pai').addEventListener('change', async (e) => {
+  cfg = await window.husk.config.set({ paiEnabled: e.target.checked });
+  const msg = cfg.paiEnabled
+    ? 'PAI enabled · restart Husk to bootstrap, restart agent to load it'
+    : 'PAI disabled · restart agent to drop the PAI prompt; existing ~/.claude/ files left in place';
+  toast(msg, 'success');
 });
 
 // ─── Update pill (topbar) ───────────────────────────────────────────────────────

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -726,6 +726,17 @@
             </section>
 
             <section class="pref-card">
+              <div class="pref-card-title">PAI</div>
+              <label class="pref-row">
+                <span class="pref-label">Enable PAI (Personal AI Infrastructure)</span>
+                <input type="checkbox" id="pref-pai" />
+              </label>
+              <div class="pref-hint">
+                PAI is the Claude Code framework Husk bundles in <code>libs/pai/</code>: skills, agents, hooks, statusline, and the Algorithm flow. Only Claude Code reads it (Copilot does not). With this off, Husk skips the bootstrap into <code>~/.claude/</code>, stops the statusline tick, and drops the PAI/Algorithm nudge from the Husk identity prompt. Pre-existing files in <code>~/.claude/</code> are left untouched — remove them by hand if you want a clean slate. Restart the agent after changing.
+              </div>
+            </section>
+
+            <section class="pref-card">
               <div class="pref-card-title">Appearance</div>
               <label class="pref-row">
                 <span class="pref-label">Theme</span>


### PR DESCRIPTION
## Summary

Sync `main` with `development`. Single commit.

- **feat(pai): preference toggle to enable/disable PAI.** PAI is the Claude-Code-only framework Husk currently always bootstraps into `~/.claude/`, ticks a statusline timer for, and nudges the model toward in the Husk identity prompt. Copilot does not use any of it, so users who work primarily in Copilot end up with a populated `~/.claude/` tree and an identity prompt referencing a framework that never runs. A new Preferences toggle ("PAI → Enable PAI (Personal AI Infrastructure)") persists `paiEnabled` in `config.json`. Default is `true` so existing installs are unaffected. When set to `false`:
  - `bootstrapPaiIfNeeded()` is a no-op (no copy into `~/.claude/`).
  - `startStatuslineRefresh()` is a no-op (no statusline tick).
  - The Husk identity prompt drops the `PAI/Algorithm` + banner/recap reference and keeps only the lightweight identity sentence.

Pre-existing files under `~/.claude/` are not removed on disable — that is the user's tree to manage, never ours to delete behind their back. The hint under the toggle calls that out.

## Test plan

- [x] `node --check` on edited renderer + main files
- [x] Default config still serializes `paiEnabled: true`; existing installs without the field treat it as enabled
- [x] Toggling off → restarting agent: claude session no longer receives the PAI/Algorithm system-prompt nudge
- [x] Toggling off → restarting Husk: no statusline tick, no new files written under `~/.claude/`
- [x] Toggling back on: bootstrap re-runs on next launch and re-deploys missing pieces