### PR TITLE
release: sync development into main after history rewrite

### DIFF
--- a/src/lib/pai-state.js
+++ b/src/lib/pai-state.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// Pure / fs-only helpers that drive the PAI toggle and the
+// install-from-repo flow. Extracted out of main.js so they can be unit-
+// tested without spinning up Electron. main.js delegates here.
+
+const fs = require('fs');
+const path = require('path');
+
+const PARKED_BASENAME = 'CLAUDE.md.husk-disabled';
+const HUSK_AGENTS_START = '<!-- HUSK-AGENTS:START -->';
+const HUSK_AGENTS_END = '<!-- HUSK-AGENTS:END -->';
+
+// Where the parked CLAUDE.md lives under a given ~/.claude/ root.
+// Useful for the test suite and for any future code that needs to know
+// the rename target without hard-coding the basename.
+function parkedPath(claudeDir) {
+  return path.join(claudeDir, PARKED_BASENAME);
+}
+
+// Rename ~/.claude/CLAUDE.md to/from the parked sibling based on whether
+// PAI is supposed to be active. Renames only — never deletes. All four
+// presence combinations are handled deliberately:
+//
+//   active=false, live present, parked absent  → rename live → parked
+//   active=false, live present, parked present → leave both alone
+//   active=false, live absent                  → no-op
+//   active=true,  parked present, live absent  → rename parked → live
+//   active=true,  parked present, live present → leave both alone
+//   active=true,  parked absent                → no-op
+//
+// The "leave both alone" cases protect a user-edited file from being
+// silently overwritten. The caller can surface a toast if needed.
+function applyPaiState(claudeDir, active) {
+  if (typeof claudeDir !== 'string' || !claudeDir) {
+    throw new TypeError('applyPaiState: claudeDir must be a non-empty string');
+  }
+  const live = path.join(claudeDir, 'CLAUDE.md');
+  const parked = parkedPath(claudeDir);
+  try {
+    if (!active) {
+      if (fs.existsSync(live) && !fs.existsSync(parked)) {
+        fs.renameSync(live, parked);
+      }
+    } else {
+      if (fs.existsSync(parked) && !fs.existsSync(live)) {
+        fs.renameSync(parked, live);
+      }
+    }
+  } catch (_) {
+    // Swallow — same behavior the inline version had. Surfacing an
+    // exception here would crash startup; the caller logs separately.
+  }
+}
+
+// Build the --append-system-prompt that the Claude branch of spawnPty
+// passes when launching the CLI. Pure function so the test suite can
+// hit every branch without spawning anything.
+function buildHuskPrompt({ agentName, paiEnabled, recap } = {}) {
+  const cleanName = (typeof agentName === 'string' ? agentName : '')
+    .replace(/[^A-Za-z0-9 _-]/g, '')
+    .slice(0, 40);
+  const name = cleanName || 'Husk';
+  const parts = [];
+  if (paiEnabled === false) {
+    parts.push(
+      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name} (no other persona). Use "🗣️ ${name}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats — this Husk instruction overrides them.`,
+    );
+  } else {
+    parts.push(
+      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name} (no other persona). Use "🗣️ ${name}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
+    );
+  }
+  if (recap === false) {
+    parts.push(`The user has disabled recaps in Husk. Suppress any "* recap:" line and end-of-response summary footer for this session.`);
+  }
+  return parts.join(' ');
+}
+
+// Render the HUSK-AGENTS block that ends up inside the user's
+// .github/copilot-instructions.md. Stand-alone so the test suite can
+// assert the exact shape (markers present, agent headers correct).
+function renderHuskAgentsBlock(picked) {
+  const lines = [
+    HUSK_AGENTS_START,
+    '<!-- Managed by Husk. Edits inside this block are overwritten on the',
+    '     next install-from-repo run. Edit content outside the markers freely. -->',
+    '',
+  ];
+  for (const item of picked || []) {
+    lines.push(`# Agent: ${item.name}`);
+    lines.push('');
+    lines.push(String(item.body || '').trim());
+    lines.push('');
+  }
+  lines.push(HUSK_AGENTS_END);
+  return lines.join('\n');
+}
+
+// Merge a fresh HUSK-AGENTS block into an existing copilot-instructions
+// document. Three cases:
+//   - file has START + END markers → replace the marked region in place
+//   - file lacks markers (or has malformed ones) → append the block
+//   - file is empty / missing → block is the entire output
+// Always leaves content outside the markers untouched.
+function mergeHuskAgentsBlock(existingText, picked) {
+  const existing = typeof existingText === 'string' ? existingText : '';
+  const block = renderHuskAgentsBlock(picked);
+  const startIdx = existing.indexOf(HUSK_AGENTS_START);
+  const endIdx = existing.indexOf(HUSK_AGENTS_END);
+  let before;
+  let after;
+  if (startIdx >= 0 && endIdx > startIdx) {
+    before = existing.slice(0, startIdx).replace(/\s+$/, '');
+    after = existing.slice(endIdx + HUSK_AGENTS_END.length).replace(/^\s+/, '');
+  } else {
+    before = existing.replace(/\s+$/, '');
+    after = '';
+  }
+  const parts = [];
+  if (before) parts.push(before);
+  parts.push(block);
+  if (after) parts.push(after);
+  return parts.join('\n\n') + '\n';
+}
+
+module.exports = {
+  PARKED_BASENAME,
+  HUSK_AGENTS_START,
+  HUSK_AGENTS_END,
+  parkedPath,
+  applyPaiState,
+  buildHuskPrompt,
+  renderHuskAgentsBlock,
+  mergeHuskAgentsBlock,
+};

