### PR TITLE
fix(mcp): center the 'Paste JSON instead' toggle above the form

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -3515,7 +3515,7 @@ function renderMcpModal({ mode, server }) {
 
     <div class="mcp-form-wrap" id="mcp-form-wrap">
       ${isEdit ? '' : `
-        <div style="display:flex; gap:8px; margin-bottom:10px; align-items:center;">
+        <div style="display:flex; justify-content:center; margin-bottom:10px;">
           <button type="button" class="ghost-btn" id="mcp-view-toggle">Paste JSON instead</button>
         </div>
       `}


### PR DESCRIPTION
Restores the centered placement of the view-toggle button above the custom MCP form. The previous flex container left-aligned the button by default; switching to `justify-content: center` puts it back in the middle.