### PR TITLE
fix(release): fetch tag annotations in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,15 @@ jobs:
       - name: Checkout for tag metadata
         # softprops/action-gh-release does not check out the repo, so
         # fetch the tag annotation ourselves with a minimal checkout.
+        # fetch-tags: true is REQUIRED. actions/checkout by default
+        # does not pull annotated-tag objects, only lightweight refs.
+        # Without it, `git tag -l --format='%(contents:body)'` falls
+        # back to the merge commit body and the release page ends up
+        # with the PR title instead of the full release notes.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Extract release notes from the annotated tag
         run: |


### PR DESCRIPTION
Adds `fetch-tags: true` to the release-notes extraction step. actions/checkout was pulling lightweight refs only, so `git tag -l --format='%(contents:body)'` fell back to the merge commit body. That is why the v2.1.0 GitHub Release shipped with `release: v2.1.0` as the body instead of the full annotated notes. Backfilled v2.1.0 via `gh release edit`; this change keeps future tags from hitting the same trap.