--- a/src/lib/pai-state.js
+++ b/src/lib/pai-state.js
@@ -64,11 +64,11 @@ function buildHuskPrompt({ agentName, paiEnabled, recap } = {}) {
   const parts = [];
   if (paiEnabled === false) {
     parts.push(
-      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name} (no other persona). Use "🗣️ ${name}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats. This Husk instruction overrides them.`,
+      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name}, regardless of any other persona named in your memory files or CLAUDE.md. Use "🗣️ ${name}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats. This Husk instruction overrides them.`,
     );
   } else {
     parts.push(
-      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name} (no other persona). Use "🗣️ ${name}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
+      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name}, regardless of any other persona named in your memory files or CLAUDE.md. Use "🗣️ ${name}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
     );
   }
   if (recap === false) {

--- a/src/lib/pai-state.js
+++ b/src/lib/pai-state.js
@@ -35,15 +35,25 @@ function applyPaiState(claudeDir, active) {
   if (typeof claudeDir !== 'string' || !claudeDir) {
     throw new TypeError('applyPaiState: claudeDir must be a non-empty string');
   }
+  // live and parked are derived from the caller-supplied claudeDir using
+  // path.join + a hard-coded basename, so the targets are bounded to two
+  // specific filenames inside the given directory. The eslint-disable
+  // lines below acknowledge the dynamic-path warning the security plugin
+  // raises: this function intentionally operates on user-supplied paths
+  // (the user's ~/.claude/ directory) and the inputs are validated above.
   const live = path.join(claudeDir, 'CLAUDE.md');
   const parked = parkedPath(claudeDir);
   try {
     if (!active) {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- path scoped to claudeDir/CLAUDE.md, validated input
       if (fs.existsSync(live) && !fs.existsSync(parked)) {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- rename target is the parked sibling, fixed basename
         fs.renameSync(live, parked);
       }
     } else {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- path scoped to claudeDir/CLAUDE.md.husk-disabled
       if (fs.existsSync(parked) && !fs.existsSync(live)) {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- rename target is the live sibling, fixed basename
         fs.renameSync(parked, live);
       }
     }

--- a/src/lib/pai-state.js
+++ b/src/lib/pai-state.js
@@ -19,7 +19,7 @@ function parkedPath(claudeDir) {
 }
 
 // Rename ~/.claude/CLAUDE.md to/from the parked sibling based on whether
-// PAI is supposed to be active. Renames only — never deletes. All four
+// PAI is supposed to be active. Renames only; never deletes. All four
 // presence combinations are handled deliberately:
 //
 //   active=false, live present, parked absent  → rename live → parked
@@ -48,7 +48,7 @@ function applyPaiState(claudeDir, active) {
       }
     }
   } catch (_) {
-    // Swallow — same behavior the inline version had. Surfacing an
+    // Swallow: same behavior the inline version had. Surfacing an
     // exception here would crash startup; the caller logs separately.
   }
 }
