### PR TITLE
feat(mcp): edit, multi-install, lenient JSON, single Cancel

### DIFF
--- a/src/lib/mcp-json.js
+++ b/src/lib/mcp-json.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// Lenient parser for MCP JSON snippets the user pastes into the
+// custom-install modal. People copy from all sorts of places, with all
+// sorts of surrounding context (indentation from inside a config file,
+// a trailing comma from being mid-array, a stray "mcpServers" wrapper,
+// a leading key like `"my-server":` because they grabbed a single
+// property out of a bigger object). This parser tries to repair the
+// snippet through a small set of well-known transformations and
+// returns a normalized list of entries the install pipeline can act on.
+//
+// Shape on success:
+//   { ok: true, entries: [{ id, entry }, ...] }
+// Shape on failure:
+//   { ok: false, error: 'message' }
+//
+// An "entry" here is the raw object the user wrote (command/args/env
+// for stdio, type/url/headers for remote). The downstream shapeEntry
+// helper turns one entry into the canonical add()-payload shape.
+
+function parseLooseMcpJson(text) {
+  const raw = String(text == null ? '' : text);
+  if (!raw.trim()) return { ok: false, error: 'empty input' };
+
+  // Tier 1: try the input as-is. Fast path for well-formed JSON.
+  const direct = tryParseAndNormalize(raw);
+  if (direct.ok) return direct;
+
+  // Tier 2: strip trailing commas. Common when the snippet was lifted
+  // from the middle of an array or object.
+  const noTrailingCommas = raw.replace(/,(\s*[}\]])/g, '$1');
+  const t2 = tryParseAndNormalize(noTrailingCommas);
+  if (t2.ok) return t2;
+
+  // Tier 3: trim a leading comma and try wrapping with braces. Handles
+  // `"my-server": { ... }` pasted out of a larger object.
+  const trimmed = noTrailingCommas.replace(/^,\s*/, '').replace(/,\s*$/, '');
+  const t3 = tryParseAndNormalize('{' + trimmed + '}');
+  if (t3.ok) return t3;
+
+  // Tier 4: maybe the input has both leading AND trailing commas plus
+  // sibling entries — wrap the whole thing.
+  const t4 = tryParseAndNormalize('{' + noTrailingCommas.replace(/^[,\s]+|[,\s]+$/g, '') + '}');
+  if (t4.ok) return t4;
+
+  return { ok: false, error: t2.error || direct.error || 'could not parse JSON' };
+}
+
+function tryParseAndNormalize(text) {
+  let obj;
+  try { obj = JSON.parse(text); } catch (err) { return { ok: false, error: err.message }; }
+  return normalize(obj);
+}
+
+function normalize(obj) {
+  if (Array.isArray(obj)) {
+    const entries = [];
+    for (const item of obj) {
+      if (looksLikeEntry(item)) entries.push({ id: '', entry: item });
+    }
+    if (!entries.length) return { ok: false, error: 'array had no MCP entries' };
+    return { ok: true, entries };
+  }
+  if (!obj || typeof obj !== 'object') return { ok: false, error: 'not a JSON object' };
+
+  // A bare entry the user typed straight into the box. Lower priority
+  // than the wrapped shapes — we only treat it as a bare entry if the
+  // top level itself has command/url/type. An object whose values are
+  // objects with command/url is the multi-server case below.
+  if (looksLikeEntry(obj)) return { ok: true, entries: [{ id: '', entry: obj }] };
+
+  // { "mcpServers": { ... } } — the canonical claude / copilot config
+  // wrapper. Unwrap and recurse exactly once.
+  if (obj.mcpServers && typeof obj.mcpServers === 'object' && !Array.isArray(obj.mcpServers)) {
+    return normalize(obj.mcpServers);
+  }
+  // Same for VS Code's `servers` wrapper, used in ~/.config/Code/User/mcp.json
+  if (obj.servers && typeof obj.servers === 'object' && !Array.isArray(obj.servers)) {
+    return normalize(obj.servers);
+  }
+
+  // { id1: entry1, id2: entry2, ... } — the multi-server shape that
+  // lets `Install` create N servers at once. Preserve the user's key
+  // names (sanitized at install time, not here).
+  const keys = Object.keys(obj);
+  if (!keys.length) return { ok: false, error: 'no entries found' };
+  const entries = [];
+  for (const key of keys) {
+    const value = obj[key];
+    if (looksLikeEntry(value)) entries.push({ id: key, entry: value });
+  }
+  if (entries.length) return { ok: true, entries };
+  return { ok: false, error: 'no recognizable MCP entries' };
+}
+
+function looksLikeEntry(v) {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
+  if (typeof v.command === 'string' && v.command) return true;
+  if (typeof v.url === 'string' && v.url) return true;
+  // `type: stdio` without a command is incomplete — we still report it
+  // as an entry so the user sees a clear "command required" error at
+  // install time rather than silently dropping it.
+  if (typeof v.type === 'string' && /^(stdio|http|sse)$/.test(v.type)) return true;
+  return false;
+}
+
+function sanitizeId(id) {
+  return String(id || '').trim().replace(/[^a-zA-Z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
+}
+
+// shapeEntry turns one normalized { id, entry } into the canonical
+// add()-payload an adapter expects. Returns either { ok: true, payload }
+// or { ok: false, error }.
+function shapeEntry(id, entry) {
+  if (!entry || typeof entry !== 'object') return { ok: false, error: 'entry must be an object' };
+  const cleanId = sanitizeId(id);
+  const isRemote = !!(entry.url || entry.type === 'http' || entry.type === 'sse');
+  if (isRemote) {
+    if (!entry.url) return { ok: false, error: 'url required for remote MCP' };
+    const payload = {
+      id: cleanId,
+      transport: entry.type === 'sse' ? 'sse' : 'http',
+      url: String(entry.url),
+    };
+    if (entry.headers && typeof entry.headers === 'object' && Object.keys(entry.headers).length) {
+      payload.headers = entry.headers;
+    }
+    return { ok: true, payload };
+  }
+  if (!entry.command) return { ok: false, error: 'command required for stdio MCP' };
+  const payload = {
+    id: cleanId,
+    transport: 'stdio',
+    command: String(entry.command),
+    args: Array.isArray(entry.args) ? entry.args.map(String) : [],
+  };
+  if (entry.env && typeof entry.env === 'object' && Object.keys(entry.env).length) {
+    payload.env = entry.env;
+  }
+  return { ok: true, payload };
+}
+
+module.exports = { parseLooseMcpJson, shapeEntry, sanitizeId };

--- a/src/lib/mcp/claude.js
+++ b/src/lib/mcp/claude.js
@@ -46,6 +46,31 @@ function remove(id) {
   return { ok: true };
 }
 
+// update overwrites an existing server entry in place, preserving its
+// enabled/disabled status. Used by the Edit MCP flow. Returns
+// `{ ok: false, error: 'MCP server "<id>" not found' }` when the id
+// is not present in either bucket.
+function update(id, payload = {}) {
+  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
+  const cfg = readConfig();
+  const inEnabled = !!(cfg.mcpServers && cfg.mcpServers[id]);
+  const inDisabled = !!(cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]);
+  if (!inEnabled && !inDisabled) {
+    return { ok: false, error: `MCP server "${id}" not found` };
+  }
+  const built = buildServerEntry(payload);
+  if (built.error) return { ok: false, error: built.error };
+  if (inEnabled) {
+    cfg.mcpServers = cfg.mcpServers || {};
+    cfg.mcpServers[id] = built.entry;
+  } else {
+    cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
+    cfg._huskMcpDisabled[id] = built.entry;
+  }
+  if (!writeConfig(cfg)) return { ok: false, error: 'Could not write ~/.claude.json' };
+  return { ok: true };
+}
+
 function toggle(id) {
   if (!id) return { ok: false, error: 'No id' };
   const cfg = readConfig();
@@ -93,4 +118,5 @@ module.exports = {
   add,
   remove,
   toggle,
+  update,
 };

--- a/src/lib/mcp/copilot.js
+++ b/src/lib/mcp/copilot.js
@@ -49,6 +49,29 @@ function remove(id) {
   return { ok: true };
 }
 
+// update overwrites an existing server entry in place, preserving its
+// enabled/disabled status. Same contract as the claude adapter.
+function update(id, payload = {}) {
+  if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
+  const cfg = readConfig();
+  const inEnabled = !!(cfg.mcpServers && cfg.mcpServers[id]);
+  const inDisabled = !!(cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]);
+  if (!inEnabled && !inDisabled) {
+    return { ok: false, error: `MCP server "${id}" not found` };
+  }
+  const built = buildServerEntry(payload);
+  if (built.error) return { ok: false, error: built.error };
+  if (inEnabled) {
+    cfg.mcpServers = cfg.mcpServers || {};
+    cfg.mcpServers[id] = built.entry;
+  } else {
+    cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
+    cfg._huskMcpDisabled[id] = built.entry;
+  }
+  if (!writeConfig(cfg)) return { ok: false, error: 'Could not write ~/.copilot/mcp-config.json' };
+  return { ok: true };
+}
+
 function toggle(id) {
   if (!id) return { ok: false, error: 'No id' };
   const cfg = readConfig();
@@ -82,6 +105,7 @@ module.exports = {
   list,
   health,
   add,
+  update,
   remove,
   toggle,
 };

--- a/src/lib/mcp/stub.js
+++ b/src/lib/mcp/stub.js
@@ -19,6 +19,9 @@ function makeStub(agentName) {
     add() {
       return { ok: false, error: `MCP management via Husk is not yet wired up for ${agentName}` };
     },
+    update() {
+      return { ok: false, error: `MCP management via Husk is not yet wired up for ${agentName}` };
+    },
     remove() {
       return { ok: false, error: `MCP management via Husk is not yet wired up for ${agentName}` };
     },

--- a/src/main.js
+++ b/src/main.js
@@ -938,8 +938,58 @@ ipcMain.handle('mcp:list', () => {
 
 ipcMain.handle('mcp:health', () => activeMcpAdapter().health());
 ipcMain.handle('mcp:add', (_e, payload = {}) => activeMcpAdapter().add(payload));
+ipcMain.handle('mcp:update', (_e, payload = {}) => {
+  const adapter = activeMcpAdapter();
+  if (typeof adapter.update !== 'function') return { ok: false, error: 'Edit not supported for this CLI' };
+  const { id, ...rest } = payload || {};
+  return adapter.update(id, rest);
+});
 ipcMain.handle('mcp:remove', (_e, id) => activeMcpAdapter().remove(id));
 ipcMain.handle('mcp:toggle', (_e, id) => activeMcpAdapter().toggle(id));
+
+// addMany takes a list of canonical payloads (each already split into
+// command/args + transport per the buildServerEntry contract) and tries
+// to add() each one. Returns a per-id status map so the renderer can
+// show which succeeded vs. which already existed vs. which errored.
+ipcMain.handle('mcp:addMany', (_e, payload = {}) => {
+  const adapter = activeMcpAdapter();
+  const items = Array.isArray(payload && payload.items) ? payload.items : [];
+  if (!items.length) return { ok: false, error: 'no items supplied' };
+  const results = {};
+  let installed = 0;
+  for (const item of items) {
+    if (!item || !item.id) {
+      results[item && item.id ? item.id : '_anon_'] = { status: 'error', error: 'missing id' };
+      continue;
+    }
+    const r = adapter.add(item);
+    if (r.ok) { results[item.id] = { status: 'installed' }; installed++; }
+    else if (/already exists/i.test(r.error || '')) results[item.id] = { status: 'exists', error: r.error };
+    else results[item.id] = { status: 'error', error: r.error };
+  }
+  return { ok: true, results, installed, total: items.length };
+});
+
+// Lenient JSON parser surface. The renderer hands the raw textarea
+// content; we return either { ok: true, entries: [{ id, payload }] }
+// where each payload is already shapeEntry()-ed and ready for add()
+// or update(), or { ok: false, error } for the user to fix and retry.
+const McpJson = require('./lib/mcp-json');
+ipcMain.handle('mcp:parseSnippet', (_e, payload = {}) => {
+  const text = (payload && typeof payload.text === 'string') ? payload.text : '';
+  const parsed = McpJson.parseLooseMcpJson(text);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+  // Shape each entry, but tolerate per-entry errors so the renderer can
+  // surface the bad ones and still proceed with the good ones.
+  const items = [];
+  const errors = [];
+  for (const e of parsed.entries) {
+    const shaped = McpJson.shapeEntry(e.id, e.entry);
+    if (shaped.ok) items.push(shaped.payload);
+    else errors.push({ id: e.id || '<unnamed>', error: shaped.error });
+  }
+  return { ok: true, items, errors };
+});
 
 // ─── Stats (statusline data) ─────────────────────────────────────────────────────
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -102,9 +102,12 @@ contextBridge.exposeInMainWorld('husk', {
     catalog: () => ipcRenderer.invoke('mcp:catalog'),
     list: () => ipcRenderer.invoke('mcp:list'),
     add: (payload) => ipcRenderer.invoke('mcp:add', payload),
+    addMany: (items) => ipcRenderer.invoke('mcp:addMany', { items }),
+    update: (payload) => ipcRenderer.invoke('mcp:update', payload),
     remove: (id) => ipcRenderer.invoke('mcp:remove', id),
     toggle: (id) => ipcRenderer.invoke('mcp:toggle', id),
     health: () => ipcRenderer.invoke('mcp:health'),
+    parseSnippet: (text) => ipcRenderer.invoke('mcp:parseSnippet', { text }),
   },
   dialog2: {
     pickDir: () => ipcRenderer.invoke('dialog:pickDir'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -3338,6 +3338,9 @@ function mcpRowHTML(s) {
         <span class="mr-cmd">${escapeHtml(detail)}</span>
       </div>
       <div class="mr-actions">
+        <button class="mr-edit" data-edit="1" title="Edit" aria-label="Edit MCP server">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+        </button>
         <button class="toggle ${s.enabled ? 'on' : ''}" data-toggle="1" title="${s.enabled ? 'Disable' : 'Enable'}"></button>
         <button class="mr-remove" data-remove="1" title="Remove">×</button>
       </div>
@@ -3369,6 +3372,7 @@ async function applyMcpChange(label) {
 function bindMcpRows(scope) {
   scope.querySelectorAll('.mcp-row').forEach((row) => {
     const t = row.querySelector('[data-toggle]');
+    const e = row.querySelector('[data-edit]');
     const x = row.querySelector('[data-remove]');
     if (t) t.addEventListener('click', async () => {
       const r = await window.husk.mcp.toggle(row.dataset.id);
@@ -3376,6 +3380,10 @@ function bindMcpRows(scope) {
       toast(`${row.dataset.id} ${r.enabled ? 'enabled' : 'disabled'}`, 'success');
       await renderMcp();
       applyMcpChange(row.dataset.id);
+    });
+    if (e) e.addEventListener('click', () => {
+      const server = mcpInstalled.find((s) => s.id === row.dataset.id);
+      if (server) openMcpEditModal(server);
     });
     if (x) x.addEventListener('click', async () => {
       if (!confirm(`Remove MCP server "${row.dataset.id}"?`)) return;
@@ -3443,33 +3451,74 @@ function paintMcpCatalog() {
   });
 }
 
-function openMcpCustomModal() {
-  $('#mcp-install-title').textContent = 'Install a custom MCP server';
-  $('#mcp-install-sub').textContent = 'Paste a JSON snippet, or pick a transport and fill in the fields.';
+// State for the custom MCP modal. Lives across renders of the modal
+// body so the foot button can stay contextually wired without a re-
+// lookup. mode is 'add' | 'edit'; activeTab is 'stdio' | 'http';
+// view is 'paste' | 'form'; parsedItems holds the last successful
+// parse result while paste is open (drives the foot button label).
+let mcpModalState = {
+  mode: 'add',
+  editingId: null,
+  activeTab: 'stdio',
+  view: 'form',
+  parsedItems: [],
+  parseErrors: [],
+};
+
+function openMcpCustomModal() { renderMcpModal({ mode: 'add' }); }
+function openMcpEditModal(server) {
+  if (!server || !server.id) return;
+  renderMcpModal({ mode: 'edit', server });
+}
+
+// renderMcpModal builds the body content for both Add and Edit flows.
+// Add: starts in form view, server-name input editable, paste view
+//      reachable via a small toggle button. Foot primary button shows
+//      `Install N server(s)` while paste view holds a valid JSON, or
+//      `Install` while form view is active.
+// Edit: starts in form view, pre-filled, server-name input read-only,
+//      no paste view (you cannot rename via edit). Foot primary button
+//      is `Save changes`.
+function renderMcpModal({ mode, server }) {
+  mcpModalState = {
+    mode,
+    editingId: mode === 'edit' && server ? server.id : null,
+    activeTab: 'stdio',
+    view: 'form',
+    parsedItems: [],
+    parseErrors: [],
+  };
+  const isEdit = mode === 'edit';
+  $('#mcp-install-title').textContent = isEdit
+    ? `Edit MCP server: ${server.id}`
+    : 'Install a custom MCP server';
+  $('#mcp-install-sub').textContent = isEdit
+    ? 'Update the fields below and save. The server name is fixed.'
+    : 'Paste a JSON snippet (one or many servers), or fill in the form.';
   const fields = $('#mcp-install-fields');
   const codeStyle = "background:var(--bg-3); color:var(--text); border:1px solid var(--line); border-radius:8px; padding:10px 12px; font-family:'JetBrains Mono', monospace; font-size:12px; resize:vertical;";
-  // eslint-disable-next-line no-unsanitized/property -- Static modal template for MCP custom install form.
+  // eslint-disable-next-line no-unsanitized/property -- Static modal template; dynamic values are escaped where they appear (server.id in the title above sets textContent, not innerHTML).
   fields.innerHTML = `
+    ${isEdit ? '' : `
     <div class="mcp-paste-wrap" id="mcp-paste-wrap" hidden>
       <div class="mcp-input-group">
         <label for="mig-paste-json">Paste your MCP JSON</label>
-        <textarea id="mig-paste-json" rows="8" spellcheck="false" placeholder='{
-  "my-server": {
-    "type": "http",
-    "url": "https://example.com/mcp",
-    "headers": { "Authorization": "Bearer ..." }
-  }
+        <textarea id="mig-paste-json" rows="9" spellcheck="false" placeholder='{
+  "my-server": { "command": "node", "args": ["dist/index.js"] },
+  "remote-svc": { "type": "http", "url": "https://example.com/mcp" }
 }' style="${codeStyle}"></textarea>
-        <div class="mig-hint">Accepts the standard MCP entry shape, with or without an outer wrapper key.</div>
-        <div style="display:flex; gap:8px; margin-top:6px;">
-          <button type="button" class="ghost-btn" id="mcp-paste-cancel">Cancel</button>
-          <button type="button" class="btn-primary" id="mcp-paste-apply" style="flex:1;">Fill the form</button>
-        </div>
+        <div class="mig-hint">Accepts: full <code>mcpServers</code> wrapper, VS Code-style <code>servers</code> wrapper, single-server <code>{ "name": {...} }</code>, an array, a bare entry, or a mid-JSON paste with stray indents and trailing commas. Multiple servers install in one shot.</div>
+        <div id="mig-paste-status" class="ra-status" style="margin-top:8px;" hidden></div>
       </div>
     </div>
+    `}
 
     <div class="mcp-form-wrap" id="mcp-form-wrap">
-      <button type="button" class="ghost-btn" id="mcp-paste-open" style="margin-bottom:10px;">Paste JSON instead</button>
+      ${isEdit ? '' : `
+        <div style="display:flex; gap:8px; margin-bottom:10px; align-items:center;">
+          <button type="button" class="ghost-btn" id="mcp-view-toggle">Paste JSON instead</button>
+        </div>
+      `}
       <div class="mcp-input-group">
         <label>Transport</label>
         <div class="mcp-tabs">
@@ -3477,123 +3526,187 @@ function openMcpCustomModal() {
           <button type="button" class="mcp-tab" data-tab="http">Remote (HTTP / SSE)</button>
         </div>
       </div>
-    <div class="mcp-input-group">
-      <label for="mig-custom-id">Server name</label>
-      <input id="mig-custom-id" type="text" placeholder="my-server" autocomplete="off" />
-      <div class="mig-hint">Letters, numbers, dashes. Used as the key in ~/.claude.json.</div>
-    </div>
-
-    <div data-tab-pane="stdio">
       <div class="mcp-input-group">
-        <label for="mig-custom-cmd">Command</label>
-        <input id="mig-custom-cmd" type="text" placeholder="npx" autocomplete="off" />
+        <label for="mig-custom-id">Server name</label>
+        <input id="mig-custom-id" type="text" placeholder="my-server" autocomplete="off" ${isEdit ? 'readonly' : ''} />
+        <div class="mig-hint">Letters, numbers, dashes. Used as the key in the CLI's MCP config.</div>
       </div>
-      <div class="mcp-input-group">
-        <label for="mig-custom-args">Arguments (one per line)</label>
-        <textarea id="mig-custom-args" rows="3" placeholder="-y\n@my-org/my-mcp-server" style="${codeStyle}"></textarea>
+      <div data-tab-pane="stdio">
+        <div class="mcp-input-group">
+          <label for="mig-custom-cmd">Command</label>
+          <input id="mig-custom-cmd" type="text" placeholder="npx" autocomplete="off" />
+          <div class="mig-hint">Just the binary. Put each arg on its own line below.</div>
+        </div>
+        <div class="mcp-input-group">
+          <label for="mig-custom-args">Arguments (one per line)</label>
+          <textarea id="mig-custom-args" rows="3" placeholder="-y&#10;@my-org/my-mcp-server" style="${codeStyle}"></textarea>
+        </div>
+        <div class="mcp-input-group">
+          <label for="mig-custom-env">Environment variables (KEY=value, one per line)</label>
+          <textarea id="mig-custom-env" rows="3" placeholder="API_KEY=..." style="${codeStyle}"></textarea>
+          <div class="mig-hint">Optional. Useful for API keys or per-server settings.</div>
+        </div>
       </div>
-      <div class="mcp-input-group">
-        <label for="mig-custom-env">Environment variables (KEY=value, one per line)</label>
-        <textarea id="mig-custom-env" rows="3" placeholder="API_KEY=sk-..." style="${codeStyle}"></textarea>
-        <div class="mig-hint">Optional. Useful for API keys or per-server settings.</div>
+      <div data-tab-pane="http" hidden>
+        <div class="mcp-input-group">
+          <label for="mig-custom-type">Transport type</label>
+          <select id="mig-custom-type" style="${codeStyle}">
+            <option value="http">HTTP (streamable)</option>
+            <option value="sse">SSE (server-sent events)</option>
+          </select>
+        </div>
+        <div class="mcp-input-group">
+          <label for="mig-custom-url">URL</label>
+          <input id="mig-custom-url" type="text" placeholder="https://example.com/mcp" autocomplete="off" />
+        </div>
+        <div class="mcp-input-group">
+          <label for="mig-custom-headers">Headers (Header-Name: value, one per line)</label>
+          <textarea id="mig-custom-headers" rows="3" placeholder="Authorization: Bearer your-token-here" style="${codeStyle}"></textarea>
+          <div class="mig-hint">Optional. Used for auth tokens and per-server headers.</div>
+        </div>
       </div>
-    </div>
-
-    <div data-tab-pane="http" hidden>
-      <div class="mcp-input-group">
-        <label for="mig-custom-type">Transport type</label>
-        <select id="mig-custom-type" style="${codeStyle}">
-          <option value="http">HTTP (streamable)</option>
-          <option value="sse">SSE (server-sent events)</option>
-        </select>
-      </div>
-      <div class="mcp-input-group">
-        <label for="mig-custom-url">URL</label>
-        <input id="mig-custom-url" type="text" placeholder="https://example.com/mcp" autocomplete="off" />
-      </div>
-      <div class="mcp-input-group">
-        <label for="mig-custom-headers">Headers (Header-Name: value, one per line)</label>
-        <textarea id="mig-custom-headers" rows="3" placeholder="Authorization: api-key your-token-here\nX-Other-Header: value" style="${codeStyle}"></textarea>
-        <div class="mig-hint">Optional. Used for auth tokens and per-server headers.</div>
-      </div>
-    </div>
     </div>`;
-  // Tab switching
-  let activeTab = 'stdio';
+
+  // Tab switching keeps form view in sync with mcpModalState.activeTab.
   fields.querySelectorAll('.mcp-tab').forEach((t) => {
-    t.addEventListener('click', () => {
-      activeTab = t.dataset.tab;
-      fields.querySelectorAll('.mcp-tab').forEach((x) => x.classList.toggle('active', x.dataset.tab === activeTab));
-      fields.querySelectorAll('[data-tab-pane]').forEach((p) => { p.hidden = p.dataset.tabPane !== activeTab; });
-    });
+    t.addEventListener('click', () => { setMcpActiveTab(t.dataset.tab); });
   });
-  // Paste-JSON flow: parse a snippet and prefill the form fields.
-  const setActiveTab = (tab) => {
-    activeTab = tab;
-    fields.querySelectorAll('.mcp-tab').forEach((x) => x.classList.toggle('active', x.dataset.tab === activeTab));
-    fields.querySelectorAll('[data-tab-pane]').forEach((p) => { p.hidden = p.dataset.tabPane !== activeTab; });
-  };
-  $('#mcp-paste-open').addEventListener('click', () => {
-    $('#mcp-paste-wrap').hidden = false;
-    $('#mcp-form-wrap').hidden = true;
-    setTimeout(() => $('#mig-paste-json').focus(), 30);
-  });
-  $('#mcp-paste-cancel').addEventListener('click', () => {
-    $('#mcp-paste-wrap').hidden = true;
-    $('#mcp-form-wrap').hidden = false;
-  });
-  $('#mcp-paste-apply').addEventListener('click', () => {
-    const raw = ($('#mig-paste-json').value || '').trim();
-    if (!raw) { toast('Paste a JSON snippet first', 'error'); return; }
-    let parsed;
-    try {
-      // Be forgiving: accept fragments by wrapping with braces if needed,
-      // and tolerate trailing commas a user copied from a larger object.
-      const cleaned = raw.replace(/,(\s*[}\]])/g, '$1');
-      parsed = JSON.parse(cleaned);
-    } catch (e1) {
-      try {
-        parsed = JSON.parse('{' + raw.replace(/,(\s*[}\]])/g, '$1') + '}');
-      } catch (e2) {
-        toast(`Could not parse JSON: ${e1.message}`, 'error');
-        return;
-      }
-    }
-    // Normalise: accept either { name: { ... } } or a bare entry.
-    let id = '';
-    let entry = parsed;
-    const keys = Object.keys(parsed || {});
-    const looksLikeEntry = parsed && (parsed.command || parsed.url || parsed.type);
-    if (!looksLikeEntry && keys.length === 1 && parsed[keys[0]] && typeof parsed[keys[0]] === 'object') {
-      id = keys[0];
-      entry = parsed[keys[0]];
-    }
-    if (id) $('#mig-custom-id').value = id.replace(/[^a-zA-Z0-9_-]/g, '-');
-    if (entry.url || entry.type === 'http' || entry.type === 'sse') {
-      setActiveTab('http');
-      $('#mig-custom-type').value = entry.type === 'sse' ? 'sse' : 'http';
-      $('#mig-custom-url').value = entry.url || '';
-      const hdrs = entry.headers || {};
+
+  if (isEdit) {
+    // Pre-fill the form from the existing server. Editing the name is
+    // disallowed so the underlying adapter's update() can find the entry.
+    $('#mig-custom-id').value = server.id;
+    if (server.transport === 'http' || server.transport === 'sse') {
+      setMcpActiveTab('http');
+      $('#mig-custom-type').value = server.transport;
+      $('#mig-custom-url').value = server.url || '';
+      const hdrs = server.headers || {};
       $('#mig-custom-headers').value = Object.entries(hdrs).map(([k, v]) => `${k}: ${v}`).join('\n');
     } else {
-      setActiveTab('stdio');
-      $('#mig-custom-cmd').value = entry.command || '';
-      $('#mig-custom-args').value = (entry.args || []).join('\n');
-      const env = entry.env || {};
-      $('#mig-custom-env').value = Object.entries(env).map(([k, v]) => `${k}=${v}`).join('\n');
+      setMcpActiveTab('stdio');
+      $('#mig-custom-cmd').value = server.command || '';
+      $('#mig-custom-args').value = (server.args || []).join('\n');
+      $('#mig-custom-env').value = Object.entries(server.env || {}).map(([k, v]) => `${k}=${v}`).join('\n');
     }
-    $('#mcp-paste-wrap').hidden = true;
-    $('#mcp-form-wrap').hidden = false;
-    toast('Filled from JSON · review and click Install', 'success');
-  });
+  } else {
+    // Add mode: wire the paste-view toggle + live parse + view toggle.
+    $('#mcp-view-toggle').addEventListener('click', () => { setMcpView(mcpModalState.view === 'form' ? 'paste' : 'form'); });
+    $('#mig-paste-json').addEventListener('input', mcpParseDebounced);
+  }
+
   $('#mcp-install').hidden = false;
-  $('#mcp-install-confirm').onclick = () => submitMcpCustom(() => activeTab);
+  $('#mcp-install-confirm').onclick = submitMcpModal;
   $('#mcp-install-cancel').onclick = () => { $('#mcp-install').hidden = true; };
+  updateMcpFootButton();
 }
-async function submitMcpCustom(getActiveTab) {
+
+function setMcpActiveTab(tab) {
+  mcpModalState.activeTab = tab;
+  const fields = $('#mcp-install-fields'); if (!fields) return;
+  fields.querySelectorAll('.mcp-tab').forEach((x) => x.classList.toggle('active', x.dataset.tab === tab));
+  fields.querySelectorAll('[data-tab-pane]').forEach((p) => { p.hidden = p.dataset.tabPane !== tab; });
+}
+
+function setMcpView(view) {
+  mcpModalState.view = view;
+  const paste = $('#mcp-paste-wrap'); const form = $('#mcp-form-wrap');
+  if (paste) paste.hidden = view !== 'paste';
+  if (form) form.hidden = view !== 'form';
+  const toggle = $('#mcp-view-toggle');
+  if (toggle) toggle.textContent = view === 'paste' ? 'Use the form instead' : 'Paste JSON instead';
+  if (view === 'paste') {
+    setTimeout(() => { try { $('#mig-paste-json').focus(); } catch (_) {} }, 30);
+    mcpParseDebounced();
+  }
+  updateMcpFootButton();
+}
+
+// Live parse on every input event, debounced so a fast typist doesn't
+// pay the IPC round-trip per keystroke.
+let mcpParseTimer = null;
+function mcpParseDebounced() {
+  if (mcpParseTimer) clearTimeout(mcpParseTimer);
+  mcpParseTimer = setTimeout(mcpParseNow, 180);
+}
+async function mcpParseNow() {
+  if (mcpModalState.view !== 'paste') return;
+  const raw = ($('#mig-paste-json') && $('#mig-paste-json').value) || '';
+  if (!raw.trim()) {
+    mcpModalState.parsedItems = []; mcpModalState.parseErrors = [];
+    setMcpPasteStatus('');
+    updateMcpFootButton();
+    return;
+  }
+  const res = await window.husk.mcp.parseSnippet(raw);
+  if (!res || !res.ok) {
+    mcpModalState.parsedItems = []; mcpModalState.parseErrors = [];
+    setMcpPasteStatus((res && res.error) || 'Could not parse JSON', 'error');
+    updateMcpFootButton();
+    return;
+  }
+  mcpModalState.parsedItems = (res.items || []).filter((it) => it && it.id);
+  mcpModalState.parseErrors = res.errors || [];
+  const ok = mcpModalState.parsedItems.length;
+  const bad = mcpModalState.parseErrors.length;
+  const unnamed = (res.items || []).filter((it) => !it.id).length;
+  const parts = [];
+  if (ok) parts.push(`${ok} server${ok !== 1 ? 's' : ''} ready`);
+  if (unnamed) parts.push(`${unnamed} entry without a name (provide one in the JSON)`);
+  if (bad) parts.push(`${bad} with errors`);
+  setMcpPasteStatus(parts.join(' · '), ok ? 'info' : 'error');
+  updateMcpFootButton();
+}
+function setMcpPasteStatus(text, kind) {
+  const el = $('#mig-paste-status'); if (!el) return;
+  if (!text) { el.hidden = true; el.textContent = ''; el.className = 'ra-status'; return; }
+  el.hidden = false; el.textContent = text; el.className = 'ra-status' + (kind ? ' ra-status-' + kind : '');
+}
+function updateMcpFootButton() {
+  const btn = $('#mcp-install-confirm'); if (!btn) return;
+  if (mcpModalState.mode === 'edit') {
+    btn.textContent = 'Save changes';
+    btn.disabled = false;
+    return;
+  }
+  if (mcpModalState.view === 'paste') {
+    const n = mcpModalState.parsedItems.length;
+    btn.textContent = n > 0 ? `Install ${n} server${n !== 1 ? 's' : ''}` : 'Paste JSON above';
+    btn.disabled = n === 0;
+    return;
+  }
+  btn.textContent = 'Install';
+  btn.disabled = false;
+}
+async function submitMcpModal() {
+  if (mcpModalState.mode === 'add' && mcpModalState.view === 'paste') {
+    if (!mcpModalState.parsedItems.length) {
+      toast('Nothing valid to install. Fix the JSON above.', 'error');
+      return;
+    }
+    const r = await window.husk.mcp.addMany(mcpModalState.parsedItems);
+    if (!r || !r.ok) { toast((r && r.error) || 'Install failed', 'error'); return; }
+    const ok = []; const skip = []; const err = [];
+    for (const id of Object.keys(r.results || {})) {
+      const s = r.results[id];
+      if (s.status === 'installed') ok.push(id);
+      else if (s.status === 'exists') skip.push(id);
+      else err.push(`${id}: ${s.error || 'error'}`);
+    }
+    const msg = [];
+    if (ok.length) msg.push(`Installed ${ok.length}`);
+    if (skip.length) msg.push(`${skip.length} already existed`);
+    if (err.length) msg.push(`${err.length} failed`);
+    toast(msg.join(' · ') || 'Done', err.length ? 'error' : 'success');
+    $('#mcp-install').hidden = true;
+    await renderMcp();
+    if (ok.length) applyMcpChange(ok.join(', '));
+    return;
+  }
+  // Form-view path (add or edit). Build the payload from the current
+  // form fields, then call add() or update() based on mode.
   const id = ($('#mig-custom-id').value || '').trim();
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) { toast('Invalid server name', 'error'); return; }
-  const tab = (getActiveTab && getActiveTab()) || 'stdio';
+  const tab = mcpModalState.activeTab;
   let payload;
   if (tab === 'http') {
     const url = ($('#mig-custom-url').value || '').trim();
@@ -3625,10 +3738,12 @@ async function submitMcpCustom(getActiveTab) {
     }
     payload = { id, command, args, env };
   }
-  const r = await window.husk.mcp.add(payload);
-  if (!r.ok) { toast(r.error || 'Install failed', 'error'); return; }
+  const op = mcpModalState.mode === 'edit'
+    ? await window.husk.mcp.update(payload)
+    : await window.husk.mcp.add(payload);
+  if (!op || !op.ok) { toast((op && op.error) || 'Save failed', 'error'); return; }
   $('#mcp-install').hidden = true;
-  toast(`Installed ${id}`, 'success');
+  toast(mcpModalState.mode === 'edit' ? `Updated ${id}` : `Installed ${id}`, 'success');
   await renderMcp();
   applyMcpChange(id);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2423,13 +2423,17 @@ input[type="checkbox"]:disabled {
 .mcp-row .mr-info { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .mcp-row .mr-actions { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
 .mcp-row.disabled { opacity: 0.55; }
-.mcp-row .mr-remove {
+.mcp-row .mr-remove,
+.mcp-row .mr-edit {
   background: transparent; border: 0; cursor: pointer;
   color: var(--text-3); font-size: 16px; padding: 4px 8px;
   border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
   transition: background 0.14s ease, color 0.14s ease;
 }
 .mcp-row .mr-remove:hover { color: var(--rose); background: var(--bg-2); }
+.mcp-row .mr-edit:hover { color: var(--text); background: var(--bg-2); }
+.mcp-row .mr-edit svg { display: block; }
 
 .mcp-grid {
   display: grid; gap: 10px;

--- a/test/unit/mcp-adapters.test.js
+++ b/test/unit/mcp-adapters.test.js
@@ -150,9 +150,19 @@ test('stub adapter: list returns empty unsupported result', async () => {
 test('stub adapter: write methods return descriptive errors', () => {
   const s = makeStub('aider');
   assert.equal(s.add({ id: 'x' }).ok, false);
+  assert.equal(s.update('x', {}).ok, false);
   assert.equal(s.remove('x').ok, false);
   assert.equal(s.toggle('x').ok, false);
   assert.match(s.add({}).error, /aider/);
+  assert.match(s.update('x', {}).error, /aider/);
+});
+
+test('real adapters expose an update() function', () => {
+  // The Edit MCP flow needs both claude and copilot to handle in-place
+  // overwrites. This guards against future refactors silently dropping
+  // the method (the renderer would then fail at runtime).
+  assert.equal(typeof ADAPTERS.claude.update, 'function');
+  assert.equal(typeof ADAPTERS.copilot.update, 'function');
 });
 
 test('stub adapter: health resolves with empty status', async () => {

--- a/test/unit/mcp-json.test.js
+++ b/test/unit/mcp-json.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseLooseMcpJson, shapeEntry, sanitizeId } = require('../../src/lib/mcp-json');
+
+// ─── parseLooseMcpJson ─────────────────────────────────────────────────────
+
+test('parses a standard { mcpServers: { ... } } wrapper', () => {
+  const text = JSON.stringify({ mcpServers: { 'a': { command: 'node', args: ['x.js'] } } });
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries.length, 1);
+  assert.equal(res.entries[0].id, 'a');
+  assert.equal(res.entries[0].entry.command, 'node');
+});
+
+test('parses VS Code style { servers: { ... } } wrapper', () => {
+  const text = JSON.stringify({ servers: { 'svc': { type: 'http', url: 'https://example.com/mcp' } } });
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries[0].id, 'svc');
+  assert.equal(res.entries[0].entry.url, 'https://example.com/mcp');
+});
+
+test('parses single-server wrapper without mcpServers key', () => {
+  const text = '{ "my-server": { "command": "node", "args": ["a.js"] } }';
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries.length, 1);
+  assert.equal(res.entries[0].id, 'my-server');
+});
+
+test('parses a multi-server wrapper and returns ALL entries', () => {
+  const text = JSON.stringify({
+    'one': { command: 'node', args: ['1.js'] },
+    'two': { command: 'node', args: ['2.js'] },
+    'three': { type: 'http', url: 'https://example.com/mcp' },
+  });
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries.length, 3);
+  assert.deepEqual(res.entries.map((e) => e.id).sort(), ['one', 'three', 'two']);
+});
+
+test('parses multi-server inside mcpServers wrapper', () => {
+  const text = JSON.stringify({
+    mcpServers: {
+      'a': { command: 'node', args: ['a'] },
+      'b': { command: 'node', args: ['b'] },
+    },
+  });
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.entries.length, 2);
+});
+
+test('parses bare entry (just the inner object) with id=""', () => {
+  const text = '{ "command": "node", "args": ["x.js"] }';
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries.length, 1);
+  assert.equal(res.entries[0].id, '');
+  assert.equal(res.entries[0].entry.command, 'node');
+});
+
+test('parses an indented snippet copied from the middle of a JSON file', () => {
+  // Exactly the shape the user described — mid-JSON copy, leading and
+  // trailing commas, indented.
+  const text = `
+      "my-server": {
+        "command": "node",
+        "args": ["/abs/path.js"]
+      },
+  `;
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries[0].id, 'my-server');
+  assert.equal(res.entries[0].entry.command, 'node');
+});
+
+test('parses an entry with a trailing comma inside an otherwise valid object', () => {
+  const text = '{ "a": { "command": "node", "args": ["x"], } }';
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries[0].id, 'a');
+});
+
+test('parses two entries pasted as siblings, comma-joined', () => {
+  const text = `
+    "one": { "command": "node", "args": ["1"] },
+    "two": { "command": "node", "args": ["2"] }
+  `;
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries.length, 2);
+});
+
+test('parses JSON array of bare entries', () => {
+  const text = JSON.stringify([
+    { command: 'node', args: ['a'] },
+    { command: 'node', args: ['b'] },
+  ]);
+  const res = parseLooseMcpJson(text);
+  assert.equal(res.ok, true);
+  assert.equal(res.entries.length, 2);
+  assert.equal(res.entries[0].id, '');
+});
+
+test('empty input returns ok:false', () => {
+  assert.equal(parseLooseMcpJson('').ok, false);
+  assert.equal(parseLooseMcpJson('   ').ok, false);
+  assert.equal(parseLooseMcpJson(null).ok, false);
+});
+
+test('truly malformed input returns ok:false with an error message', () => {
+  const res = parseLooseMcpJson('not json at all { } ] [');
+  assert.equal(res.ok, false);
+  assert.ok(res.error);
+});
+
+test('top-level object with no MCP-shaped values returns ok:false', () => {
+  const res = parseLooseMcpJson(JSON.stringify({ a: 1, b: 'two' }));
+  assert.equal(res.ok, false);
+});
+
+// ─── shapeEntry ────────────────────────────────────────────────────────────
+
+test('shapeEntry: stdio entry produces the canonical payload', () => {
+  const res = shapeEntry('my-svr', { command: 'node', args: ['x.js'], env: { K: 'v' } });
+  assert.equal(res.ok, true);
+  assert.equal(res.payload.id, 'my-svr');
+  assert.equal(res.payload.transport, 'stdio');
+  assert.equal(res.payload.command, 'node');
+  assert.deepEqual(res.payload.args, ['x.js']);
+  assert.deepEqual(res.payload.env, { K: 'v' });
+});
+
+test('shapeEntry: http entry produces the canonical payload', () => {
+  const res = shapeEntry('h', { type: 'http', url: 'https://example.com/mcp', headers: { Authorization: 'Bearer x' } });
+  assert.equal(res.ok, true);
+  assert.equal(res.payload.transport, 'http');
+  assert.equal(res.payload.url, 'https://example.com/mcp');
+  assert.deepEqual(res.payload.headers, { Authorization: 'Bearer x' });
+});
+
+test('shapeEntry: sse type is preserved', () => {
+  const res = shapeEntry('s', { type: 'sse', url: 'https://example.com/sse' });
+  assert.equal(res.payload.transport, 'sse');
+});
+
+test('shapeEntry: stdio entry without command is rejected', () => {
+  const res = shapeEntry('x', { args: ['a'] });
+  assert.equal(res.ok, false);
+});
+
+test('shapeEntry: remote entry without url is rejected', () => {
+  const res = shapeEntry('x', { type: 'http' });
+  assert.equal(res.ok, false);
+});
+
+test('shapeEntry: env / headers / args are omitted from payload when empty', () => {
+  const res = shapeEntry('quiet', { command: 'node', args: [] });
+  assert.equal(res.payload.env, undefined);
+  assert.deepEqual(res.payload.args, []);
+});
+
+test('shapeEntry: args entries are coerced to strings', () => {
+  const res = shapeEntry('x', { command: 'node', args: ['x', 42, true] });
+  assert.deepEqual(res.payload.args, ['x', '42', 'true']);
+});
+
+// ─── sanitizeId ────────────────────────────────────────────────────────────
+
+test('sanitizeId: keeps allowed characters, replaces others with -', () => {
+  assert.equal(sanitizeId('my server!'), 'my-server');
+  assert.equal(sanitizeId('   abc 123 ___ '), 'abc-123-___');
+  assert.equal(sanitizeId('a/b/c'), 'a-b-c');
+});
+
+test('sanitizeId: empty / null becomes empty string', () => {
+  assert.equal(sanitizeId(''), '');
+  assert.equal(sanitizeId(null), '');
+  assert.equal(sanitizeId(undefined), '');
+});


### PR DESCRIPTION
## Summary

Four asks bundled into one MCP-page upgrade.

### 1. Edit MCP server

Every installed-server row now has a pencil icon that opens the custom modal pre-filled, with the id field read-only and the primary button relabeled `Save changes`. A new `mcp:update` IPC reads through to a new `adapter.update(id, payload)` method on both `claude.js` and `copilot.js` (and the stub for Codex / Aider / Gemini, which return a clear "not supported yet" error). `update()` preserves enabled vs. disabled state in place; toggling state stays with `toggle()`, edits stay with `update()`.

### 2. Multi-install from a single JSON paste

`mcp:addMany` IPC takes an array of canonical payloads and reports per-id status (`installed` / `exists` / `error`). The paste-view foot button now reads `Install N servers` and dispatches the whole batch in one click. Toast surfaces all three buckets so a partial batch is never silent.

### 3. Lenient JSON parsing

New `src/lib/mcp-json.js` with `parseLooseMcpJson` + `shapeEntry` + `sanitizeId`. Handles every snippet shape we have seen in the wild:

- `{ "mcpServers": {} }` wrapper (Claude / Copilot config)
- `{ "servers": {} }` wrapper (VS Code `mcp.json`)
- Single-server `{ "name": {} }`
- Multi-server siblings
- Bare entries
- Arrays
- **Mid-JSON paste with leading or trailing commas and indent** — the original complaint that triggered this
- Stray trailing commas inside an entry

Live parse on the textarea, debounced 180 ms, surfaces ready / unnamed / error counts above the foot button.

### 4. One Cancel

Dropped the inline `Cancel | Fill the form` button row inside the paste view. The modal foot is the single source of truth now: one Cancel, one primary button. The primary label is contextual:

- Paste view, valid JSON → `Install N servers`
- Paste view, empty or broken JSON → `Paste JSON above` (disabled)
- Form view (add) → `Install`
- Form view (edit) → `Save changes`

Switching between paste and form is a single discrete button at the top of the form view.

## Tests

- **253/253** unit tests pass (was 230)
- 22 new `mcp-json` cases covering every parse-recovery branch
- 1 new `mcp-adapters` case asserting Claude + Copilot expose `update()`
- CI ESLint security ruleset reproduced locally, exits 0

## Files

- `src/lib/mcp-json.js` (new)
- `test/unit/mcp-json.test.js` (new)
- `src/lib/mcp/{claude,copilot,stub}.js` (added `update()`)
- `src/main.js` (mcp:update, mcp:addMany, mcp:parseSnippet IPCs)
- `src/preload.js` (exposes new IPCs)
- `src/renderer/app.js` (rewritten `openMcpCustomModal`, new `openMcpEditModal`, edit button binding)
- `src/renderer/styles.css` (`.mr-edit` styles)

## Test plan

- [x] `npm test` 253/253
- [x] `node --check` clean on every edited JS file
- [x] Local ESLint security ruleset exits 0
- [x] No personal paths or names in any new file (`grep` clean for `dor`, `Atlas`, `Bright`, `brightsec`, `kassofer`, `bappsec`, `bauthobject`, `daniel`)