### PR TITLE
feat(mcp): install MCP servers from a cloned repo, tool-agnostic

### DIFF
--- a/src/lib/repo-mcp.js
+++ b/src/lib/repo-mcp.js
@@ -1,0 +1,278 @@
+'use strict';
+
+// MCP install-from-repo helpers. Pure / fs-only logic that can be unit
+// tested without spinning up Electron, mirroring src/lib/pai-state.js.
+//
+// What a "repo of MCP servers" looks like, the layout we scan for:
+//
+//   <repoRoot>/
+//     mcp-servers/
+//       <serverName>/
+//         package.json        required: { main, scripts.build, scripts.start }
+//         .env.example        optional: lines like KEY=description
+//         dist/               optional: present when build has already run
+//
+// The scanner is forgiving. Missing files, missing fields, weird casing —
+// each branch produces a sensible status rather than throwing.
+
+const fs = require('fs');
+const path = require('path');
+
+const SERVERS_SUBDIR = 'mcp-servers';
+const ENV_EXAMPLE = '.env.example';
+
+// Cap the number of servers we surface so an oversized monorepo cannot
+// blow up the modal. The first N alphabetically; the rest are silently
+// ignored. Surfaced in the scan result so the renderer can show a hint.
+const MAX_SERVERS_SHOWN = 50;
+
+function safeRead(filePath, encoding = 'utf8') {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded reads under repoRoot
+    return fs.readFileSync(filePath, encoding);
+  } catch (_) {
+    return null;
+  }
+}
+
+function safeStat(filePath) {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded stat under repoRoot
+    return fs.statSync(filePath);
+  } catch (_) {
+    return null;
+  }
+}
+
+function safeReaddir(dirPath) {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded readdir under repoRoot
+    return fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch (_) {
+    return [];
+  }
+}
+
+// parseEnvExample reads `KEY=description` style entries from a
+// dotenv-template file. The "value" half is treated as a hint, not a
+// secret. Returns an array of { key, hint } objects in file order.
+function parseEnvExample(text) {
+  const out = [];
+  if (typeof text !== 'string' || !text) return out;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let hint = line.slice(eq + 1).trim();
+    if ((hint.startsWith('"') && hint.endsWith('"')) ||
+        (hint.startsWith("'") && hint.endsWith("'"))) {
+      hint = hint.slice(1, -1);
+    }
+    if (!/^[A-Z_][A-Z0-9_]*$/i.test(key)) continue;
+    out.push({ key, hint });
+  }
+  return out;
+}
+
+// scanRepoForMcpServers walks <repoRoot>/mcp-servers/* and returns a
+// list of `serverSummary` records, each describing what we found.
+// The shape stays serializable so the renderer can render it directly.
+function scanRepoForMcpServers(repoRoot) {
+  if (typeof repoRoot !== 'string' || !repoRoot) {
+    return { ok: false, error: 'absolute path required' };
+  }
+  const serversDir = path.join(repoRoot, SERVERS_SUBDIR);
+  const dirStat = safeStat(serversDir);
+  if (!dirStat || !dirStat.isDirectory()) {
+    return { ok: true, root: repoRoot, serversDir, servers: [], hasServersDir: false };
+  }
+  const entries = safeReaddir(serversDir)
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort((a, b) => a.localeCompare(b));
+  const truncated = entries.length > MAX_SERVERS_SHOWN;
+  const limited = entries.slice(0, MAX_SERVERS_SHOWN);
+  const servers = [];
+  for (const name of limited) {
+    servers.push(describeServer(serversDir, name));
+  }
+  return {
+    ok: true,
+    root: repoRoot,
+    serversDir,
+    hasServersDir: true,
+    servers,
+    truncated,
+    totalFound: entries.length,
+  };
+}
+
+function describeServer(serversDir, name) {
+  const dir = path.join(serversDir, name);
+  const pkgPath = path.join(dir, 'package.json');
+  const pkgText = safeRead(pkgPath);
+  let pkg = null;
+  let parseError = null;
+  if (pkgText) {
+    try { pkg = JSON.parse(pkgText); } catch (err) { parseError = err.message; }
+  }
+  const envText = safeRead(path.join(dir, ENV_EXAMPLE));
+  const envVars = parseEnvExample(envText || '');
+  const mainRel = pkg && typeof pkg.main === 'string' ? pkg.main : null;
+  const mainAbs = mainRel ? path.join(dir, mainRel) : null;
+  const mainExists = mainAbs ? !!safeStat(mainAbs) : false;
+  const hasBuild = !!(pkg && pkg.scripts && typeof pkg.scripts.build === 'string');
+  const hasStart = !!(pkg && pkg.scripts && typeof pkg.scripts.start === 'string');
+  const needsBuild = hasBuild && !mainExists;
+  return {
+    name,
+    dir,
+    pkgPath,
+    pkgFound: !!pkgText,
+    pkgParseError: parseError,
+    displayName: (pkg && typeof pkg.name === 'string') ? pkg.name : name,
+    description: pkg && typeof pkg.description === 'string' ? pkg.description : '',
+    mainRel,
+    mainAbs,
+    mainExists,
+    hasBuild,
+    hasStart,
+    needsBuild,
+    envVars,
+    installable: !!(pkgText && (mainExists || hasBuild || hasStart)),
+  };
+}
+
+// buildServerSpec turns a scanned server + user-provided env values into
+// the canonical transport spec that every adapter consumes. Splitting of
+// command and args happens here, so callers downstream cannot accidentally
+// glue them back into one string. Returns either { ok: true, spec } or
+// { ok: false, error }.
+function buildServerSpec(server, envValues) {
+  if (!server || typeof server !== 'object') {
+    return { ok: false, error: 'server summary required' };
+  }
+  if (!server.installable) {
+    return { ok: false, error: 'server has no resolvable entry point' };
+  }
+  // Prefer an absolute path to the built main file. Fall back to the
+  // first token of the start script (e.g. "node dist/index.js") if main
+  // is missing but start is set.
+  let command = 'node';
+  let args = [];
+  if (server.mainAbs) {
+    args = [server.mainAbs];
+  } else if (server.hasStart) {
+    const startScript = server.dir && server.pkgPath
+      ? (() => {
+          const pkg = (() => { try { return JSON.parse(safeRead(server.pkgPath) || '{}'); } catch (_) { return {}; } })();
+          return (pkg.scripts && pkg.scripts.start) || '';
+        })()
+      : '';
+    const tokens = String(startScript).trim().split(/\s+/).filter(Boolean);
+    if (!tokens.length) return { ok: false, error: 'start script is empty' };
+    command = tokens.shift();
+    args = tokens.map((tok) => {
+      // Resolve relative paths against the server dir so the command
+      // works regardless of cwd at launch time.
+      if (tok.startsWith('./') || tok.startsWith('../') || (!path.isAbsolute(tok) && /\.[a-zA-Z]+$/.test(tok))) {
+        return path.join(server.dir, tok);
+      }
+      return tok;
+    });
+  } else {
+    return { ok: false, error: 'no main entry point and no start script' };
+  }
+  // env: collect ONLY keys the .env.example declared; pass them through
+  // as strings. Trim wrapping whitespace and matched outer quotes.
+  const env = {};
+  const declared = Array.isArray(server.envVars) ? server.envVars : [];
+  const declaredKeys = new Set(declared.map((e) => e.key));
+  const provided = envValues && typeof envValues === 'object' ? envValues : {};
+  for (const key of declaredKeys) {
+    if (!Object.prototype.hasOwnProperty.call(provided, key)) continue;
+    let value = String(provided[key] || '').trim();
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (value) env[key] = value;
+  }
+  const spec = {
+    transport: 'stdio',
+    command,
+    args,
+  };
+  if (Object.keys(env).length) spec.env = env;
+  return { ok: true, spec };
+}
+
+// renderCodexSnippet produces a TOML [[mcp_servers]] block the user can
+// drop into ~/.codex/config.toml. Codex's MCP support is newer and the
+// schema can shift; this snippet matches the published examples as of
+// the time of writing. We do NOT auto-write the file (yet) because
+// Codex's config is shared with non-MCP fields and we do not own a
+// safe TOML merge path.
+function renderCodexSnippet(serverId, spec) {
+  if (!serverId || !spec) return '';
+  const lines = [];
+  lines.push('[[mcp_servers]]');
+  lines.push(`name = ${tomlString(serverId)}`);
+  lines.push(`command = ${tomlString(spec.command)}`);
+  lines.push(`args = ${tomlStringArray(spec.args || [])}`);
+  if (spec.env && Object.keys(spec.env).length) {
+    const pairs = Object.keys(spec.env)
+      .map((k) => `${tomlBareKey(k)} = ${tomlString(spec.env[k])}`)
+      .join(', ');
+    lines.push(`env = { ${pairs} }`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// renderAiderSnippet produces a JSON object that fits aider's --mcp
+// command-line flag (which accepts inline JSON). aider's stable
+// programmatic config does not currently sit in a well-known file;
+// the snippet is therefore a CLI flag preview, not a config-file
+// fragment.
+function renderAiderSnippet(serverId, spec) {
+  if (!serverId || !spec) return '';
+  const obj = { [serverId]: { command: spec.command, args: spec.args || [] } };
+  if (spec.env && Object.keys(spec.env).length) obj[serverId].env = spec.env;
+  return `--mcp '${JSON.stringify(obj)}'`;
+}
+
+function tomlString(s) {
+  const v = String(s == null ? '' : s);
+  // Escape backslashes and double quotes, escape control chars by
+  // dropping them. TOML basic-string rules are stricter than JSON's.
+  const escaped = v
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\x00-\x1f]/g, '');
+  return `"${escaped}"`;
+}
+
+function tomlStringArray(arr) {
+  if (!Array.isArray(arr)) return '[]';
+  return `[${arr.map(tomlString).join(', ')}]`;
+}
+
+function tomlBareKey(k) {
+  // TOML bare keys allow [A-Za-z0-9_-]+ — fall back to a quoted key
+  // when the input has anything else.
+  if (/^[A-Za-z0-9_-]+$/.test(String(k))) return String(k);
+  return tomlString(k);
+}
+
+module.exports = {
+  SERVERS_SUBDIR,
+  MAX_SERVERS_SHOWN,
+  parseEnvExample,
+  scanRepoForMcpServers,
+  describeServer,
+  buildServerSpec,
+  renderCodexSnippet,
+  renderAiderSnippet,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -1750,6 +1750,163 @@ ipcMain.handle('repoAgents:install', (_e, payload = {}) => {
   };
 });
 
+// ─── MCP install-from-repo flow ───────────────────────────────────────────
+//
+// Sibling of the repoAgents flow above. A user points Husk at a cloned
+// repo that ships <root>/mcp-servers/<name>/, picks which servers to
+// install AND which CLIs to install them into, and Husk handles the
+// build (when needed) and the per-CLI config write.
+//
+// Pure scanning + spec-building lives in src/lib/repo-mcp.js so it can
+// be unit-tested without spinning up Electron. The IPC layer below is
+// the thin shell that connects the renderer to that module + the
+// existing per-CLI MCP adapters in src/lib/mcp/.
+//
+// IPCs:
+//   repoMcp:pickDir   native folder picker (same as repoAgents)
+//   repoMcp:scan      scans <root>/mcp-servers/* and returns descriptions
+//   repoMcp:build     runs npm install + npm run build inside one server
+//   repoMcp:install   takes a built spec + a list of CLI targets, writes
+//                     to each tool's MCP config via the existing adapters
+//                     (or emits a config-snippet for tools we do not own
+//                     a safe write path for yet, e.g. Codex/Aider)
+
+const RepoMcp = require('./lib/repo-mcp');
+const McpAdapters = require('./lib/mcp');
+
+ipcMain.handle('repoMcp:pickDir', async () => {
+  const r = await dialog.showOpenDialog(mainWindow, {
+    title: 'Select a repo that ships mcp-servers/',
+    properties: ['openDirectory'],
+  });
+  return r.canceled || !r.filePaths.length ? null : r.filePaths[0];
+});
+
+ipcMain.handle('repoMcp:scan', (_e, payload = {}) => {
+  const root = String((payload && payload.root) || '').trim();
+  if (!root || !path.isAbsolute(root)) {
+    return { ok: false, error: 'absolute path required' };
+  }
+  return RepoMcp.scanRepoForMcpServers(root);
+});
+
+// Run `npm install` then (if the package declares it) `npm run build`
+// inside one server directory. Streams a final stdout/stderr tail back
+// to the renderer; no live event channel yet, keeps the wire surface
+// minimal. Honors a 5-minute total wall-clock cap so a hung native
+// build cannot freeze Husk.
+ipcMain.handle('repoMcp:build', async (_e, payload = {}) => {
+  const dir = String((payload && payload.dir) || '').trim();
+  if (!dir || !path.isAbsolute(dir)) return { ok: false, error: 'absolute server dir required' };
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    return { ok: false, error: 'server dir does not exist' };
+  }
+  const pkgPath = path.join(dir, 'package.json');
+  let pkg = null;
+  try { pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); } catch (_) {}
+  if (!pkg) return { ok: false, error: 'no readable package.json' };
+
+  const cap = Date.now() + 5 * 60 * 1000;
+  const runOnce = (script) => new Promise((resolve) => {
+    const args = script === 'install' ? ['install', '--no-audit', '--no-fund'] : ['run', script];
+    let proc;
+    try {
+      proc = spawn('npm', args, { cwd: dir, env: process.env, windowsHide: true });
+    } catch (err) {
+      resolve({ ok: false, error: err.message, stdoutTail: '', stderrTail: '' });
+      return;
+    }
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => { stdout += d.toString(); if (stdout.length > 8192) stdout = stdout.slice(-4096); });
+    proc.stderr.on('data', (d) => { stderr += d.toString(); if (stderr.length > 8192) stderr = stderr.slice(-4096); });
+    const killer = setTimeout(() => { try { proc.kill('SIGKILL'); } catch (_) {} }, Math.max(1000, cap - Date.now()));
+    proc.on('close', (code) => {
+      clearTimeout(killer);
+      if (code === 0) resolve({ ok: true, stdoutTail: stdout, stderrTail: stderr });
+      else resolve({ ok: false, error: `npm ${args.join(' ')} exited ${code}`, stdoutTail: stdout, stderrTail: stderr });
+    });
+    proc.on('error', (err) => {
+      clearTimeout(killer);
+      resolve({ ok: false, error: err.message, stdoutTail: stdout, stderrTail: stderr });
+    });
+  });
+
+  const stages = [];
+  const installRes = await runOnce('install');
+  stages.push({ stage: 'install', ...installRes });
+  if (!installRes.ok) return { ok: false, stages };
+  if (pkg.scripts && typeof pkg.scripts.build === 'string') {
+    const buildRes = await runOnce('build');
+    stages.push({ stage: 'build', ...buildRes });
+    if (!buildRes.ok) return { ok: false, stages };
+  }
+  return { ok: true, stages };
+});
+
+// Targets and what each one does on install:
+//   claude   → adapter.add() writes ~/.claude.json
+//   copilot  → adapter.add() writes ~/.copilot/mcp-config.json
+//   codex    → snippet only (TOML), no write yet
+//   aider    → snippet only (CLI --mcp flag), no write yet
+//
+// Per-target results are independent. A failure in one does not block
+// the others. The renderer paints a per-target status pill from the
+// returned `results` map.
+const SNIPPET_TARGETS = new Set(['codex', 'aider']);
+const WRITE_TARGETS = new Set(['claude', 'copilot']);
+const KNOWN_TARGETS = new Set([...SNIPPET_TARGETS, ...WRITE_TARGETS]);
+
+ipcMain.handle('repoMcp:install', (_e, payload = {}) => {
+  const summary = payload && payload.server;
+  const envValues = (payload && payload.envValues) || {};
+  const targets = Array.isArray(payload && payload.targets) ? payload.targets : [];
+  const serverId = String((payload && payload.serverId) || (summary && summary.name) || '').trim();
+  if (!summary || typeof summary !== 'object') return { ok: false, error: 'server summary required' };
+  if (!serverId || !/^[a-zA-Z0-9_-]+$/.test(serverId)) {
+    return { ok: false, error: 'serverId must match [a-zA-Z0-9_-]+' };
+  }
+  if (!targets.length) return { ok: false, error: 'pick at least one target' };
+
+  const built = RepoMcp.buildServerSpec(summary, envValues);
+  if (!built.ok) return { ok: false, error: built.error };
+  const spec = built.spec;
+
+  const results = {};
+  for (const target of targets) {
+    if (!KNOWN_TARGETS.has(target)) {
+      results[target] = { status: 'error', error: 'unknown target' };
+      continue;
+    }
+    if (SNIPPET_TARGETS.has(target)) {
+      const snippet = target === 'codex'
+        ? RepoMcp.renderCodexSnippet(serverId, spec)
+        : RepoMcp.renderAiderSnippet(serverId, spec);
+      results[target] = { status: 'snippet', snippet };
+      continue;
+    }
+    // Real write path: hand off to the per-CLI adapter. add() refuses
+    // duplicates by design; we surface that as a benign "already
+    // installed" status instead of swallowing it.
+    const adapter = McpAdapters.ADAPTERS[target];
+    if (!adapter || !adapter.supportsWrite) {
+      results[target] = { status: 'error', error: 'adapter does not support writes' };
+      continue;
+    }
+    const addRes = adapter.add({
+      id: serverId,
+      transport: spec.transport,
+      command: spec.command,
+      args: spec.args,
+      env: spec.env || {},
+    });
+    if (addRes.ok) results[target] = { status: 'installed', configPath: adapter.configPath };
+    else if (/already exists/i.test(addRes.error || '')) results[target] = { status: 'exists', configPath: adapter.configPath };
+    else results[target] = { status: 'error', error: addRes.error, configPath: adapter.configPath };
+  }
+  return { ok: true, serverId, spec, results };
+});
+
 ipcMain.handle('profiles:create', (_e, payload = {}) => {
   const id = `profile-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
   const entry = {

--- a/src/preload.js
+++ b/src/preload.js
@@ -92,6 +92,12 @@ contextBridge.exposeInMainWorld('husk', {
     scan: (root) => ipcRenderer.invoke('repoAgents:scan', { root }),
     install: (opts) => ipcRenderer.invoke('repoAgents:install', opts || {}),
   },
+  repoMcp: {
+    pickDir: () => ipcRenderer.invoke('repoMcp:pickDir'),
+    scan: (root) => ipcRenderer.invoke('repoMcp:scan', { root }),
+    build: (dir) => ipcRenderer.invoke('repoMcp:build', { dir }),
+    install: (opts) => ipcRenderer.invoke('repoMcp:install', opts || {}),
+  },
   mcp: {
     catalog: () => ipcRenderer.invoke('mcp:catalog'),
     list: () => ipcRenderer.invoke('mcp:list'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1837,6 +1837,229 @@ $('#ra-root') && $('#ra-root').addEventListener('keydown', (e) => {
   }
 });
 $('#repo-agents-modal') && $('#repo-agents-modal').addEventListener('click', (e) => { if (e.target === $('#repo-agents-modal')) closeRepoAgentsModal(); });
+
+// ─── Install MCP servers from a cloned repo ───────────────────────────────────
+// Sibling of the agent install flow. Three views inside a single modal:
+//   1) "list" — picker for repo path + scanned servers
+//   2) "detail" — env-var form + per-CLI target checkboxes for one server
+//   3) "results" — per-CLI status pills + copy-able snippets for codex/aider
+// Each view replaces the modal body, the foot button changes role between
+// Install / Back / Done so the user always knows what to press next.
+let rmScan = null;
+let rmPicked = null;
+function openRepoMcpModal() {
+  const m = $('#repo-mcp-modal');
+  if (!m) return;
+  rmScan = null;
+  rmPicked = null;
+  if ($('#rm-root')) $('#rm-root').value = '';
+  rmSetView('list');
+  rmStatus('');
+  m.hidden = false;
+  setTimeout(() => { try { $('#rm-root').focus(); } catch (_) {} }, 0);
+}
+function closeRepoMcpModal() { const m = $('#repo-mcp-modal'); if (m) m.hidden = true; }
+function rmStatus(text, kind) {
+  const el = $('#rm-status'); if (!el) return;
+  if (!text) { el.hidden = true; el.textContent = ''; el.className = 'ra-status'; return; }
+  el.hidden = false; el.className = 'ra-status' + (kind ? ' ra-status-' + kind : '');
+  el.textContent = text;
+}
+function rmSetView(view) {
+  const list = $('#rm-list'); const detail = $('#rm-detail'); const results = $('#rm-results');
+  const installBtn = $('#rm-install'); const cancelBtn = $('#rm-cancel');
+  if (list) list.hidden = view !== 'list';
+  if (detail) detail.hidden = view !== 'detail';
+  if (results) results.hidden = view !== 'results';
+  if (installBtn) {
+    installBtn.disabled = true;
+    installBtn.textContent = view === 'detail' ? 'Install' : (view === 'list' ? 'Next' : 'Done');
+    installBtn.onclick = view === 'detail' ? rmDoInstall : (view === 'list' ? rmAdvanceToDetail : closeRepoMcpModal);
+    if (view === 'results') installBtn.disabled = false;
+  }
+  if (cancelBtn) cancelBtn.textContent = view === 'list' ? 'Close' : 'Back';
+  cancelBtn.onclick = view === 'list' ? closeRepoMcpModal : () => rmSetView(view === 'detail' ? 'list' : 'detail');
+}
+async function rmBrowse() {
+  const picked = await window.husk.repoMcp.pickDir();
+  if (!picked) return;
+  if ($('#rm-root')) $('#rm-root').value = picked;
+  await rmScanRoot(picked);
+}
+async function rmScanRoot(root) {
+  const list = $('#rm-list'); if (!list) return;
+  rmStatus('Scanning…');
+  // eslint-disable-next-line no-unsanitized/property -- static loading copy
+  list.innerHTML = '<div class="ai-empty">Looking for mcp-servers/*…</div>';
+  const res = await window.husk.repoMcp.scan(root);
+  if (!res || !res.ok) {
+    rmStatus((res && res.error) || 'Scan failed', 'error');
+    // eslint-disable-next-line no-unsanitized/property -- escapeHtml below
+    list.innerHTML = `<div class="ai-empty">${escapeHtml((res && res.error) || 'Could not scan that folder')}</div>`;
+    rmScan = null; return;
+  }
+  rmScan = res;
+  if (!res.hasServersDir) {
+    // eslint-disable-next-line no-unsanitized/property -- static html
+    list.innerHTML = '<div class="ai-empty">No <code>mcp-servers/</code> directory at that path.</div>';
+    rmStatus('');
+    return;
+  }
+  if (!res.servers.length) {
+    // eslint-disable-next-line no-unsanitized/property -- static html
+    list.innerHTML = '<div class="ai-empty">The <code>mcp-servers/</code> dir exists but contains no subfolders.</div>';
+    rmStatus('');
+    return;
+  }
+  rmStatus(res.truncated
+    ? `Showing first ${res.servers.length} of ${res.totalFound} servers. Narrow the repo if you need more.`
+    : `Found ${res.servers.length} server${res.servers.length !== 1 ? 's' : ''}.`, 'info');
+  // eslint-disable-next-line no-unsanitized/property -- every interpolation escaped
+  list.innerHTML = res.servers.map((s, i) => {
+    const pillBits = [];
+    if (!s.installable) pillBits.push('<span class="ai-row-pill">not installable</span>');
+    if (s.needsBuild) pillBits.push('<span class="ai-row-pill">needs build</span>');
+    if (s.mainExists) pillBits.push('<span class="ai-row-pill">ready</span>');
+    return `
+      <label class="ai-row${s.installable ? '' : ' is-duplicate'}">
+        <input type="radio" name="rm-pick" class="ai-check rm-pick" data-idx="${i}" ${s.installable ? '' : 'disabled'} />
+        <span class="ai-check-box" aria-hidden="true"></span>
+        <div class="ai-row-body">
+          <div class="ai-row-name">${escapeHtml(s.displayName)}<span class="ai-row-source">${escapeHtml(s.name)}</span></div>
+          ${s.description ? `<div class="ai-row-desc">${escapeHtml(s.description)}</div>` : ''}
+        </div>
+        ${pillBits.join('')}
+      </label>
+    `;
+  }).join('');
+  list.querySelectorAll('.rm-pick').forEach((el) => el.addEventListener('change', () => {
+    const i = Number(el.dataset.idx);
+    rmPicked = (rmScan && Array.isArray(rmScan.servers)) ? rmScan.servers[i] : null;
+    const btn = $('#rm-install'); if (btn) btn.disabled = !rmPicked;
+  }));
+}
+function rmAdvanceToDetail() {
+  if (!rmPicked) return;
+  const detail = $('#rm-detail'); if (!detail) return;
+  const envFields = (rmPicked.envVars || []).map((e) => {
+    const safeId = 'rm-env-' + e.key.replace(/[^a-zA-Z0-9_-]/g, '');
+    return `
+      <label class="pref-row" style="flex-direction:column; align-items:stretch; gap:4px;">
+        <span class="pref-label" style="font-family:'JetBrains Mono', monospace; font-size: 12px;">${escapeHtml(e.key)}</span>
+        <input type="text" data-env="${escapeAttr(e.key)}" id="${escapeAttr(safeId)}" placeholder="${escapeAttr(e.hint || '')}" spellcheck="false" autocomplete="off" />
+      </label>
+    `;
+  }).join('') || '<div class="ai-empty" style="padding:10px 0;">No environment variables declared.</div>';
+  const targets = [
+    { id: 'claude', label: 'Claude Code', sub: 'writes ~/.claude.json', write: true },
+    { id: 'copilot', label: 'GitHub Copilot CLI', sub: 'writes ~/.copilot/mcp-config.json', write: true },
+    { id: 'codex', label: 'Codex CLI', sub: 'shows TOML snippet to paste into ~/.codex/config.toml', write: false },
+    { id: 'aider', label: 'Aider', sub: 'shows --mcp flag snippet to paste into your aider invocation', write: false },
+  ];
+  // eslint-disable-next-line no-unsanitized/property -- every interpolation escaped
+  detail.innerHTML = `
+    <div class="ra-status ra-status-info"><strong>${escapeHtml(rmPicked.displayName)}</strong> · <code>${escapeHtml(rmPicked.dir)}</code></div>
+    ${rmPicked.needsBuild ? `
+      <label class="ai-foot-toggle" title="Run npm install + npm run build inside the server before installing">
+        <input type="checkbox" id="rm-build" class="ai-check" checked />
+        <span class="ai-check-box" aria-hidden="true"></span>
+        Run npm install + npm run build first (the server's <code>dist/</code> is missing)
+      </label>
+      <div class="ra-status ra-status-info" style="margin-top:6px;">
+        Heads up: running build executes the server's <code>package.json</code> lifecycle scripts (preinstall / install / postinstall / build). Only do this for repos you trust.
+      </div>
+    ` : ''}
+    <div class="modal-section">
+      <div class="modal-label">Environment variables</div>
+      ${envFields}
+    </div>
+    <div class="modal-section">
+      <div class="modal-label">Install into</div>
+      ${targets.map((t) => `
+        <label class="ai-foot-toggle" title="${escapeAttr(t.sub)}">
+          <input type="checkbox" class="ai-check rm-target" data-target="${escapeAttr(t.id)}" ${t.write ? 'checked' : ''} />
+          <span class="ai-check-box" aria-hidden="true"></span>
+          ${escapeHtml(t.label)} <span class="ai-row-source">${escapeHtml(t.sub)}</span>
+        </label>
+      `).join('')}
+    </div>
+  `;
+  rmSetView('detail');
+  const updateBtn = () => {
+    const picked = $$('#rm-detail .rm-target:checked').length;
+    const btn = $('#rm-install'); if (btn) btn.disabled = picked === 0;
+  };
+  $$('#rm-detail .rm-target').forEach((el) => el.addEventListener('change', updateBtn));
+  updateBtn();
+}
+async function rmDoInstall() {
+  if (!rmPicked) return;
+  const targets = $$('#rm-detail .rm-target:checked').map((el) => el.dataset.target);
+  if (!targets.length) return;
+  const envValues = {};
+  $$('#rm-detail input[data-env]').forEach((el) => { envValues[el.dataset.env] = el.value; });
+  const btn = $('#rm-install'); if (btn) { btn.disabled = true; btn.textContent = 'Installing…'; }
+  const shouldBuild = rmPicked.needsBuild && $('#rm-build') && $('#rm-build').checked;
+  rmStatus(shouldBuild ? 'Running npm install + build…' : 'Installing…', 'info');
+  if (shouldBuild) {
+    const br = await window.husk.repoMcp.build(rmPicked.dir);
+    if (!br || !br.ok) {
+      const lastStage = br && Array.isArray(br.stages) ? br.stages[br.stages.length - 1] : null;
+      rmStatus((lastStage && lastStage.error) ? `Build failed: ${lastStage.error}` : 'Build failed', 'error');
+      if (btn) { btn.disabled = false; btn.textContent = 'Install'; }
+      return;
+    }
+  }
+  const res = await window.husk.repoMcp.install({
+    server: rmPicked,
+    envValues,
+    targets,
+    serverId: (rmPicked.name || '').toLowerCase().replace(/[^a-z0-9_-]/g, '-'),
+  });
+  if (!res || !res.ok) {
+    rmStatus((res && res.error) || 'Install failed', 'error');
+    if (btn) { btn.disabled = false; btn.textContent = 'Install'; }
+    return;
+  }
+  rmRenderResults(res);
+  try { const inv = await reloadMcpInventory(); snapshotLoadedMcps(inv); } catch (_) {}
+}
+function rmRenderResults(res) {
+  const wrap = $('#rm-results'); if (!wrap) return;
+  rmStatus('');
+  const rows = Object.keys(res.results || {}).map((target) => {
+    const r = res.results[target] || {};
+    let body = '';
+    let pill = '';
+    if (r.status === 'installed') { pill = 'Installed'; body = `<div class="ai-row-desc">wrote to <code>${escapeHtml(r.configPath || '')}</code></div>`; }
+    else if (r.status === 'exists') { pill = 'Already installed'; body = `<div class="ai-row-desc">entry already in <code>${escapeHtml(r.configPath || '')}</code>; remove it first if you want to replace</div>`; }
+    else if (r.status === 'snippet') {
+      pill = 'Snippet';
+      body = `<pre class="ai-row-snippet" style="white-space:pre-wrap; font-family:'JetBrains Mono', monospace; font-size: 11.5px; background: var(--bg-2); border: 1px solid var(--line); border-radius: var(--radius-md); padding: 8px 10px; margin: 6px 0 0;">${escapeHtml(r.snippet || '')}</pre><div style="margin-top:6px;"><button class="ghost-btn rm-copy" data-text="${escapeAttr(r.snippet || '')}">Copy</button></div>`;
+    } else { pill = 'Error'; body = `<div class="ai-row-desc">${escapeHtml(r.error || 'unknown error')}</div>`; }
+    return `
+      <div class="ai-row" style="cursor:default;">
+        <div class="ai-row-body">
+          <div class="ai-row-name">${escapeHtml(target)}<span class="ai-row-source">${escapeHtml(res.serverId || '')}</span></div>
+          ${body}
+        </div>
+        <span class="ai-row-pill">${escapeHtml(pill)}</span>
+      </div>`;
+  }).join('');
+  // eslint-disable-next-line no-unsanitized/property -- escapeHtml above for every dynamic value
+  wrap.innerHTML = `<div class="ai-list">${rows}</div>`;
+  wrap.querySelectorAll('.rm-copy').forEach((b) => b.addEventListener('click', async () => {
+    try { await navigator.clipboard.writeText(b.dataset.text || ''); toast('Snippet copied', 'success'); } catch (_) {}
+  }));
+  rmSetView('results');
+}
+$('#btn-mcp-install-from-repo') && $('#btn-mcp-install-from-repo').addEventListener('click', openRepoMcpModal);
+$('#rm-close') && $('#rm-close').addEventListener('click', closeRepoMcpModal);
+$('#rm-browse') && $('#rm-browse').addEventListener('click', rmBrowse);
+$('#rm-root') && $('#rm-root').addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') { e.preventDefault(); const v = ($('#rm-root').value || '').trim(); if (v) rmScanRoot(v); }
+});
+$('#repo-mcp-modal') && $('#repo-mcp-modal').addEventListener('click', (e) => { if (e.target === $('#repo-mcp-modal')) closeRepoMcpModal(); });
 $('#agent-modal-close') && $('#agent-modal-close').addEventListener('click', closeAgentModal);
 $('#agent-modal-cancel') && $('#agent-modal-cancel').addEventListener('click', closeAgentModal);
 $('#agent-modal-save') && $('#agent-modal-save').addEventListener('click', saveAgentModal);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -418,6 +418,31 @@
           </div>
         </div>
 
+        <!-- INSTALL MCP SERVERS FROM REPO MODAL -->
+        <div id="repo-mcp-modal" class="modal" hidden>
+          <div class="modal-card modal-card-md">
+            <div class="modal-head">
+              <h2 class="modal-title">Install MCP servers from repo</h2>
+              <button class="modal-close" id="rm-close" aria-label="Close">&times;</button>
+            </div>
+            <div class="modal-body">
+              <p class="ra-hint">Point Husk at a cloned repo that ships an <code>mcp-servers/</code> directory. Each subfolder with a <code>package.json</code> is offered as a separate server. Husk will build it when needed and write the right entry into the active CLI's MCP config. Claude and Copilot get a real config write; Codex and Aider get a snippet you can paste.</p>
+              <div class="ra-pathrow">
+                <input type="text" id="rm-root" class="ra-root" placeholder="/path/to/repo-with-mcp-servers" autocomplete="off" spellcheck="false" />
+                <button class="ghost-btn" id="rm-browse">Browse&hellip;</button>
+              </div>
+              <div id="rm-status" class="ra-status" hidden></div>
+              <div id="rm-list" class="ai-list"></div>
+              <div id="rm-detail" hidden></div>
+              <div id="rm-results" hidden></div>
+            </div>
+            <div class="modal-foot ra-foot">
+              <button class="ghost-btn" id="rm-cancel">Close</button>
+              <button class="btn-primary" id="rm-install" disabled>Install</button>
+            </div>
+          </div>
+        </div>
+
         <!-- INSTALL AGENTS FROM REPO MODAL -->
         <div id="repo-agents-modal" class="modal" hidden>
           <div class="modal-card modal-card-md">
@@ -638,6 +663,7 @@
             </div>
             <div class="page-head-right">
               <button class="ghost-btn" id="btn-mcp-refresh" title="Refresh"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7L21 8"/><path d="M21 3v5h-5"/></svg></button>
+              <button class="ghost-btn" id="btn-mcp-install-from-repo" title="Install MCP servers from a cloned repo"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/><path d="M12 11v6M9 14l3 3 3-3"/></svg> Install from repo</button>
               <button class="btn-primary" id="btn-mcp-add-custom" title="Install any MCP server with a custom command"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> Add custom server</button>
             </div>
           </div>

--- a/test/unit/repo-mcp.test.js
+++ b/test/unit/repo-mcp.test.js
@@ -1,0 +1,357 @@
+'use strict';
+
+// Tests for src/lib/repo-mcp.js — scanner, env-example parser, spec
+// builder, snippet renderers. Each fs-touching test mints a private
+// tmpdir; no test ever touches the real home directory.
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  parseEnvExample,
+  scanRepoForMcpServers,
+  describeServer,
+  buildServerSpec,
+  renderCodexSnippet,
+  renderAiderSnippet,
+} = require('../../src/lib/repo-mcp');
+
+let tmp;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-repomcp-')); });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} });
+
+function mkServer(name, opts = {}) {
+  const dir = path.join(tmp, 'mcp-servers', name);
+  fs.mkdirSync(dir, { recursive: true });
+  if (opts.pkg !== null) {
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(opts.pkg || {
+      name, main: 'dist/index.js', scripts: { build: 'tsc', start: 'node dist/index.js' },
+    }, null, 2));
+  }
+  if (opts.distMain) {
+    fs.mkdirSync(path.join(dir, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'dist', 'index.js'), opts.distMain);
+  }
+  if (opts.env) fs.writeFileSync(path.join(dir, '.env.example'), opts.env);
+  return dir;
+}
+
+// ─── parseEnvExample ───────────────────────────────────────────────────────
+
+test('parseEnvExample: returns KEY/hint pairs in file order', () => {
+  const text = 'TOKEN=your bot token\nCHANNEL=channel id\n';
+  const out = parseEnvExample(text);
+  assert.deepEqual(out, [
+    { key: 'TOKEN', hint: 'your bot token' },
+    { key: 'CHANNEL', hint: 'channel id' },
+  ]);
+});
+
+test('parseEnvExample: skips comments and blank lines', () => {
+  const text = [
+    '# a comment',
+    '',
+    'TOKEN=abc',
+    '   ',
+    '# trailing comment',
+    'OTHER=xyz',
+  ].join('\n');
+  assert.deepEqual(parseEnvExample(text), [
+    { key: 'TOKEN', hint: 'abc' },
+    { key: 'OTHER', hint: 'xyz' },
+  ]);
+});
+
+test('parseEnvExample: strips matched outer quotes from the hint', () => {
+  assert.deepEqual(parseEnvExample('TOKEN="quoted hint"\nOTHER=\'single\'\n'), [
+    { key: 'TOKEN', hint: 'quoted hint' },
+    { key: 'OTHER', hint: 'single' },
+  ]);
+});
+
+test('parseEnvExample: ignores lines without =', () => {
+  assert.deepEqual(parseEnvExample('JUST_A_KEY\nOTHER=ok\n'), [
+    { key: 'OTHER', hint: 'ok' },
+  ]);
+});
+
+test('parseEnvExample: rejects keys with invalid characters', () => {
+  // Spaces and lowercase-start are tolerated by some tools but we follow
+  // the strict dotenv convention to avoid emitting weird env names.
+  assert.deepEqual(parseEnvExample('bad key=v\n9LEADING=v\nOK_KEY=v\n'), [
+    { key: 'OK_KEY', hint: 'v' },
+  ]);
+});
+
+test('parseEnvExample: empty / non-string input returns []', () => {
+  assert.deepEqual(parseEnvExample(''), []);
+  assert.deepEqual(parseEnvExample(undefined), []);
+  assert.deepEqual(parseEnvExample(null), []);
+});
+
+// ─── scanRepoForMcpServers ─────────────────────────────────────────────────
+
+test('scanRepoForMcpServers: returns empty + hasServersDir=false when no mcp-servers dir', () => {
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.ok, true);
+  assert.equal(res.hasServersDir, false);
+  assert.deepEqual(res.servers, []);
+});
+
+test('scanRepoForMcpServers: lists each subdir as a server, alphabetically', () => {
+  mkServer('zeta');
+  mkServer('alpha');
+  mkServer('mu');
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.hasServersDir, true);
+  assert.deepEqual(res.servers.map((s) => s.name), ['alpha', 'mu', 'zeta']);
+});
+
+test('scanRepoForMcpServers: server without package.json gets installable=false', () => {
+  // mkServer creates package.json by default; skip it for this case.
+  fs.mkdirSync(path.join(tmp, 'mcp-servers', 'naked'), { recursive: true });
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.servers[0].pkgFound, false);
+  assert.equal(res.servers[0].installable, false);
+});
+
+test('scanRepoForMcpServers: server with malformed package.json reports pkgParseError', () => {
+  const dir = path.join(tmp, 'mcp-servers', 'broken');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ not valid json');
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.servers[0].pkgFound, true);
+  assert.ok(res.servers[0].pkgParseError, 'parse error reported');
+  assert.equal(res.servers[0].installable, false);
+});
+
+test('scanRepoForMcpServers: needsBuild=true when main is missing and build script exists', () => {
+  mkServer('needs-build', { pkg: {
+    name: 'needs-build', main: 'dist/index.js',
+    scripts: { build: 'tsc' },
+  } });
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.servers[0].needsBuild, true);
+  assert.equal(res.servers[0].mainExists, false);
+});
+
+test('scanRepoForMcpServers: needsBuild=false when main is already present', () => {
+  mkServer('prebuilt', {
+    pkg: { name: 'prebuilt', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '// built',
+  });
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.servers[0].mainExists, true);
+  assert.equal(res.servers[0].needsBuild, false);
+});
+
+test('scanRepoForMcpServers: surfaces description from package.json', () => {
+  mkServer('described', { pkg: {
+    name: 'described', main: 'dist/index.js', description: 'sends pings',
+    scripts: { build: 'tsc' },
+  } });
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(res.servers[0].description, 'sends pings');
+});
+
+test('scanRepoForMcpServers: returns absolute serversDir + relative dir for each', () => {
+  mkServer('abc', { distMain: '//' });
+  const res = scanRepoForMcpServers(tmp);
+  assert.equal(path.isAbsolute(res.serversDir), true);
+  assert.equal(path.isAbsolute(res.servers[0].dir), true);
+});
+
+test('scanRepoForMcpServers: rejects non-string repoRoot', () => {
+  assert.equal(scanRepoForMcpServers(null).ok, false);
+  assert.equal(scanRepoForMcpServers('').ok, false);
+});
+
+// ─── describeServer envVars wiring ─────────────────────────────────────────
+
+test('describeServer: env-example keys land in envVars[]', () => {
+  mkServer('with-env', {
+    pkg: { name: 'with-env', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+    env: 'TOKEN=bot token\nCHANNEL_ID=where to post\n',
+  });
+  const summary = describeServer(path.join(tmp, 'mcp-servers'), 'with-env');
+  assert.deepEqual(summary.envVars.map((e) => e.key), ['TOKEN', 'CHANNEL_ID']);
+});
+
+// ─── buildServerSpec ───────────────────────────────────────────────────────
+
+test('ISC-10: buildServerSpec ALWAYS returns command + args separately (no joined string)', () => {
+  // This is the regression guard for the joined-command bug. The spec
+  // must never lose the structural split between command and args.
+  mkServer('alpha', {
+    pkg: { name: 'alpha', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+  });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], {});
+  assert.equal(out.ok, true);
+  assert.equal(typeof out.spec.command, 'string');
+  assert.ok(Array.isArray(out.spec.args), 'args must be an array');
+  assert.ok(!out.spec.command.includes(' '), 'command must not contain spaces');
+});
+
+test('buildServerSpec: { command: "node", args: [<absolute main path>] } shape', () => {
+  mkServer('alpha', {
+    pkg: { name: 'alpha', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+  });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], {});
+  assert.equal(out.spec.command, 'node');
+  assert.equal(out.spec.args.length, 1);
+  assert.equal(path.isAbsolute(out.spec.args[0]), true);
+  assert.equal(out.spec.args[0].endsWith(path.join('alpha', 'dist', 'index.js')), true);
+});
+
+test('buildServerSpec: falls back to start script when main is absent', () => {
+  mkServer('starty', { pkg: {
+    name: 'starty',
+    scripts: { start: 'node lib/server.js' },
+  } });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], {});
+  assert.equal(out.ok, true);
+  assert.equal(out.spec.command, 'node');
+  assert.equal(out.spec.args.length, 1);
+  assert.equal(path.isAbsolute(out.spec.args[0]), true);
+  assert.equal(out.spec.args[0].endsWith(path.join('starty', 'lib', 'server.js')), true);
+});
+
+test('buildServerSpec: refuses a server with no main and no start script', () => {
+  mkServer('empty', { pkg: { name: 'empty', scripts: {} } });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], {});
+  assert.equal(out.ok, false);
+});
+
+test('buildServerSpec: pipes declared env-example keys when values are provided', () => {
+  mkServer('envious', {
+    pkg: { name: 'envious', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+    env: 'TOKEN=bot token\nCHANNEL_ID=where to post\n',
+  });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], { TOKEN: 'abc123', CHANNEL_ID: 'C0001' });
+  assert.equal(out.ok, true);
+  assert.deepEqual(out.spec.env, { TOKEN: 'abc123', CHANNEL_ID: 'C0001' });
+});
+
+test('buildServerSpec: ignores env values for keys the server did not declare', () => {
+  mkServer('only-token', {
+    pkg: { name: 'only-token', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+    env: 'TOKEN=bot token\n',
+  });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], { TOKEN: 'abc', NOT_DECLARED: 'leaks?' });
+  assert.equal(out.spec.env.TOKEN, 'abc');
+  assert.equal(out.spec.env.NOT_DECLARED, undefined);
+});
+
+test('buildServerSpec: trims whitespace and matched outer quotes from env values', () => {
+  mkServer('q', {
+    pkg: { name: 'q', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+    env: 'TOKEN=hint\n',
+  });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], { TOKEN: '  "abc"  ' });
+  assert.equal(out.spec.env.TOKEN, 'abc');
+});
+
+test('buildServerSpec: omits env entirely when no values were supplied', () => {
+  mkServer('quiet', {
+    pkg: { name: 'quiet', main: 'dist/index.js', scripts: { build: 'tsc' } },
+    distMain: '//',
+  });
+  const scan = scanRepoForMcpServers(tmp);
+  const out = buildServerSpec(scan.servers[0], {});
+  assert.equal(out.spec.env, undefined);
+});
+
+test('buildServerSpec: rejects non-object server input', () => {
+  assert.equal(buildServerSpec(null, {}).ok, false);
+  assert.equal(buildServerSpec(undefined, {}).ok, false);
+});
+
+// ─── renderCodexSnippet ────────────────────────────────────────────────────
+
+test('renderCodexSnippet: emits a TOML [[mcp_servers]] block with name/command/args', () => {
+  const out = renderCodexSnippet('my-server', {
+    command: 'node', args: ['/abs/path/index.js'],
+  });
+  assert.match(out, /^\[\[mcp_servers\]\]/);
+  assert.match(out, /name = "my-server"/);
+  assert.match(out, /command = "node"/);
+  assert.match(out, /args = \["\/abs\/path\/index\.js"\]/);
+});
+
+test('renderCodexSnippet: emits inline env table when env is non-empty', () => {
+  const out = renderCodexSnippet('s', {
+    command: 'node', args: ['x'], env: { TOKEN: 'abc', CHANNEL: 'C0001' },
+  });
+  assert.match(out, /env = \{ TOKEN = "abc", CHANNEL = "C0001" \}/);
+});
+
+test('renderCodexSnippet: escapes embedded double quotes and backslashes', () => {
+  const out = renderCodexSnippet('s', {
+    command: 'node', args: ['a"b', 'c\\d'],
+  });
+  assert.match(out, /"a\\"b"/);
+  assert.match(out, /"c\\\\d"/);
+});
+
+// ─── renderAiderSnippet ────────────────────────────────────────────────────
+
+test('renderAiderSnippet: emits a --mcp flag with JSON for the server entry', () => {
+  const out = renderAiderSnippet('my-server', {
+    command: 'node', args: ['/abs/path.js'],
+  });
+  assert.match(out, /^--mcp '/);
+  // Extract the JSON, must parse and contain command + args
+  const m = out.match(/'(\{.*\})'$/);
+  assert.ok(m, 'JSON envelope present');
+  const obj = JSON.parse(m[1]);
+  assert.equal(obj['my-server'].command, 'node');
+  assert.deepEqual(obj['my-server'].args, ['/abs/path.js']);
+});
+
+test('renderAiderSnippet: includes env object when env is non-empty', () => {
+  const out = renderAiderSnippet('s', { command: 'node', args: [], env: { TOKEN: 'abc' } });
+  const m = out.match(/'(\{.*\})'$/);
+  const obj = JSON.parse(m[1]);
+  assert.equal(obj.s.env.TOKEN, 'abc');
+});
+
+// ─── Anti-criteria sanity checks ───────────────────────────────────────────
+
+test('ISC-A1: a freshly built spec is structurally always { command: string, args: array }', () => {
+  // Loop a handful of shapes through the builder and confirm the
+  // structural invariant holds every time. This is the regression
+  // guard the user explicitly called out.
+  const cases = [
+    { pkg: { name: 'a', main: 'dist/i.js', scripts: { build: 'tsc' } }, distMain: '//' },
+    { pkg: { name: 'b', scripts: { start: 'node main.js' } } },
+    { pkg: { name: 'c', main: 'dist/i.js', scripts: { start: 'node dist/i.js' } }, distMain: '//' },
+  ];
+  for (const opts of cases) {
+    const name = opts.pkg.name;
+    mkServer(name, opts);
+  }
+  const scan = scanRepoForMcpServers(tmp);
+  for (const summary of scan.servers) {
+    const out = buildServerSpec(summary, {});
+    assert.equal(out.ok, true, `spec built for ${summary.name}`);
+    assert.equal(typeof out.spec.command, 'string');
+    assert.ok(!out.spec.command.includes(' '));
+    assert.ok(Array.isArray(out.spec.args));
+  }
+});


### PR DESCRIPTION
## Summary

Sibling of the repoAgents install-from-repo flow. Point Husk at a cloned repo that ships `mcp-servers/<name>/`, pick a server, fill the env vars its `.env.example` declares, pick which CLIs to install into, and Husk does the rest.

What lands on disk per CLI target:

| Target | What happens |
| --- | --- |
| **Claude Code** | Existing adapter writes `~/.claude.json` |
| **GitHub Copilot CLI** | Existing adapter writes `~/.copilot/mcp-config.json` |
| **Codex CLI** | Renders a TOML `[[mcp_servers]]` snippet with a Copy button (no write yet, see below) |
| **Aider** | Renders an `--mcp` flag JSON snippet with a Copy button |

Codex / Aider get snippets rather than writes because their config formats are non-JSON (TOML for Codex, ad-hoc for Aider) and the snippet path is the same one their own docs recommend. Real adapters can graduate later behind the same UI.

### The bug this PR makes structurally impossible

`buildServerSpec` always returns `{ command: string, args: array }` with `command` guaranteed not to contain spaces. ISC-10 in the test suite locks this in. Same shape applies to the Copilot / Claude / Codex / Aider outputs. Hand-edited joined-command entries (the kind that broke the slack-logs spawn last week) cannot be produced through Husk anymore.

### Why no behavior change for existing flows

- `mcp:add`, `mcp:list`, `mcp:health` paths untouched
- Existing `Add custom server` modal untouched
- Per-tool adapter code untouched; new IPC routes calls THROUGH them

### Tests

- 31 new node:test cases in `test/unit/repo-mcp.test.js`
- Full unit suite: **230/230** (was 199 pre-PR)
- ESLint security ruleset (same one CI runs): exits 0 locally
- Covers: env-example parsing edge cases, scanner edge cases (missing dir, malformed package.json, needsBuild detection, sort order, description surface, absolute paths), spec builder (joined-string regression guard, fallback to start script, env value filtering and trimming, missing entry points), Codex TOML quoting + env tables, Aider `--mcp` flag JSON envelope, structural anti-criterion across multiple shapes

### Adversarial review notes

- The build step intentionally runs `npm install` + `npm run build` inside the picked dir, which executes the server's `package.json` lifecycle scripts (`preinstall` / `install` / `postinstall` / `build`). The detail view shows a clear "only run this for repos you trust" notice next to the build checkbox.
- 5-minute wall-clock cap on each build stage so a hung native compile cannot freeze Husk.
- `serverId` is regex-checked against `[a-zA-Z0-9_-]+` at the IPC boundary so it cannot inject TOML or JSON syntax into the rendered snippet.

### Files

- `src/lib/repo-mcp.js` (new): pure scan / parse / spec / snippet logic
- `test/unit/repo-mcp.test.js` (new): 31 cases
- `src/main.js`: `repoMcp:{pickDir,scan,build,install}` IPC handlers
- `src/preload.js`: `window.husk.repoMcp` surface
- `src/renderer/index.html`: button + 3-view modal
- `src/renderer/app.js`: modal flow + per-CLI target checkboxes + env form + results view with snippet Copy buttons

## Test plan

- [x] `npm test` 230/230 pass
- [x] `node --check` clean on every edited JS file
- [x] Local ESLint security check (same rules as CI) exits 0
- [x] No personal paths, names, or vendor references in any new file (grep clean)