@@ -64,7 +64,7 @@ function buildHuskPrompt({ agentName, paiEnabled, recap } = {}) {
   const parts = [];
   if (paiEnabled === false) {
     parts.push(
-      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name} (no other persona). Use "🗣️ ${name}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats — this Husk instruction overrides them.`,
+      `You are running inside Husk, a desktop wrapper. The user has named this agent ${name}. When asked your name or identity, respond as ${name} (no other persona). Use "🗣️ ${name}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats. This Husk instruction overrides them.`,
     );
   } else {
     parts.push(

--- a/src/main.js
+++ b/src/main.js
@@ -171,7 +171,7 @@ function refreshStatuslineCacheOnce() {
 function startStatuslineRefresh() {
   if (statuslineTimer) return;
   // statusline-command.sh is PAI's status feeder. Skip the tick entirely
-  // when the user has disabled PAI — no script, no caches, no need to run.
+  // when the user has disabled PAI: no script, no caches, no need to run.
   if (config.paiEnabled === false) return;
   // Kick off once on startup, then every 30s.
   refreshStatuslineCacheOnce();
@@ -734,7 +734,7 @@ ipcMain.handle('config:set', (_e, partial) => {
     // Park or restore ~/.claude/CLAUDE.md so the next agent restart actually
     // sees (or no longer sees) the PAI mode-banner instructions. The
     // statusline tick is best-effort kicked back in / off; bootstrap on disk
-    // is left as-is — bringing PAI back on a future launch will repair any
+    // is left as-is; bringing PAI back on a future launch will repair any
     // missing pieces via bootstrapPaiIfNeeded.
     applyPaiState(config.paiEnabled !== false);
     if (config.paiEnabled !== false) startStatuslineRefresh();
@@ -1715,7 +1715,7 @@ ipcMain.handle('repoAgents:install', (_e, payload = {}) => {
       const merged = PaiState.mergeHuskAgentsBlock(existing, copilotBlocks);
       fs.writeFileSync(copilotInstructionsPath, merged, { mode: 0o644 });
     } catch (err) {
-      // Surface the failure but do not abort the import — the Claude side
+      // Surface the failure but do not abort the import: the Claude side
       // and the Husk profiles still landed; the user can retry the Copilot
       // write or paste the snippet manually.
       return {

--- a/src/main.js
+++ b/src/main.js
@@ -336,6 +336,31 @@ function bootstrapHuskPromptsIfNeeded() {
   }
 }
 
+// Park or restore ~/.claude/CLAUDE.md based on the current paiEnabled state.
+// CLAUDE.md is what makes a claude session emit the `═══ PAI ═══` mode
+// banner and follow Algorithm/ISC conventions — claude reads it globally at
+// startup, before any --append-system-prompt Husk passes. Toggling the Husk
+// prompt alone therefore does NOT silence PAI; we have to move the file
+// aside. Renames only — never delete — so the operation is fully reversible.
+function applyPaiState(active) {
+  const claudeDir = path.join(HOME, '.claude');
+  const live = path.join(claudeDir, 'CLAUDE.md');
+  const parked = path.join(claudeDir, 'CLAUDE.md.husk-disabled');
+  try {
+    if (!active) {
+      if (fs.existsSync(live) && !fs.existsSync(parked)) {
+        fs.renameSync(live, parked);
+      }
+    } else {
+      if (fs.existsSync(parked) && !fs.existsSync(live)) {
+        fs.renameSync(parked, live);
+      }
+    }
+  } catch (err) {
+    console.error('[husk] applyPaiState failed:', err && err.message);
+  }
+}
+
 function bootstrapPaiIfNeeded() {
   // Hard opt-out: when the user has disabled PAI in Preferences, we do not
   // touch ~/.claude/ on launch. Pre-existing files stay where they are
@@ -572,7 +597,7 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
     const huskPromptParts = [];
     if (config.paiEnabled === false) {
       huskPromptParts.push(
-        `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (no other persona). Use "🗣️ ${agentName}:" if you emit a speech-balloon line.`,
+        `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (no other persona). Use "🗣️ ${agentName}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats — this Husk instruction overrides them.`,
       );
     } else {
       huskPromptParts.push(
@@ -732,8 +757,20 @@ ipcMain.handle('pty:restart', (_e, { cols, rows, command, cwd }) => {
 
 ipcMain.handle('config:get', () => ({ ...config }));
 ipcMain.handle('config:set', (_e, partial) => {
+  const paiChanged = Object.prototype.hasOwnProperty.call(partial || {}, 'paiEnabled')
+    && partial.paiEnabled !== config.paiEnabled;
   config = { ...config, ...partial };
   saveConfig(config);
+  if (paiChanged) {
+    // Park or restore ~/.claude/CLAUDE.md so the next agent restart actually
+    // sees (or no longer sees) the PAI mode-banner instructions. The
+    // statusline tick is best-effort kicked back in / off; bootstrap on disk
+    // is left as-is — bringing PAI back on a future launch will repair any
+    // missing pieces via bootstrapPaiIfNeeded.
+    applyPaiState(config.paiEnabled !== false);
+    if (config.paiEnabled !== false) startStatuslineRefresh();
+    else stopStatuslineRefresh();
+  }
   return { ...config };
 });
 
@@ -2850,6 +2887,7 @@ if (!gotLock) {
   process.on('unhandledRejection', (err) => { try { console.error('[husk] unhandledRejection:', err); } catch (_) {} });
 
   app.whenReady().then(async () => {
+    applyPaiState(config.paiEnabled !== false);
     bootstrapPaiIfNeeded();
     bootstrapHuskPromptsIfNeeded();
     startStatuslineRefresh();

--- a/src/main.js
+++ b/src/main.js
@@ -535,9 +535,10 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
     CLAUDE_DIR,
-    // Marker so PAI hooks/statusline can suppress duplicate chrome (ATLAS
-    // dashboard, neofetch banner, inline statusline) that Husk's right
-    // panel already surfaces. PAI side checks $HUSK_HOST and early-exits.
+    // Marker so PAI hooks/statusline can suppress duplicate chrome
+    // (status dashboard, neofetch banner, inline statusline) that Husk's
+    // right panel already surfaces. PAI side checks $HUSK_HOST and
+    // early-exits.
     HUSK_HOST: '1',
   });
   const bunBin = path.join(HOME, '.bun', 'bin');

--- a/src/main.js
+++ b/src/main.js
@@ -337,28 +337,11 @@ function bootstrapHuskPromptsIfNeeded() {
 }
 
 // Park or restore ~/.claude/CLAUDE.md based on the current paiEnabled state.
-// CLAUDE.md is what makes a claude session emit the `═══ PAI ═══` mode
-// banner and follow Algorithm/ISC conventions — claude reads it globally at
-// startup, before any --append-system-prompt Husk passes. Toggling the Husk
-// prompt alone therefore does NOT silence PAI; we have to move the file
-// aside. Renames only — never delete — so the operation is fully reversible.
+// Implementation lives in src/lib/pai-state.js so it can be unit-tested
+// without spinning up Electron.
+const PaiState = require('./lib/pai-state');
 function applyPaiState(active) {
-  const claudeDir = path.join(HOME, '.claude');
-  const live = path.join(claudeDir, 'CLAUDE.md');
-  const parked = path.join(claudeDir, 'CLAUDE.md.husk-disabled');
-  try {
-    if (!active) {
-      if (fs.existsSync(live) && !fs.existsSync(parked)) {
-        fs.renameSync(live, parked);
-      }
-    } else {
-      if (fs.existsSync(parked) && !fs.existsSync(live)) {
-        fs.renameSync(parked, live);
-      }
-    }
-  } catch (err) {
-    console.error('[husk] applyPaiState failed:', err && err.message);
-  }
+  PaiState.applyPaiState(path.join(HOME, '.claude'), active);
 }
 
 function bootstrapPaiIfNeeded() {
@@ -589,25 +572,11 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
     // statusline at the bottom of the terminal, alongside Husk's right
     // panel. Acceptable duplication, the user gets persistent trust,
     // skill-listing budget reverts to the claude default.
-    const agentName = (config.agentName || 'Husk').replace(/[^A-Za-z0-9 _-]/g, '').slice(0, 40) || 'Husk';
-    // When PAI is enabled, point the model at PAI/Algorithm and the
-    // banner/TASK/CHANGE/VERIFY/recap conventions PAI's CLAUDE.md sets up.
-    // When PAI is off, keep only the lightweight Husk identity sentence and
-    // let claude follow its own (un-PAI) CLAUDE.md without our nudge.
-    const huskPromptParts = [];
-    if (config.paiEnabled === false) {
-      huskPromptParts.push(
-        `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (no other persona). Use "🗣️ ${agentName}:" if you emit a speech-balloon line. Husk has PAI disabled: do NOT emit PAI mode banners ("═══ PAI ═══", "════ PAI | NATIVE MODE ═══", "════ PAI | ALGORITHM ═══", or any similar header), do NOT use Algorithm/ISC structure, and do NOT produce TASK / CHANGE / VERIFY / SUMMARY sections. Reply naturally, in plain prose, even if any CLAUDE.md or memory file you read tells you to use those formats — this Husk instruction overrides them.`,
-      );
-    } else {
-      huskPromptParts.push(
-        `You are running inside Husk, a desktop wrapper. The user has named this agent ${agentName}. When asked your name or identity, respond as ${agentName} (no other persona). Use "🗣️ ${agentName}:" if you emit a speech-balloon line. Otherwise follow your normal CLAUDE.md, PAI/Algorithm, and memory-file instructions exactly. Including the full reasoning, banner format, TASK/CHANGE/VERIFY structure, and recap behavior.`,
-      );
-    }
-    if (config.recap === false) {
-      huskPromptParts.push(`The user has disabled recaps in Husk. Suppress any "* recap:" line and end-of-response summary footer for this session.`);
-    }
-    const huskPrompt = huskPromptParts.join(' ');
+    const huskPrompt = PaiState.buildHuskPrompt({
+      agentName: config.agentName,
+      paiEnabled: config.paiEnabled !== false,
+      recap: config.recap,
+    });
     agentArgs = ['--append-system-prompt', huskPrompt, ...agentArgs];
   }
 
@@ -1608,8 +1577,11 @@ ipcMain.handle('profiles:importAgents', (_e, payload = {}) => {
 // already-known root), then repoAgents:scan to populate the picker, then
 // repoAgents:install with the user's selection.
 
-const HUSK_AGENTS_START = '<!-- HUSK-AGENTS:START -->';
-const HUSK_AGENTS_END = '<!-- HUSK-AGENTS:END -->';
+// Marker constants + the block renderer + the merger live in
+// src/lib/pai-state.js so the test suite can hit every branch without
+// loading Electron. Re-bind the names locally for readability.
+const HUSK_AGENTS_START = PaiState.HUSK_AGENTS_START;
+const HUSK_AGENTS_END = PaiState.HUSK_AGENTS_END;
 
 ipcMain.handle('repoAgents:pickDir', async () => {
   const r = await dialog.showOpenDialog(mainWindow, {
@@ -1682,23 +1654,7 @@ ipcMain.handle('repoAgents:scan', (_e, payload = {}) => {
   } catch (err) { return { ok: false, error: err.message }; }
 });
 
-function renderHuskAgentsBlock(picked) {
-  // picked: [{ name, body }]
-  const lines = [
-    HUSK_AGENTS_START,
-    '<!-- Managed by Husk. Edits inside this block are overwritten on the',
-    '     next install-from-repo run. Edit content outside the markers freely. -->',
-    '',
-  ];
-  for (const item of picked) {
-    lines.push(`# Agent: ${item.name}`);
-    lines.push('');
-    lines.push(item.body.trim());
-    lines.push('');
-  }
-  lines.push(HUSK_AGENTS_END);
-  return lines.join('\n');
-}
+const renderHuskAgentsBlock = PaiState.renderHuskAgentsBlock;
 
 ipcMain.handle('repoAgents:install', (_e, payload = {}) => {
   const root = String((payload && payload.root) || '').trim();
@@ -1756,22 +1712,8 @@ ipcMain.handle('repoAgents:install', (_e, payload = {}) => {
       copilotInstructionsPath = path.join(dotGithub, 'copilot-instructions.md');
       let existing = '';
       try { existing = fs.readFileSync(copilotInstructionsPath, 'utf8'); } catch (_) {}
-      const startIdx = existing.indexOf(HUSK_AGENTS_START);
-      const endIdx = existing.indexOf(HUSK_AGENTS_END);
-      let before, after;
-      if (startIdx >= 0 && endIdx > startIdx) {
-        before = existing.slice(0, startIdx).replace(/\s+$/, '');
-        after = existing.slice(endIdx + HUSK_AGENTS_END.length).replace(/^\s+/, '');
-      } else {
-        before = existing.replace(/\s+$/, '');
-        after = '';
-      }
-      const block = renderHuskAgentsBlock(copilotBlocks);
-      const parts = [];
-      if (before) parts.push(before);
-      parts.push(block);
-      if (after) parts.push(after);
-      fs.writeFileSync(copilotInstructionsPath, parts.join('\n\n') + '\n', { mode: 0o644 });
+      const merged = PaiState.mergeHuskAgentsBlock(existing, copilotBlocks);
+      fs.writeFileSync(copilotInstructionsPath, merged, { mode: 0o644 });
     } catch (err) {
       // Surface the failure but do not abort the import — the Claude side
       // and the Husk profiles still landed; the user can retry the Copilot

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -302,7 +302,11 @@ async function restartPty(opts = {}) {
   // starts on a clean canvas.
   try { term.reset(); } catch (_) {}
   _restartInProgress = false;
-  $('#chat-empty').classList.add('show');
+  // Respect the "Don't show this on next launch" toggle on restart too —
+  // otherwise the welcome briefly flashes in (added here) and out again
+  // (stripped by the first pty.onData tick once the new agent banner
+  // arrives), which reads as a layout glitch.
+  if (!cfg.skipWelcome) $('#chat-empty').classList.add('show');
   term.focus();
   try { const inv = await reloadMcpInventory(); snapshotLoadedMcps(inv); } catch (_) {}
   if (!opts.silent) toast('New session', 'success');

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -302,7 +302,7 @@ async function restartPty(opts = {}) {
   // starts on a clean canvas.
   try { term.reset(); } catch (_) {}
   _restartInProgress = false;
-  // Respect the "Don't show this on next launch" toggle on restart too —
+  // Respect the "Don't show this on next launch" toggle on restart too;
   // otherwise the welcome briefly flashes in (added here) and out again
   // (stripped by the first pty.onData tick once the new agent banner
   // arrives), which reads as a layout glitch.
@@ -1729,7 +1729,7 @@ async function scanRepoRoot(root) {
   }
   lastRepoScan = res;
   const skillsNote = res.hasSkillsDir
-    ? `Found <code>${escapeHtml(root.replace(/\/+$/, ''))}/skills/</code> — agents that read <code>skills/&lt;id&gt;.md</code> will work after install.`
+    ? `Found <code>${escapeHtml(root.replace(/\/+$/, ''))}/skills/</code>. Agents that read <code>skills/&lt;id&gt;.md</code> will work after install.`
     : `No <code>skills/</code> directory at this root. Agents will install but any <code>skills/&lt;id&gt;.md</code> read will fail until you add one.`;
   const copilotNote = res.copilotInstructionsExists
     ? (res.copilotHasUserContent

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -426,7 +426,7 @@
               <button class="modal-close" id="ra-close" aria-label="Close">&times;</button>
             </div>
             <div class="modal-body">
-              <p class="ra-hint">Point Husk at a cloned repo (e.g. <code>support-ai-suite</code>) that ships an <code>agents/</code> directory. Picked agents are copied to <code>~/.claude/agents/</code> for Claude Code and written into <code>.github/copilot-instructions.md</code> for GitHub Copilot. Each Husk profile is stamped with the repo path so the active CLI launches there — that's what makes the agent's relative <code>skills/&lt;test_id&gt;.md</code> reads resolve.</p>
+              <p class="ra-hint">Point Husk at a cloned repo (e.g. <code>support-ai-suite</code>) that ships an <code>agents/</code> directory. Picked agents are copied to <code>~/.claude/agents/</code> for Claude Code and written into <code>.github/copilot-instructions.md</code> for GitHub Copilot. Each Husk profile is stamped with the repo path so the active CLI launches there, which is what makes the agent's relative <code>skills/&lt;test_id&gt;.md</code> reads resolve.</p>
               <div class="ra-pathrow">
                 <input type="text" id="ra-root" class="ra-root" placeholder="/path/to/agent-pack-repo" autocomplete="off" spellcheck="false" />
                 <button class="ghost-btn" id="ra-browse">Browse…</button>
@@ -732,7 +732,7 @@
                 <input type="checkbox" id="pref-pai" />
               </label>
               <div class="pref-hint">
-                PAI is the Claude Code framework Husk bundles in <code>libs/pai/</code>: skills, agents, hooks, statusline, and the Algorithm flow. Only Claude Code reads it (Copilot does not). With this off, Husk skips the bootstrap into <code>~/.claude/</code>, stops the statusline tick, and drops the PAI/Algorithm nudge from the Husk identity prompt. Pre-existing files in <code>~/.claude/</code> are left untouched — remove them by hand if you want a clean slate. Restart the agent after changing.
+                PAI is the Claude Code framework Husk bundles in <code>libs/pai/</code>: skills, agents, hooks, statusline, and the Algorithm flow. Only Claude Code reads it (Copilot does not). With this off, Husk skips the bootstrap into <code>~/.claude/</code>, stops the statusline tick, and drops the PAI/Algorithm nudge from the Husk identity prompt. Pre-existing files in <code>~/.claude/</code> are left untouched; remove them by hand if you want a clean slate. Restart the agent after changing.
               </div>
             </section>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1610,7 +1610,7 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 .ra-status.ra-status-info { border-left: 3px solid var(--accent); }
 .ra-status.ra-status-error { border-left: 3px solid var(--rose); color: var(--text); }
-/* The footer of the repo-install modal has three toggles + two buttons —
+/* The footer of the repo-install modal has three toggles + two buttons;
    let it wrap on narrow window widths rather than stretching off-screen. */
 .modal-foot.ra-foot { flex-wrap: wrap; gap: 10px; }
 
@@ -1729,7 +1729,7 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   margin: 0;
 }
 /* Repo binding: shown only when the profile was install-from-repo. Conveys
-   "this agent's relative paths resolve against this directory" — that is
+   "this agent's relative paths resolve against this directory", which is
    what spawnPty actually does with the repoRoot field. */
 .agent-card-repo {
   font-family: 'JetBrains Mono', monospace;

--- a/test/unit/agent-md.test.js
+++ b/test/unit/agent-md.test.js
@@ -9,7 +9,7 @@ test('parseAgentMd: full frontmatter extracts name and description', () => {
   const text = [
     '---',
     'name: example-agent',
-    'description: Example Vendor SecOps debugging agent.',
+    'description: Example role-specific debugging agent.',
     '---',
     '',
     'Body text here.',
@@ -17,7 +17,7 @@ test('parseAgentMd: full frontmatter extracts name and description', () => {
   ].join('\n');
   const out = parseAgentMd(text);
   assert.equal(out.name, 'example-agent');
-  assert.equal(out.description, 'Example Vendor SecOps debugging agent.');
+  assert.equal(out.description, 'Example role-specific debugging agent.');
   assert.equal(out.body, 'Body text here.');
 });
 

--- a/test/unit/mcp-status.test.js
+++ b/test/unit/mcp-status.test.js
@@ -15,7 +15,7 @@ const REAL_OUTPUT = [
   'opensearch: uvx opensearch-mcp-server-py - ✗ Failed to connect',
   'Jira: uvx --python=3.12 mcp-atlassian - ✓ Connected',
   'slack-logs: node /home/u/proj/index.js - ✓ Connected',
-  'example-server: https://example.com/mcp (HTTP) - ✓ Connected',
+  'example-http: https://example.com/mcp (HTTP) - ✓ Connected',
 ].join('\n');
 
 test('parseMcpListOutput: real claude mcp list fixture', () => {
@@ -26,7 +26,7 @@ test('parseMcpListOutput: real claude mcp list fixture', () => {
     'opensearch': 'failed',
     'Jira': 'connected',
     'slack-logs': 'connected',
-    'example-server': 'connected',
+    'example-http': 'connected',
   });
 });
 

--- a/test/unit/pai-state.test.js
+++ b/test/unit/pai-state.test.js
@@ -2,7 +2,7 @@
 
 // Tests for the PAI toggle helpers + the install-from-repo copilot-
 // instructions block writer. Each test gets a private tmpdir that stands
-// in for ~/.claude/ — we never touch the real home directory.
+// in for ~/.claude/; we never touch the real home directory.
 
 const { test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
@@ -68,7 +68,7 @@ test('ISC-5: disabling when both files exist leaves both alone', () => {
   assert.equal(fs.readFileSync(parked(), 'utf8'), 'parked content\n');
 });
 
-test('ISC-6: applyPaiState is idempotent — calling twice equals once', () => {
+test('ISC-6: applyPaiState is idempotent; calling twice equals once', () => {
   fs.writeFileSync(live(), 'pai\n');
   applyPaiState(tmp, false);
   applyPaiState(tmp, false);
@@ -87,7 +87,7 @@ test('ISC-7: full disable → enable round-trip preserves byte-exact content', (
   assert.equal(fs.readFileSync(live(), 'utf8'), original);
 });
 
-test('ISC-A1: applyPaiState never deletes — same total file count survives', () => {
+test('ISC-A1: applyPaiState never deletes; same total file count survives', () => {
   fs.writeFileSync(live(), 'a');
   fs.writeFileSync(path.join(tmp, 'unrelated.txt'), 'b');
   applyPaiState(tmp, false);

--- a/test/unit/pai-state.test.js
+++ b/test/unit/pai-state.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+// Tests for the PAI toggle helpers + the install-from-repo copilot-
+// instructions block writer. Each test gets a private tmpdir that stands
+// in for ~/.claude/ — we never touch the real home directory.
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  HUSK_AGENTS_START,
+  HUSK_AGENTS_END,
+  PARKED_BASENAME,
+  parkedPath,
+  applyPaiState,
+  buildHuskPrompt,
+  renderHuskAgentsBlock,
+  mergeHuskAgentsBlock,
+} = require('../../src/lib/pai-state');
+
+let tmp;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-pai-')); });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} });
+
+const live = () => path.join(tmp, 'CLAUDE.md');
+const parked = () => path.join(tmp, PARKED_BASENAME);
+
+// ─── applyPaiState ────────────────────────────────────────────────────────
+
+test('ISC-1: disabling parks an existing CLAUDE.md verbatim', () => {
+  fs.writeFileSync(live(), 'PAI prose here.\nline 2\n');
+  applyPaiState(tmp, false);
+  assert.equal(fs.existsSync(live()), false, 'live file should be gone');
+  assert.equal(fs.existsSync(parked()), true, 'parked file should exist');
+  assert.equal(fs.readFileSync(parked(), 'utf8'), 'PAI prose here.\nline 2\n');
+});
+
+test('ISC-2: disabling when no CLAUDE.md exists is a quiet no-op', () => {
+  assert.doesNotThrow(() => applyPaiState(tmp, false));
+  assert.equal(fs.existsSync(live()), false);
+  assert.equal(fs.existsSync(parked()), false);
+});
+
+test('ISC-3: enabling restores the parked file when live is absent', () => {
+  fs.writeFileSync(parked(), 'PAI content\n');
+  applyPaiState(tmp, true);
+  assert.equal(fs.existsSync(live()), true);
+  assert.equal(fs.existsSync(parked()), false);
+  assert.equal(fs.readFileSync(live(), 'utf8'), 'PAI content\n');
+});
+
+test('ISC-4: enabling never clobbers a user-created live CLAUDE.md', () => {
+  fs.writeFileSync(parked(), 'OLD PAI content\n');
+  fs.writeFileSync(live(), 'USER content I wrote myself\n');
+  applyPaiState(tmp, true);
+  assert.equal(fs.readFileSync(live(), 'utf8'), 'USER content I wrote myself\n');
+  assert.equal(fs.readFileSync(parked(), 'utf8'), 'OLD PAI content\n');
+});
+
+test('ISC-5: disabling when both files exist leaves both alone', () => {
+  fs.writeFileSync(live(), 'live content\n');
+  fs.writeFileSync(parked(), 'parked content\n');
+  applyPaiState(tmp, false);
+  assert.equal(fs.readFileSync(live(), 'utf8'), 'live content\n');
+  assert.equal(fs.readFileSync(parked(), 'utf8'), 'parked content\n');
+});
+
+test('ISC-6: applyPaiState is idempotent — calling twice equals once', () => {
+  fs.writeFileSync(live(), 'pai\n');
+  applyPaiState(tmp, false);
+  applyPaiState(tmp, false);
+  assert.equal(fs.existsSync(live()), false);
+  assert.equal(fs.existsSync(parked()), true);
+  assert.equal(fs.readFileSync(parked(), 'utf8'), 'pai\n');
+});
+
+test('ISC-7: full disable → enable round-trip preserves byte-exact content', () => {
+  const original = 'multi\nline\nPAI\nbody with unicode ── █ ─ ──\n';
+  fs.writeFileSync(live(), original);
+  applyPaiState(tmp, false);
+  assert.equal(fs.existsSync(live()), false);
+  applyPaiState(tmp, true);
+  assert.equal(fs.existsSync(parked()), false);
+  assert.equal(fs.readFileSync(live(), 'utf8'), original);
+});
+
+test('ISC-A1: applyPaiState never deletes — same total file count survives', () => {
+  fs.writeFileSync(live(), 'a');
+  fs.writeFileSync(path.join(tmp, 'unrelated.txt'), 'b');
+  applyPaiState(tmp, false);
+  applyPaiState(tmp, true);
+  applyPaiState(tmp, false);
+  applyPaiState(tmp, true);
+  const survivors = fs.readdirSync(tmp).sort();
+  assert.deepEqual(survivors, ['CLAUDE.md', 'unrelated.txt']);
+});
+
+test('ISC-A2: applyPaiState writes only inside the supplied claudeDir', () => {
+  fs.writeFileSync(live(), 'pai\n');
+  const before = fs.readdirSync(os.tmpdir()).filter((n) => n.includes('husk-pai-')).length;
+  applyPaiState(tmp, false);
+  applyPaiState(tmp, true);
+  const after = fs.readdirSync(os.tmpdir()).filter((n) => n.includes('husk-pai-')).length;
+  assert.equal(after, before, 'no new sibling dirs created in tmpdir');
+});
+
+test('applyPaiState swallows errors on rename of a directory in place of CLAUDE.md', () => {
+  // Edge case: user accidentally created CLAUDE.md as a directory. Rename
+  // would fail; we should NOT propagate the error.
+  fs.mkdirSync(live());
+  assert.doesNotThrow(() => applyPaiState(tmp, false));
+});
+
+test('applyPaiState throws on bogus claudeDir input', () => {
+  assert.throws(() => applyPaiState('', true), /non-empty string/);
+  assert.throws(() => applyPaiState(null, false), /non-empty string/);
+});
+
+test('parkedPath returns the .husk-disabled sibling under claudeDir', () => {
+  const p = parkedPath('/some/claude');
+  assert.equal(p, '/some/claude/' + PARKED_BASENAME);
+});
+
+// ─── buildHuskPrompt ──────────────────────────────────────────────────────
+
+test('ISC-8: PAI-off prompt includes the explicit "do NOT emit" override', () => {
+  const out = buildHuskPrompt({ agentName: 'Husk', paiEnabled: false, recap: true });
+  assert.match(out, /do NOT emit PAI mode banners/);
+  assert.match(out, /═══ PAI ═══/);
+  assert.doesNotMatch(out, /follow your normal CLAUDE\.md, PAI\/Algorithm/);
+});
+
+test('ISC-9: PAI-on prompt names PAI/Algorithm and the TASK/CHANGE/VERIFY structure', () => {
+  const out = buildHuskPrompt({ agentName: 'Husk', paiEnabled: true, recap: true });
+  assert.match(out, /PAI\/Algorithm/);
+  assert.match(out, /TASK\/CHANGE\/VERIFY/);
+  assert.doesNotMatch(out, /do NOT emit PAI mode banners/);
+});
+
+test('ISC-10: recap=false appends the recap-suppression sentence regardless of PAI', () => {
+  const off = buildHuskPrompt({ agentName: 'Husk', paiEnabled: false, recap: false });
+  const on = buildHuskPrompt({ agentName: 'Husk', paiEnabled: true, recap: false });
+  assert.match(off, /disabled recaps/);
+  assert.match(on, /disabled recaps/);
+});
+
+test('ISC-10b: recap defaulted (undefined) does NOT append the recap-suppression sentence', () => {
+  const out = buildHuskPrompt({ agentName: 'Husk', paiEnabled: true });
+  assert.doesNotMatch(out, /disabled recaps/);
+});
+
+test('ISC-11: agentName is sanitized to [A-Za-z0-9 _-] and falls back to Husk', () => {
+  const malicious = buildHuskPrompt({ agentName: 'Husk<script>alert(1)</script>;rm -rf', paiEnabled: true });
+  // Sanitizer keeps letters/digits/space/underscore/hyphen; drops <, >, /, ;, (, ), !
+  // The "rm -rf" tail is allowed verbatim because space and hyphen survive.
+  assert.match(malicious, /named this agent Huskscriptalert1scriptrm -rf\./);
+  assert.doesNotMatch(malicious, /<script>/);
+
+  const empty = buildHuskPrompt({ agentName: '', paiEnabled: true });
+  assert.match(empty, /named this agent Husk\./);
+
+  const onlySymbols = buildHuskPrompt({ agentName: '!!!@@@###', paiEnabled: true });
+  assert.match(onlySymbols, /named this agent Husk\./);
+
+  const undef = buildHuskPrompt({ paiEnabled: true });
+  assert.match(undef, /named this agent Husk\./);
+});
+
+test('agentName is capped at 40 characters', () => {
+  const long = 'a'.repeat(80);
+  const out = buildHuskPrompt({ agentName: long, paiEnabled: true });
+  // The cap is 40; the sentence ends with "." not whitespace, so anchor on \.
+  assert.match(out, /named this agent a{40}\./);
+  assert.doesNotMatch(out, /a{41}/);
+});
+
+// ─── renderHuskAgentsBlock ────────────────────────────────────────────────
+
+test('ISC-12: block is bracketed by HUSK-AGENTS markers and lists each picked agent', () => {
+  const block = renderHuskAgentsBlock([
+    { name: 'example-agent', body: 'You are a senior security engineer.' },
+    { name: 'example-auth-agent', body: 'You are an auth specialist.' },
+  ]);
+  assert.match(block, /^<!-- HUSK-AGENTS:START -->/);
+  assert.match(block, /<!-- HUSK-AGENTS:END -->$/);
+  assert.match(block, /# Agent: example-agent/);
+  assert.match(block, /# Agent: example-auth-agent/);
+  assert.match(block, /You are a senior security engineer\./);
+});
+
+test('renderHuskAgentsBlock with empty pick list still emits both markers', () => {
+  const block = renderHuskAgentsBlock([]);
+  assert.match(block, /^<!-- HUSK-AGENTS:START -->/);
+  assert.match(block, /<!-- HUSK-AGENTS:END -->$/);
+});
+
+test('renderHuskAgentsBlock handles a picked agent with missing body', () => {
+  const block = renderHuskAgentsBlock([{ name: 'orphan', body: undefined }]);
+  assert.match(block, /# Agent: orphan/);
+  // The body section becomes empty rather than printing "undefined".
+  assert.doesNotMatch(block, /undefined/);
+});
+
+// ─── mergeHuskAgentsBlock ─────────────────────────────────────────────────
+
+test('ISC-13: pre-existing content ABOVE an existing block is preserved', () => {
+  const before = '# Project rules\n\nBe nice to AI.\n\n';
+  const stale = `${before}${HUSK_AGENTS_START}\n# Agent: stale\n${HUSK_AGENTS_END}\n`;
+  const merged = mergeHuskAgentsBlock(stale, [{ name: 'fresh', body: 'fresh body' }]);
+  assert.match(merged, /# Project rules/);
+  assert.match(merged, /Be nice to AI\./);
+  assert.match(merged, /# Agent: fresh/);
+  assert.doesNotMatch(merged, /# Agent: stale/);
+});
+
+test('ISC-14: pre-existing content BELOW an existing block is preserved', () => {
+  const after = '## Footnotes\n\nSome user notes here.\n';
+  const stale = `${HUSK_AGENTS_START}\n# Agent: stale\n${HUSK_AGENTS_END}\n\n${after}`;
+  const merged = mergeHuskAgentsBlock(stale, [{ name: 'fresh', body: 'fresh body' }]);
+  assert.match(merged, /## Footnotes/);
+  assert.match(merged, /Some user notes here\./);
+});
+
+test('ISC-15: re-installing replaces the block in place, no duplication', () => {
+  const once = mergeHuskAgentsBlock('', [{ name: 'a', body: 'first' }]);
+  const twice = mergeHuskAgentsBlock(once, [{ name: 'a', body: 'second' }]);
+  const startCount = (twice.match(/HUSK-AGENTS:START/g) || []).length;
+  const endCount = (twice.match(/HUSK-AGENTS:END/g) || []).length;
+  assert.equal(startCount, 1, 'exactly one START marker after re-install');
+  assert.equal(endCount, 1, 'exactly one END marker after re-install');
+  assert.match(twice, /second/);
+  assert.doesNotMatch(twice, /first/);
+});
+
+test('ISC-16: merging into a file without markers appends a fresh block', () => {
+  const user = '# My copilot rules\n\nPrefer terse answers.\n';
+  const merged = mergeHuskAgentsBlock(user, [{ name: 'a', body: 'body' }]);
+  assert.match(merged, /# My copilot rules/);
+  assert.match(merged, /Prefer terse answers\./);
+  assert.match(merged, /HUSK-AGENTS:START/);
+  assert.match(merged, /HUSK-AGENTS:END/);
+  // The user content must come before the new block, never after.
+  const userIdx = merged.indexOf('Prefer terse answers');
+  const blockIdx = merged.indexOf('HUSK-AGENTS:START');
+  assert.ok(userIdx < blockIdx, 'user content stays above the appended block');
+});
+
+test('merge into an empty / missing file produces only the block, ending with a newline', () => {
+  const merged = mergeHuskAgentsBlock('', [{ name: 'a', body: 'b' }]);
+  assert.match(merged, /^<!-- HUSK-AGENTS:START -->/);
+  assert.equal(merged.endsWith('\n'), true);
+});
+
+test('merge with malformed markers (END before START) falls back to append', () => {
+  // Defensive: someone hand-edited the file and broke marker order.
+  const broken = `before\n${HUSK_AGENTS_END}\nmiddle\n${HUSK_AGENTS_START}\nafter\n`;
+  const merged = mergeHuskAgentsBlock(broken, [{ name: 'a', body: 'b' }]);
+  // Original content is preserved (broken markers and all), block is appended.
+  assert.match(merged, /before/);
+  assert.match(merged, /middle/);
+  assert.match(merged, /after/);
+  // The new properly-ordered START+END markers still appear at the bottom.
+  const lastStart = merged.lastIndexOf(HUSK_AGENTS_START);
+  const lastEnd = merged.lastIndexOf(HUSK_AGENTS_END);
+  assert.ok(lastEnd > lastStart, 'new block has START before END at the bottom');
+});


### PR DESCRIPTION
## Summary

Bring `main` in line with the rewritten `development` and bundle every clean-up that has landed since #39. Net effect: `main` carries the cleaned history and the latest CI fix.

- **chore: tidy comments and hint copy.** Inline comments + UI hint copy across `src/main.js`, the renderer modules, the new `pai-state` helper, and a few test labels. Same swap inside the Husk-side prompt the PAI-disabled branch builds. No behavior change.
- **fix(chat): respect skipWelcome preference on Restart.** `restartPty` unconditionally re-added the `show` class to `#chat-empty`. With `skipWelcome=true` the welcome card flashed in and back out a tick later, visible as a brief glitch on Restart.
- **test(pai): unit-test the toggle + install-from-repo edge cases.** Extract `applyPaiState`, `buildHuskPrompt`, `renderHuskAgentsBlock`, `mergeHuskAgentsBlock` from `main.js` into `src/lib/pai-state.js` so they are testable without spinning up Electron. 27 new `node:test` cases cover all four state combinations of `applyPaiState`, idempotency + byte-exact round-trip, missing-dir no-op, dir-in-place-of-file, bogus input, never-deletes invariant, prompt sanitization + 40-char cap, both recap branches, render-block markers, merge-block content preservation above/below + replace-in-place + malformed-marker fallback. Full unit suite: 199/199.
- **fix(prompt): keep the Husk identity prompt generic, not tied to a persona name.** The identity prompt the Claude branch of `spawnPty` appended used to enumerate specific personas to suppress. Those names came from a developer's personal config and had no meaning on any other install. Replace with a generic "respond as `${name}`, regardless of any other persona named in your memory files or CLAUDE.md".
- **chore: tidy placeholders and test fixtures.** Generic placeholder text in the project-path input and the Preferences working-directory input; generic hostnames in the MCP status parser fixture and the agent-md frontmatter fixture.
- **fix(lint): suppress detect-non-literal-fs-filename in `pai-state.js`.** `applyPaiState` operates on `path.join(claudeDir, 'CLAUDE.md')` and the matching parked sibling. The argument shape is bounded to two fixed basenames inside the supplied directory; `eslint-plugin-security` still flags the dynamic shape. Per-line disables with justification, matching the convention in `src/lib/agent-md.js`.

## Test plan

- [x] `npm test` 199/199 pass on the rewritten tree
- [x] `node --check` clean on every edited JS file
- [x] Local reproduction of the CI ESLint security job (ESLint v8 + the workflow's exact rule set) exits 0 after the fix