### PR TITLE
Harden PTY, autonomy, MCP config, and renderer hot paths

### DIFF
--- a/src/lib/autonomy/supervisor.js
+++ b/src/lib/autonomy/supervisor.js
@@ -188,6 +188,37 @@ function startRun(opts = {}) {
     });
   }
 
+  // Async twin of endRun. Same audit ordering, but the end-of-run diff
+  // is computed with the async walker so the Electron main thread is
+  // never frozen hashing a large workspace at run end.
+  async function endRunAsync(detail) {
+    if (state.status === 'running') {
+      state.status = 'ended';
+      state.haltReason = 'natural';
+      state.haltDetail = detail || null;
+      state.endedAt = now();
+      auditWriter.append({ kind: 'end_run', payload: detail || null });
+    }
+    let diff = { ok: false, changes: [] };
+    try {
+      diff = await Snapshot.diffWorkspaceAsync(workspaceRoot, storageRoot, sessionId, { ignore: opts.ignore });
+    } catch (_) { diff = { ok: false, changes: [] }; }
+    auditWriter.append({
+      kind: 'run_summary',
+      payload: {
+        turnCount: state.turnCount,
+        status: state.status,
+        haltReason: state.haltReason,
+        haltDetail: state.haltDetail,
+        startedAt: state.startedAt,
+        endedAt: state.endedAt,
+        durationMs: state.endedAt ? state.endedAt - state.startedAt : 0,
+        diff: diff.ok ? diff.changes : [],
+        meter: budget.state(now()),
+      },
+    });
+  }
+
   function snapshotOnly() { return snap.manifest; }
   function getState() { return Object.assign({}, state); }
 
@@ -203,6 +234,7 @@ function startRun(opts = {}) {
       halt,
       cancel,
       endRun,
+      endRunAsync,
       getState,
       snapshotManifest: snapshotOnly,
       budgetState: () => budget.state(now()),
@@ -250,6 +282,32 @@ function summarizeRun(opts = {}) {
     diff = Snapshot.diffWorkspace(workspaceRoot, storageRoot, sessionId);
   }
   const chain = Audit.verifyAuditChain(storageRoot, sessionId);
+  return buildSummary(audit, diff, chain);
+}
+
+// Async twin of summarizeRun: identical output, but the workspace diff
+// is walked off the main thread.
+async function summarizeRunAsync(opts = {}) {
+  const sessionId = String(opts.sessionId || '').trim();
+  const workspaceRoot = String(opts.workspaceRoot || '').trim();
+  const storageRoot = String(opts.storageRoot || '').trim();
+  if (!sessionId || !storageRoot) {
+    return { ok: false, error: 'sessionId, storageRoot required' };
+  }
+  const decrypt = typeof opts.decrypt === 'function' ? opts.decrypt : null;
+  const audit = Audit.readAuditLog(storageRoot, sessionId, { decrypt });
+  if (!audit.ok) return { ok: false, error: audit.error };
+  let diff = { ok: false, changes: [] };
+  if (workspaceRoot) {
+    try { diff = await Snapshot.diffWorkspaceAsync(workspaceRoot, storageRoot, sessionId); }
+    catch (_) { diff = { ok: false, changes: [] }; }
+  }
+  const chain = Audit.verifyAuditChain(storageRoot, sessionId);
+  return buildSummary(audit, diff, chain);
+}
+
+// Shared shaping for both summarize variants.
+function buildSummary(audit, diff, chain) {
   // Pull the most recent run_summary AND the original start_run row.
   // run_summary carries the final meter / diff; start_run carries the
   // goal + caps the user originally set. Both are needed for Review +
@@ -280,4 +338,4 @@ function summarizeRun(opts = {}) {
   };
 }
 
-module.exports = { startRun, revertRun, summarizeRun };
+module.exports = { startRun, revertRun, summarizeRun, summarizeRunAsync };

--- a/src/lib/mcp/claude.js
+++ b/src/lib/mcp/claude.js
@@ -3,13 +3,22 @@
 const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
-const { shapeServer, readJsonFile, writeJsonFile, buildServerEntry } = require('./common');
+const { shapeServer, readJsonFile, readJsonFileStrict, writeJsonFile, buildServerEntry } = require('./common');
 const { parseMcpListOutput } = require('../mcp-status');
 
 const CONFIG_PATH = path.join(os.homedir(), '.claude.json');
 
 function readConfig() { return readJsonFile(CONFIG_PATH); }
 function writeConfig(obj) { return writeJsonFile(CONFIG_PATH, obj); }
+
+// Read for the write path. Returns the parsed config, or an error
+// string when the file exists but cannot be parsed so the caller can
+// refuse to overwrite it.
+function readConfigForWrite() {
+  const r = readJsonFileStrict(CONFIG_PATH);
+  if (!r.ok) return { error: 'Refusing to write: ~/.claude.json exists but could not be read' };
+  return { cfg: r.data };
+}
 
 function list() {
   const cfg = readConfig();
@@ -25,7 +34,9 @@ function list() {
 function add(payload = {}) {
   const { id } = payload;
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
     return { ok: false, error: `MCP server "${id}" already exists` };
@@ -39,7 +50,9 @@ function add(payload = {}) {
 
 function remove(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
   if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
   writeConfig(cfg);
@@ -52,7 +65,9 @@ function remove(id) {
 // is not present in either bucket.
 function update(id, payload = {}) {
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   const inEnabled = !!(cfg.mcpServers && cfg.mcpServers[id]);
   const inDisabled = !!(cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]);
   if (!inEnabled && !inDisabled) {
@@ -73,7 +88,9 @@ function update(id, payload = {}) {
 
 function toggle(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
   if (cfg.mcpServers[id]) {
@@ -91,7 +108,15 @@ function toggle(id) {
 
 // Live probe via `claude mcp list`. The command takes 25-40 seconds in
 // practice because it actually round-trips every configured server.
-function health() {
+// Because it is slow, a fresh result is cached for a short window and
+// concurrent callers share a single in-flight probe: opening the MCP
+// panel or re-rendering must not stack a new 30s+ child process each
+// time.
+const HEALTH_TTL_MS = 20000;
+let healthCache = null;       // { at, result }
+let healthInflight = null;    // Promise while a probe is running
+
+function runHealthProbe() {
   return new Promise((resolve) => {
     let proc;
     try {
@@ -106,6 +131,25 @@ function health() {
     proc.on('error', (err) => resolve({ ok: false, error: err.message, status: {} }));
     proc.on('close', () => resolve({ ok: true, status: parseMcpListOutput(buf) }));
   });
+}
+
+function health(opts = {}) {
+  const now = Date.now();
+  if (!opts.force && healthCache && (now - healthCache.at) < HEALTH_TTL_MS) {
+    return Promise.resolve(healthCache.result);
+  }
+  if (healthInflight) return healthInflight;
+  healthInflight = runHealthProbe().then((result) => {
+    // Only cache a successful probe; a transient spawn error should not
+    // suppress the next real attempt for the whole TTL window.
+    if (result && result.ok) healthCache = { at: Date.now(), result };
+    healthInflight = null;
+    return result;
+  }).catch((err) => {
+    healthInflight = null;
+    return { ok: false, error: (err && err.message) || 'probe failed', status: {} };
+  });
+  return healthInflight;
 }
 
 module.exports = {

--- a/src/lib/mcp/common.js
+++ b/src/lib/mcp/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 // shapeServer takes the raw config entry (as written in the agent's
 // mcp-servers config file) and returns the renderer-friendly shape.
@@ -44,14 +45,45 @@ function readJsonFile(filePath) {
   }
 }
 
-function writeJsonFile(filePath, obj) {
+// Strict reader for the read-modify-write path. A missing file is a
+// clean empty config, but a file that exists yet does not parse is an
+// error: returning {} there would let a mutating op overwrite a config
+// it could not actually read and drop every key it holds. The config
+// file is owned and written by the agent CLI itself, so callers must
+// refuse to write when this returns ok:false.
+function readJsonFileStrict(filePath) {
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    fs.writeFileSync(filePath, JSON.stringify(obj, null, 2), { mode: 0o600 });
+    if (!fs.existsSync(filePath)) return { ok: true, data: {}, missing: true };
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return { ok: true, data: JSON.parse(raw) };
+  } catch (err) {
+    return { ok: false, error: (err && err.message) || 'unreadable' };
+  }
+}
+
+// Atomic write: serialize to a sibling temp file then rename over the
+// target. rename is atomic on a single filesystem, so a crash or full
+// disk mid-write leaves the original config intact instead of a
+// half-written, unparseable file.
+function writeJsonFile(filePath, obj) {
+  let tmp;
+  try {
+    const dir = path.dirname(filePath);
+    tmp = path.join(dir, '.' + path.basename(filePath) + '.husk-' + process.pid + '.tmp');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), { mode: 0o600 });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    try { fs.chmodSync(tmp, 0o600); } catch (_) {}
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.renameSync(tmp, filePath);
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     try { fs.chmodSync(filePath, 0o600); } catch (_) {}
     return true;
   } catch (_) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (tmp) try { fs.unlinkSync(tmp); } catch (_) {}
     return false;
   }
 }
@@ -82,4 +114,4 @@ function agentKey(agentCommand) {
   return base.replace(/\.(exe|cmd|bat|ps1)$/i, '');
 }
 
-module.exports = { shapeServer, readJsonFile, writeJsonFile, buildServerEntry, agentKey };
+module.exports = { shapeServer, readJsonFile, readJsonFileStrict, writeJsonFile, buildServerEntry, agentKey };

--- a/src/lib/mcp/copilot.js
+++ b/src/lib/mcp/copilot.js
@@ -2,7 +2,7 @@
 
 const os = require('os');
 const path = require('path');
-const { shapeServer, readJsonFile, writeJsonFile, buildServerEntry } = require('./common');
+const { shapeServer, readJsonFile, readJsonFileStrict, writeJsonFile, buildServerEntry } = require('./common');
 
 // Copilot's MCP config lives at ~/.copilot/mcp-config.json. Schema is
 // compatible with claude's (mcpServers map, transport+url for remote,
@@ -13,6 +13,15 @@ const CONFIG_PATH = path.join(os.homedir(), '.copilot', 'mcp-config.json');
 
 function readConfig() { return readJsonFile(CONFIG_PATH); }
 function writeConfig(obj) { return writeJsonFile(CONFIG_PATH, obj); }
+
+// Read for the write path. Refuses to proceed when the file exists but
+// cannot be parsed so a mutating op never overwrites a config it could
+// not read.
+function readConfigForWrite() {
+  const r = readJsonFileStrict(CONFIG_PATH);
+  if (!r.ok) return { error: 'Refusing to write: ~/.copilot/mcp-config.json exists but could not be read' };
+  return { cfg: r.data };
+}
 
 function list() {
   const cfg = readConfig();
@@ -28,7 +37,9 @@ function list() {
 function add(payload = {}) {
   const { id } = payload;
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
     return { ok: false, error: `MCP server "${id}" already exists` };
@@ -42,7 +53,9 @@ function add(payload = {}) {
 
 function remove(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
   if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
   writeConfig(cfg);
@@ -53,7 +66,9 @@ function remove(id) {
 // enabled/disabled status. Same contract as the claude adapter.
 function update(id, payload = {}) {
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   const inEnabled = !!(cfg.mcpServers && cfg.mcpServers[id]);
   const inDisabled = !!(cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]);
   if (!inEnabled && !inDisabled) {
@@ -74,7 +89,9 @@ function update(id, payload = {}) {
 
 function toggle(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
   if (cfg.mcpServers[id]) {

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -96,14 +96,37 @@ function graphToOrderedSteps(graph) {
   if (!g.nodes.length) return [];
   const byId = new Map(g.nodes.map((n) => [n.id, n]));
   const hasIncoming = new Set(g.edges.map((e) => e.to));
-  let cur = g.nodes.find((n) => !hasIncoming.has(n.id)) || g.nodes[0];
+  // Outgoing adjacency in edge-declaration order, so branch order is
+  // stable and follows how the user wired the graph.
+  const out = new Map();
+  for (const e of g.edges) {
+    if (!out.has(e.from)) out.set(e.from, []);
+    out.get(e.from).push(e.to);
+  }
   const order = [];
   const seen = new Set();
-  while (cur && !seen.has(cur.id)) {
-    seen.add(cur.id);
-    order.push(cur);
-    const edge = g.edges.find((e) => e.from === cur.id);
-    cur = edge ? byId.get(edge.to) : null;
+  // Breadth-first from every root (a node with no incoming edge). The
+  // previous version followed only the first outgoing edge of a single
+  // root, which silently dropped every other branch and any
+  // disconnected node. A pure-cycle graph has no root, so seed with the
+  // first node to stay terminating while still emitting every node.
+  const roots = g.nodes.filter((n) => !hasIncoming.has(n.id));
+  const queue = (roots.length ? roots : [g.nodes[0]]).map((n) => n.id);
+  while (queue.length) {
+    const id = queue.shift();
+    if (seen.has(id)) continue;
+    const node = byId.get(id);
+    if (!node) continue;
+    seen.add(id);
+    order.push(node);
+    for (const to of (out.get(id) || [])) {
+      if (!seen.has(to)) queue.push(to);
+    }
+  }
+  // Append any node not reachable from a root (a disconnected
+  // component) so no step is silently lost.
+  for (const n of g.nodes) {
+    if (!seen.has(n.id)) { seen.add(n.id); order.push(n); }
   }
   return order;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
-const { spawn, spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 const pty = require('node-pty');
 
 const { shJoin } = require('./lib/shell-quote');
@@ -14,22 +14,35 @@ const { resolveInside } = require('./lib/path-confine');
 const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
 const { buildSpawnSpec } = require('./lib/pty-spawn');
-const { getUserPath } = require('./lib/user-path');
+const { parseShellPathOutput, MARKER_START, MARKER_END } = require('./lib/user-path');
 const { getAdapter: getMcpAdapter } = require('./lib/mcp');
 
 // On macOS in particular, a GUI-launched Electron app inherits a
 // minimal PATH that does not include the npm-global, homebrew, or bun
 // install directories where users keep their agent CLIs. Read the
-// user's actual shell PATH once at startup so subsequent spawns can
-// find their binaries.
-try {
-  const userPath = getUserPath({
-    platform: process.platform,
-    env: process.env,
-    runShell: (shell, args) => spawnSync(shell, args, { encoding: 'utf8', timeout: 5000 }),
-  });
-  if (userPath) process.env.PATH = userPath;
-} catch (_) {}
+// user's actual shell PATH so subsequent spawns can find their
+// binaries.
+//
+// This runs ASYNCHRONOUSLY: an interactive login shell sources the
+// user's full rc chain (nvm, pyenv, conda init), which can take
+// hundreds of ms to seconds. Doing it with spawnSync at module load
+// froze the whole process before the window appeared. Agent spawns
+// happen on user action, well after this resolves, so async is safe.
+function augmentUserPathAsync() {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') return;
+  const shellBin = (typeof process.env.SHELL === 'string' && process.env.SHELL) ? process.env.SHELL : '/bin/zsh';
+  try {
+    const child = spawn(shellBin, ['-ilc', `echo "${MARKER_START}$PATH${MARKER_END}"`], { timeout: 5000 });
+    let out = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.on('error', () => {});
+    child.on('close', () => {
+      const p = parseShellPathOutput(out);
+      if (p) process.env.PATH = p;
+    });
+  } catch (_) {}
+}
+augmentUserPathAsync();
 const {
   sanitizeGraph,
   migrateWorkflow,
@@ -62,6 +75,23 @@ app.commandLine.appendSwitch('ignore-gpu-blocklist');
 
 let mainWindow = null;
 let ptyProc = null;
+// node-pty listener disposables for the current process, so a respawn
+// can detach them instead of leaking emitter registrations.
+let ptyDataDisposable = null;
+let ptyExitDisposable = null;
+// PTY output coalescing buffer (see spawnPty's onData).
+let ptyDataBuf = '';
+let ptyFlushScheduled = false;
+// Timestamp of the last byte the agent emitted, used to detect when its
+// TUI has settled before we paste an autonomy goal into it.
+let ptyLastDataAt = 0;
+function flushPtyData() {
+  ptyFlushScheduled = false;
+  if (!ptyDataBuf) return;
+  const data = ptyDataBuf;
+  ptyDataBuf = '';
+  if (mainWindow) mainWindow.webContents.send('pty:data', data);
+}
 
 // ─── Config ──────────────────────────────────────────────────────────────────────
 
@@ -527,6 +557,16 @@ function killPtyTree() {
 // ─── PTY ─────────────────────────────────────────────────────────────────────────
 
 function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null) {
+  // Dispose the previous process's data/exit listeners before we drop
+  // the reference, otherwise each restart/resume leaks a node-pty
+  // emitter registration. Also drop any buffered output from the old
+  // process so it cannot bleed into the new session.
+  try { if (ptyDataDisposable) ptyDataDisposable.dispose(); } catch (_) {}
+  try { if (ptyExitDisposable) ptyExitDisposable.dispose(); } catch (_) {}
+  ptyDataDisposable = null;
+  ptyExitDisposable = null;
+  ptyDataBuf = '';
+  ptyFlushScheduled = false;
   if (ptyProc) try { ptyProc.kill(); } catch (_) {}
   const shellBin = process.platform === 'win32'
     ? (process.env.ComSpec || 'cmd.exe')
@@ -662,13 +702,28 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
 
   ptyProc = pty.spawn(spec.exe, spec.argv, { name: 'xterm-256color', cols, rows, cwd, env });
   activePtyCwd = cwd;
-  ptyProc.onData((data) => {
-    if (mainWindow) mainWindow.webContents.send('pty:data', data);
+  // Coalesce PTY output: a chatty agent (build logs, a big cat) emits
+  // many chunks per tick. Buffer them and flush once per microtask so
+  // the renderer receives one message per burst instead of one IPC send
+  // per chunk, which otherwise floods the channel and janks the UI.
+  ptyDataDisposable = ptyProc.onData((data) => {
+    ptyLastDataAt = Date.now();
+    ptyDataBuf += data;
+    if (!ptyFlushScheduled) { ptyFlushScheduled = true; setImmediate(flushPtyData); }
     autonomyTap(data);
   });
-  ptyProc.onExit(({ exitCode }) => {
+  ptyExitDisposable = ptyProc.onExit(({ exitCode }) => {
+    flushPtyData();
     if (mainWindow) mainWindow.webContents.send('pty:exit', exitCode);
     ptyProc = null;
+    // If an autonomy run was live, the agent process just died. Close
+    // the run so its 1s meter interval stops, the budget stops ticking
+    // wall-clock against a dead process, and a new run can start (the
+    // "already active" guard would otherwise block forever).
+    if (activeRunner && !autonomyFinishing) {
+      if (mainWindow) mainWindow.webContents.send('autonomy:halt', { reason: 'agent-exited' });
+      finishActiveRun({ reason: 'agent-exited' });
+    }
   });
 }
 
@@ -691,13 +746,33 @@ function readActiveSessionStats() {
       .filter((f) => f.endsWith('.jsonl'))
       .map((f) => {
         const p = path.join(dir, f);
-        try { return { p, mtime: fs.statSync(p).mtimeMs }; } catch (_) { return null; }
+        try { const st = fs.statSync(p); return { p, mtime: st.mtimeMs, size: st.size }; } catch (_) { return null; }
       })
       .filter(Boolean)
       .sort((a, b) => b.mtime - a.mtime);
     if (!files.length) return null;
     const latest = files[0].p;
-    const raw = fs.readFileSync(latest, 'utf8').split('\n').filter(Boolean);
+    // Cap the read. A session JSONL grows for the whole conversation and
+    // can reach many megabytes; reading and parsing the entire file on
+    // every status poll stalls the main thread. Read at most the last
+    // CAP bytes (dropping the first partial line) so the cost stays
+    // bounded. For large sessions the turn/char numbers become a
+    // recent-tail estimate, which is acceptable for a coarse readout.
+    const CAP = 1024 * 1024;
+    let raw;
+    const sz = files[0].size;
+    if (Number.isFinite(sz) && sz > CAP) {
+      const fd = fs.openSync(latest, 'r');
+      try {
+        const buf = Buffer.alloc(CAP);
+        fs.readSync(fd, buf, 0, CAP, sz - CAP);
+        const tail = buf.toString('utf8');
+        const nl = tail.indexOf('\n');
+        raw = (nl >= 0 ? tail.slice(nl + 1) : tail).split('\n').filter(Boolean);
+      } finally { fs.closeSync(fd); }
+    } else {
+      raw = fs.readFileSync(latest, 'utf8').split('\n').filter(Boolean);
+    }
     let turns = 0;
     let chars = 0;
     for (const line of raw) {
@@ -744,6 +819,9 @@ ipcMain.handle('pty:restart', (_e, { cols, rows, command, cwd }) => {
 const Autonomy = require('./lib/autonomy');
 const electronApp = require('electron');
 let activeRunner = null;
+// Guards finishActiveRun against re-entry: an agent crash (onExit) and a
+// user cancel can both try to close the same run at once.
+let autonomyFinishing = false;
 function autonomyStorageRoot() {
   return path.join(app.getPath('userData'), 'autonomy');
 }
@@ -890,6 +968,28 @@ function sigintPty() {
   try { ptyProc.write('\x03'); } catch (_) {}
 }
 
+// Resolve once the agent's TUI looks ready for input: it has emitted
+// output and then gone quiet for a short settle window, or maxMs has
+// elapsed. This replaces a fixed wall-clock guess that, on a slow cold
+// start, pasted the goal before the input field had mounted and the run
+// silently did nothing.
+function whenAgentReady(maxMs) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const settleMs = 350; // quiet period after last output = TUI settled
+    const minWaitMs = Math.min(250, maxMs);
+    const check = () => {
+      const now = Date.now();
+      if (now - start >= maxMs) return resolve('timeout');
+      const sawOutput = ptyLastDataAt >= start - 50;
+      const quietFor = now - ptyLastDataAt;
+      if (sawOutput && quietFor >= settleMs && (now - start) >= minWaitMs) return resolve('ready');
+      setTimeout(check, 80);
+    };
+    setTimeout(check, minWaitMs);
+  });
+}
+
 ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
   if (activeRunner) return { ok: false, error: 'an autonomy run is already active' };
   // Autonomy requires an active project. The whole feature is built
@@ -966,9 +1066,8 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
   if (ptyJustBooted) {
     try { spawnPty(100, 30, null, workspaceRoot); } catch (_) {}
   }
-  const injectDelayMs = ptyJustBooted ? 2500 : 400;
   if (goal) {
-    setTimeout(() => {
+    const deliver = () => {
       const ok = injectGoalToPty(goal);
       // Surface delivery to the activity feed so the user has explicit
       // feedback that the goal reached the agent. Without this, an
@@ -980,7 +1079,18 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
           at: Date.now(),
         });
       }
-    }, injectDelayMs);
+    };
+    if (ptyJustBooted) {
+      // Cold start: wait for the freshly spawned agent's banner to
+      // render and settle before pasting, with a hard fallback so the
+      // goal is always delivered even if the readiness signal never
+      // arrives.
+      whenAgentReady(6000).then(deliver);
+    } else {
+      // Agent already running in Chat: a short delay is enough for the
+      // bracketed paste to land in the existing input.
+      setTimeout(deliver, 400);
+    }
   }
   return { ok: true, sessionId, workspaceRoot, fileCount: snap.fileCount, goal };
 });
@@ -1003,27 +1113,41 @@ ipcMain.handle('autonomy:end', (_e, detail = {}) => {
   return finishActiveRun(detail);
 });
 
-function finishActiveRun(detail) {
-  if (!activeRunner) return { ok: false, error: 'no active run' };
-  try { activeRunner.endRun(detail || null); } catch (_) {}
-  try { clearInterval(activeRunner._tickInterval); } catch (_) {}
-  // Drain any pending PTY tap output so the final agent_output event
-  // makes it into the audit log before we null the runner.
-  try { if (autonomyOutputFlushTimer) { clearTimeout(autonomyOutputFlushTimer); autonomyOutputFlushTimer = null; } } catch (_) {}
-  try { flushAutonomyOutput(); } catch (_) {}
-  autonomyOutputBuf = '';
-  autonomyLineTail = '';
-  autonomyLastTailEmit = '';
-  autonomyLastTailEmitAt = 0;
-  const sessionId = activeRunner.sessionId;
-  const workspaceRoot = activeRunner.workspaceRoot;
-  activeRunner = null;
-  const { decrypt } = autonomyCrypto();
-  const sum = Autonomy.supervisor.summarizeRun({
-    sessionId, workspaceRoot, storageRoot: autonomyStorageRoot(), decrypt,
-  });
-  if (mainWindow) mainWindow.webContents.send('autonomy:ended', sum);
-  return { ok: true, sessionId, summary: sum };
+async function finishActiveRun(detail) {
+  if (!activeRunner || autonomyFinishing) return { ok: false, error: 'no active run' };
+  autonomyFinishing = true;
+  const runner = activeRunner;
+  try {
+    try { clearInterval(runner._tickInterval); } catch (_) {}
+    // Drain any pending PTY tap output so the final agent_output event
+    // makes it into the audit log before we close the runner.
+    try { if (autonomyOutputFlushTimer) { clearTimeout(autonomyOutputFlushTimer); autonomyOutputFlushTimer = null; } } catch (_) {}
+    try { flushAutonomyOutput(); } catch (_) {}
+    autonomyOutputBuf = '';
+    autonomyLineTail = '';
+    autonomyLastTailEmit = '';
+    autonomyLastTailEmitAt = 0;
+    // endRunAsync walks the end-of-run diff off the main thread so the
+    // UI does not freeze hashing the workspace at run end.
+    try { await runner.endRunAsync(detail || null); } catch (_) {}
+    const sessionId = runner.sessionId;
+    const workspaceRoot = runner.workspaceRoot;
+    activeRunner = null;
+    const { decrypt } = autonomyCrypto();
+    let sum;
+    try {
+      sum = await Autonomy.supervisor.summarizeRunAsync({
+        sessionId, workspaceRoot, storageRoot: autonomyStorageRoot(), decrypt,
+      });
+    } catch (err) {
+      sum = { ok: false, error: (err && err.message) || String(err) };
+    }
+    if (mainWindow) mainWindow.webContents.send('autonomy:ended', sum);
+    return { ok: true, sessionId, summary: sum };
+  } finally {
+    activeRunner = null;
+    autonomyFinishing = false;
+  }
 }
 
 ipcMain.handle('autonomy:status', () => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -231,14 +231,39 @@ term.attachCustomKeyEventHandler((e) => {
   });
   window.addEventListener('blur', hideMenu);
 }
+// Small trailing debounce: coalesce rapid calls (search keystrokes) so
+// an expensive repaint runs once the user pauses, not per character.
+function debounce(fn, ms) {
+  let t = null;
+  return (...args) => {
+    if (t) clearTimeout(t);
+    t = setTimeout(() => { t = null; fn(...args); }, ms);
+  };
+}
+
+// Coalesce PTY output into one xterm write per animation frame. A
+// chatty agent emits many chunks in quick succession; writing each one
+// separately (with its own scroll callback and speech scan) burned CPU
+// and janked scrolling. Buffering to the next frame collapses a burst
+// into a single write + single scroll + single speech scan.
+let _termWriteBuf = '';
+let _termFlushScheduled = false;
+function _flushTermWrite() {
+  _termFlushScheduled = false;
+  if (!_termWriteBuf) return;
+  const data = _termWriteBuf;
+  _termWriteBuf = '';
+  term.write(data, () => term.scrollToBottom());
+  detectAndSpeak(data);
+}
 window.husk.pty.onData((d) => {
   if (!chatHasInput) {
     chatHasInput = true;
     $('#chat-empty').classList.remove('show');
   }
   if (_restartInProgress) return;
-  term.write(d, () => term.scrollToBottom());
-  detectAndSpeak(d);
+  _termWriteBuf += d;
+  if (!_termFlushScheduled) { _termFlushScheduled = true; requestAnimationFrame(_flushTermWrite); }
 });
 window.husk.pty.onExit((code) => {
   // Suppress the exit notice when we're tearing the old PTY down on purpose,
@@ -695,7 +720,7 @@ async function deleteProject(id, name) {
 // Wire Projects page controls + Add Project modal.
 {
   const search = document.getElementById('projects-search');
-  if (search) search.addEventListener('input', () => paintProjects(projectsCache, search.value));
+  if (search) search.addEventListener('input', debounce(() => paintProjects(projectsCache, search.value), 120));
 
   const newBtn = document.getElementById('btn-projects-new');
   const modal = document.getElementById('new-project-modal');
@@ -2190,7 +2215,7 @@ async function previewPrompt(mdPath) {
 // Wire prompts search + refresh + create.
 {
   const search = document.getElementById('prompts-search');
-  if (search) search.addEventListener('input', () => paintPrompts(promptsCache, search.value));
+  if (search) search.addEventListener('input', debounce(() => paintPrompts(promptsCache, search.value), 120));
   const refresh = document.getElementById('btn-prompts-refresh');
   if (refresh) refresh.addEventListener('click', renderPrompts);
 
@@ -2356,7 +2381,7 @@ function paintSkills(list, query) {
     });
   });
 }
-$('#skills-search').addEventListener('input', (e) => paintSkills(skillsCache, e.target.value));
+$('#skills-search').addEventListener('input', debounce((e) => paintSkills(skillsCache, e.target.value), 120));
 $('#btn-skills-refresh').addEventListener('click', renderSkills);
 $('#btn-skills-open').addEventListener('click', () => lastStats && window.husk.fs.open(lastStats.skillsDir));
 $('#btn-skills-new').addEventListener('click', openCreateSkillModal);
@@ -2514,9 +2539,22 @@ function paintSessions(list, query) {
 
 function toggleSessionSelection(p) {
   if (!p) return;
-  if (sessionsSelected.has(p)) sessionsSelected.delete(p);
+  const wasSelected = sessionsSelected.has(p);
+  if (wasSelected) sessionsSelected.delete(p);
   else sessionsSelected.add(p);
-  paintSessions(sessionsCache, $('#sessions-search').value);
+  // Update only the affected row in place. Repainting the whole list on
+  // every checkbox click was an O(n) DOM teardown and listener rebind.
+  const ul = $('#sessions-list');
+  if (ul) {
+    for (const row of ul.querySelectorAll('.session-row')) {
+      if (row.dataset.path === p) {
+        row.classList.toggle('selected', !wasSelected);
+        const cb = row.querySelector('input[type="checkbox"]');
+        if (cb) cb.checked = !wasSelected;
+        break;
+      }
+    }
+  }
   syncSelectModeUI();
 }
 
@@ -2561,7 +2599,7 @@ async function deleteSelectedSessions() {
   await renderSessions();
 }
 
-$('#sessions-search').addEventListener('input', (e) => paintSessions(sessionsCache, e.target.value));
+$('#sessions-search').addEventListener('input', debounce((e) => paintSessions(sessionsCache, e.target.value), 120));
 $('#btn-sessions-refresh').addEventListener('click', renderSessions);
 $('#btn-sessions-open').addEventListener('click', () => lastStats && window.husk.fs.open(lastStats.sessionsDir));
 $('#btn-sessions-select').addEventListener('click', enterSelectMode);

--- a/test/unit/mcp-common.test.js
+++ b/test/unit/mcp-common.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { readJsonFile, readJsonFileStrict, writeJsonFile } = require('../../src/lib/mcp/common');
+
+function tmpFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-mcp-common-'));
+  return path.join(dir, 'config.json');
+}
+
+// ─── readJsonFileStrict ────────────────────────────────────────────────────
+
+test('readJsonFileStrict: missing file is a clean empty config', () => {
+  const r = readJsonFileStrict(tmpFile());
+  assert.equal(r.ok, true);
+  assert.equal(r.missing, true);
+  assert.deepEqual(r.data, {});
+});
+
+test('readJsonFileStrict: valid file parses', () => {
+  const p = tmpFile();
+  fs.writeFileSync(p, JSON.stringify({ mcpServers: { a: { command: 'x' } } }));
+  const r = readJsonFileStrict(p);
+  assert.equal(r.ok, true);
+  assert.equal(r.data.mcpServers.a.command, 'x');
+});
+
+test('readJsonFileStrict: a corrupt existing file is an error, not empty', () => {
+  const p = tmpFile();
+  fs.writeFileSync(p, '{ this is not json');
+  const r = readJsonFileStrict(p);
+  assert.equal(r.ok, false);
+  // The lenient reader would silently return {} here, which is exactly
+  // the path that lets a mutating op overwrite a config it could not read.
+  assert.deepEqual(readJsonFile(p), {});
+});
+
+// ─── writeJsonFile (atomic) ──────────────────────────────────────────────────
+
+test('writeJsonFile: writes valid parseable JSON', () => {
+  const p = tmpFile();
+  assert.equal(writeJsonFile(p, { mcpServers: { a: 1 } }), true);
+  const back = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.deepEqual(back, { mcpServers: { a: 1 } });
+});
+
+test('writeJsonFile: leaves no temp file behind on success', () => {
+  const p = tmpFile();
+  writeJsonFile(p, { ok: true });
+  const leftovers = fs.readdirSync(path.dirname(p)).filter((f) => f.includes('.tmp'));
+  assert.deepEqual(leftovers, []);
+});
+
+test('writeJsonFile: preserves the original when the target dir is unwritable', () => {
+  const p = tmpFile();
+  fs.writeFileSync(p, JSON.stringify({ original: true }));
+  // Point at a path whose parent does not exist: the write must fail
+  // cleanly and never produce a half-written file.
+  const bad = path.join(p, 'nope', 'config.json');
+  assert.equal(writeJsonFile(bad, { changed: true }), false);
+  // Original untouched.
+  assert.deepEqual(JSON.parse(fs.readFileSync(p, 'utf8')), { original: true });
+});

--- a/test/unit/workflow-graph.test.js
+++ b/test/unit/workflow-graph.test.js
@@ -176,6 +176,32 @@ test('graphToOrderedSteps: empty graph returns []', () => {
   assert.deepEqual(wf.graphToOrderedSteps({ nodes: [], edges: [] }), []);
 });
 
+test('graphToOrderedSteps: a branching node keeps every branch', () => {
+  // a -> b, a -> c. The old single-edge walk dropped the second branch.
+  const g = {
+    nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+    edges: [
+      { from: 'a', to: 'b', condition: { type: 'always' } },
+      { from: 'a', to: 'c', condition: { type: 'always' } },
+    ],
+  };
+  const ids = wf.graphToOrderedSteps(g).map((n) => n.id);
+  assert.equal(ids.length, 3);
+  assert.ok(ids.includes('b') && ids.includes('c'));
+  assert.equal(ids[0], 'a');
+});
+
+test('graphToOrderedSteps: disconnected nodes are not dropped', () => {
+  // b is wired to a; c stands alone. Both must appear.
+  const g = {
+    nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+    edges: [{ from: 'a', to: 'b', condition: { type: 'always' } }],
+  };
+  const ids = wf.graphToOrderedSteps(g).map((n) => n.id);
+  assert.equal(ids.length, 3);
+  assert.ok(ids.includes('c'));
+});
+
 // ─── wfEdgeMatches ───────────────────────────────────────────────────────────
 
 test('wfEdgeMatches: contains is case-insensitive', () => {


### PR DESCRIPTION
Fixes verified during a subsystem audit. Each item was confirmed against the code before changing it; findings that turned out to be inert or already defended were left alone.

## Main process and PTY
- Coalesce PTY output into one send per microtask so a chatty agent no longer floods the IPC channel one chunk at a time.
- Dispose the previous process's data and exit listeners on respawn, so restart and resume no longer leak emitter registrations.
- When the agent process exits during an autonomy run, close the run so its 1s meter interval stops and a new run can start, instead of the already-active guard blocking forever.
- Resolve shell PATH augmentation asynchronously at startup instead of running an interactive login shell synchronously before the window appears.
- Cap the session usage read so a large session log no longer stalls the main thread on every status poll.
- Gate autonomy goal injection on terminal readiness with a fallback, instead of a fixed wall-clock guess that could paste before the TUI mounted its input.

## Autonomy
- Compute the end-of-run and summary diffs with the async walker so the main process does not freeze hashing the workspace at run end.

## MCP config
- Write server config atomically (temp file plus rename) so a crash mid-write cannot truncate the file.
- Refuse to write when the config file exists but cannot be parsed, so a mutating op never overwrites a config it could not read.
- Cache the claude health probe for a short window and share a single in-flight call so opening the panel does not stack repeated slow probes.

## Workflows
- Order graph steps breadth-first from all roots and append disconnected nodes, so a branching or disconnected graph no longer silently drops steps.

## Renderer
- Batch terminal writes to one flush per animation frame.
- Debounce the sessions, skills, prompts, and projects search inputs.
- Toggle a session row's selection in place instead of repainting the whole list.

## Verification
- 348 unit tests pass (8 added for the new config-writer and workflow-ordering behavior).
- Strict security lint clean on the strict scope.
- Electron e2e smoke boots clean with no console errors.