### PR TITLE
Autonomy: fix run completion, cap halt, safe revert, and UX

### DIFF
--- a/src/lib/autonomy/snapshot.js
+++ b/src/lib/autonomy/snapshot.js
@@ -213,8 +213,10 @@ function restoreFromSnapshot(workspaceRoot, storageRoot, sessionId, opts = {}) {
   // snapshot was captured from. The second pass deletes every workspace
   // file not in the manifest, so restoring into the wrong root (e.g. a
   // caller that fell back to HOME for an empty workspaceRoot) would wipe
-  // an unrelated directory. Refuse rather than trust the caller.
-  if (manifest.workspaceRoot && path.resolve(manifest.workspaceRoot) !== path.resolve(workspaceRoot)) {
+  // an unrelated directory. Refuse rather than trust the caller. A manifest
+  // with no recorded root is refused outright so the check can never be
+  // short-circuited by a legacy or hand-crafted manifest.
+  if (!manifest.workspaceRoot || path.resolve(manifest.workspaceRoot) !== path.resolve(workspaceRoot)) {
     return { ok: false, error: 'workspaceRoot does not match the snapshot manifest; refusing to restore' };
   }
   const bdir = blobsDir(storageRoot, sessionId);

--- a/src/lib/autonomy/snapshot.js
+++ b/src/lib/autonomy/snapshot.js
@@ -176,6 +176,12 @@ function walk(absRoot, rel, ignores, entries, warnings, opts, bdir) {
       // error mid-walk. Record a warning and move on; do NOT abort
       // the whole snapshot.
       warnings.push({ path: relChild, reason: err.message });
+      // If it was a file we simply could not read (transient lock,
+      // permission blip), still record it as a pre-existing entry so the
+      // diff does not later call it "added" and a revert does not delete
+      // a file the agent never touched. We cannot hash it, so it carries
+      // no sha and restore leaves its content alone.
+      try { if (ent.isFile()) entries[relChild] = { type: 'unreadable' }; } catch (_) {}
     }
   }
 }
@@ -203,6 +209,14 @@ function restoreFromSnapshot(workspaceRoot, storageRoot, sessionId, opts = {}) {
   if (!manifest || !manifest.entries || typeof manifest.entries !== 'object') {
     return { ok: false, error: 'manifest malformed' };
   }
+  // Safety cross-check: the restore target must be the same directory the
+  // snapshot was captured from. The second pass deletes every workspace
+  // file not in the manifest, so restoring into the wrong root (e.g. a
+  // caller that fell back to HOME for an empty workspaceRoot) would wipe
+  // an unrelated directory. Refuse rather than trust the caller.
+  if (manifest.workspaceRoot && path.resolve(manifest.workspaceRoot) !== path.resolve(workspaceRoot)) {
+    return { ok: false, error: 'workspaceRoot does not match the snapshot manifest; refusing to restore' };
+  }
   const bdir = blobsDir(storageRoot, sessionId);
 
   const restored = [];
@@ -214,6 +228,10 @@ function restoreFromSnapshot(workspaceRoot, storageRoot, sessionId, opts = {}) {
   // hostile or pre-existing symlink in the workspace.
   for (const relPath of Object.keys(manifest.entries)) {
     const meta = manifest.entries[relPath];
+    // Pre-existing file we could not read at capture time: we never
+    // captured its content, so leave whatever is on disk untouched. It
+    // stays in the keep-set below, so the delete pass will not remove it.
+    if (meta && meta.type === 'unreadable') continue;
     const abs = joinSafely(workspaceRoot, relPath);
     if (!abs) { warnings.push({ path: relPath, reason: 'path escapes workspaceRoot' }); continue; }
     if (!validateAncestorChain(workspaceRoot, abs)) {
@@ -546,6 +564,9 @@ async function walkAsync(absRoot, rel, ignores, entries, warnings, opts, bdir, s
       }
     } catch (err) {
       warnings.push({ path: relChild, reason: err.message });
+      // See walk(): a momentarily-unreadable pre-existing file is recorded
+      // so the diff does not call it "added" and a revert does not delete it.
+      try { if (ent.isFile()) entries[relChild] = { type: 'unreadable' }; } catch (_) {}
     }
   }
 }

--- a/src/lib/autonomy/supervisor.js
+++ b/src/lib/autonomy/supervisor.js
@@ -188,6 +188,37 @@ function startRun(opts = {}) {
     });
   }
 
+  // Async twin of endRun. Same audit ordering, but the end-of-run diff
+  // is computed with the async walker so the Electron main thread is
+  // never frozen hashing a large workspace at run end.
+  async function endRunAsync(detail) {
+    if (state.status === 'running') {
+      state.status = 'ended';
+      state.haltReason = 'natural';
+      state.haltDetail = detail || null;
+      state.endedAt = now();
+      auditWriter.append({ kind: 'end_run', payload: detail || null });
+    }
+    let diff = { ok: false, changes: [] };
+    try {
+      diff = await Snapshot.diffWorkspaceAsync(workspaceRoot, storageRoot, sessionId, { ignore: opts.ignore });
+    } catch (_) { diff = { ok: false, changes: [] }; }
+    auditWriter.append({
+      kind: 'run_summary',
+      payload: {
+        turnCount: state.turnCount,
+        status: state.status,
+        haltReason: state.haltReason,
+        haltDetail: state.haltDetail,
+        startedAt: state.startedAt,
+        endedAt: state.endedAt,
+        durationMs: state.endedAt ? state.endedAt - state.startedAt : 0,
+        diff: diff.ok ? diff.changes : [],
+        meter: budget.state(now()),
+      },
+    });
+  }
+
   function snapshotOnly() { return snap.manifest; }
   function getState() { return Object.assign({}, state); }
 
@@ -203,6 +234,7 @@ function startRun(opts = {}) {
       halt,
       cancel,
       endRun,
+      endRunAsync,
       getState,
       snapshotManifest: snapshotOnly,
       budgetState: () => budget.state(now()),
@@ -250,6 +282,32 @@ function summarizeRun(opts = {}) {
     diff = Snapshot.diffWorkspace(workspaceRoot, storageRoot, sessionId);
   }
   const chain = Audit.verifyAuditChain(storageRoot, sessionId);
+  return buildSummary(audit, diff, chain);
+}
+
+// Async twin of summarizeRun: identical output, but the workspace diff
+// is walked off the main thread.
+async function summarizeRunAsync(opts = {}) {
+  const sessionId = String(opts.sessionId || '').trim();
+  const workspaceRoot = String(opts.workspaceRoot || '').trim();
+  const storageRoot = String(opts.storageRoot || '').trim();
+  if (!sessionId || !storageRoot) {
+    return { ok: false, error: 'sessionId, storageRoot required' };
+  }
+  const decrypt = typeof opts.decrypt === 'function' ? opts.decrypt : null;
+  const audit = Audit.readAuditLog(storageRoot, sessionId, { decrypt });
+  if (!audit.ok) return { ok: false, error: audit.error };
+  let diff = { ok: false, changes: [] };
+  if (workspaceRoot) {
+    try { diff = await Snapshot.diffWorkspaceAsync(workspaceRoot, storageRoot, sessionId); }
+    catch (_) { diff = { ok: false, changes: [] }; }
+  }
+  const chain = Audit.verifyAuditChain(storageRoot, sessionId);
+  return buildSummary(audit, diff, chain);
+}
+
+// Shared shaping for both summarize variants.
+function buildSummary(audit, diff, chain) {
   // Pull the most recent run_summary AND the original start_run row.
   // run_summary carries the final meter / diff; start_run carries the
   // goal + caps the user originally set. Both are needed for Review +
@@ -280,4 +338,4 @@ function summarizeRun(opts = {}) {
   };
 }
 
-module.exports = { startRun, revertRun, summarizeRun };
+module.exports = { startRun, revertRun, summarizeRun, summarizeRunAsync };

--- a/src/lib/mcp/claude.js
+++ b/src/lib/mcp/claude.js
@@ -3,13 +3,22 @@
 const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
-const { shapeServer, readJsonFile, writeJsonFile, buildServerEntry } = require('./common');
+const { shapeServer, readJsonFile, readJsonFileStrict, writeJsonFile, buildServerEntry } = require('./common');
 const { parseMcpListOutput } = require('../mcp-status');
 
 const CONFIG_PATH = path.join(os.homedir(), '.claude.json');
 
 function readConfig() { return readJsonFile(CONFIG_PATH); }
 function writeConfig(obj) { return writeJsonFile(CONFIG_PATH, obj); }
+
+// Read for the write path. Returns the parsed config, or an error
+// string when the file exists but cannot be parsed so the caller can
+// refuse to overwrite it.
+function readConfigForWrite() {
+  const r = readJsonFileStrict(CONFIG_PATH);
+  if (!r.ok) return { error: 'Refusing to write: ~/.claude.json exists but could not be read' };
+  return { cfg: r.data };
+}
 
 function list() {
   const cfg = readConfig();
@@ -25,7 +34,9 @@ function list() {
 function add(payload = {}) {
   const { id } = payload;
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
     return { ok: false, error: `MCP server "${id}" already exists` };
@@ -39,7 +50,9 @@ function add(payload = {}) {
 
 function remove(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
   if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
   writeConfig(cfg);
@@ -52,7 +65,9 @@ function remove(id) {
 // is not present in either bucket.
 function update(id, payload = {}) {
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   const inEnabled = !!(cfg.mcpServers && cfg.mcpServers[id]);
   const inDisabled = !!(cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]);
   if (!inEnabled && !inDisabled) {
@@ -73,7 +88,9 @@ function update(id, payload = {}) {
 
 function toggle(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
   if (cfg.mcpServers[id]) {
@@ -91,7 +108,15 @@ function toggle(id) {
 
 // Live probe via `claude mcp list`. The command takes 25-40 seconds in
 // practice because it actually round-trips every configured server.
-function health() {
+// Because it is slow, a fresh result is cached for a short window and
+// concurrent callers share a single in-flight probe: opening the MCP
+// panel or re-rendering must not stack a new 30s+ child process each
+// time.
+const HEALTH_TTL_MS = 20000;
+let healthCache = null;       // { at, result }
+let healthInflight = null;    // Promise while a probe is running
+
+function runHealthProbe() {
   return new Promise((resolve) => {
     let proc;
     try {
@@ -106,6 +131,25 @@ function health() {
     proc.on('error', (err) => resolve({ ok: false, error: err.message, status: {} }));
     proc.on('close', () => resolve({ ok: true, status: parseMcpListOutput(buf) }));
   });
+}
+
+function health(opts = {}) {
+  const now = Date.now();
+  if (!opts.force && healthCache && (now - healthCache.at) < HEALTH_TTL_MS) {
+    return Promise.resolve(healthCache.result);
+  }
+  if (healthInflight) return healthInflight;
+  healthInflight = runHealthProbe().then((result) => {
+    // Only cache a successful probe; a transient spawn error should not
+    // suppress the next real attempt for the whole TTL window.
+    if (result && result.ok) healthCache = { at: Date.now(), result };
+    healthInflight = null;
+    return result;
+  }).catch((err) => {
+    healthInflight = null;
+    return { ok: false, error: (err && err.message) || 'probe failed', status: {} };
+  });
+  return healthInflight;
 }
 
 module.exports = {

--- a/src/lib/mcp/common.js
+++ b/src/lib/mcp/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 // shapeServer takes the raw config entry (as written in the agent's
 // mcp-servers config file) and returns the renderer-friendly shape.
@@ -44,14 +45,45 @@ function readJsonFile(filePath) {
   }
 }
 
-function writeJsonFile(filePath, obj) {
+// Strict reader for the read-modify-write path. A missing file is a
+// clean empty config, but a file that exists yet does not parse is an
+// error: returning {} there would let a mutating op overwrite a config
+// it could not actually read and drop every key it holds. The config
+// file is owned and written by the agent CLI itself, so callers must
+// refuse to write when this returns ok:false.
+function readJsonFileStrict(filePath) {
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    fs.writeFileSync(filePath, JSON.stringify(obj, null, 2), { mode: 0o600 });
+    if (!fs.existsSync(filePath)) return { ok: true, data: {}, missing: true };
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return { ok: true, data: JSON.parse(raw) };
+  } catch (err) {
+    return { ok: false, error: (err && err.message) || 'unreadable' };
+  }
+}
+
+// Atomic write: serialize to a sibling temp file then rename over the
+// target. rename is atomic on a single filesystem, so a crash or full
+// disk mid-write leaves the original config intact instead of a
+// half-written, unparseable file.
+function writeJsonFile(filePath, obj) {
+  let tmp;
+  try {
+    const dir = path.dirname(filePath);
+    tmp = path.join(dir, '.' + path.basename(filePath) + '.husk-' + process.pid + '.tmp');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.writeFileSync(tmp, JSON.stringify(obj, null, 2), { mode: 0o600 });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    try { fs.chmodSync(tmp, 0o600); } catch (_) {}
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.renameSync(tmp, filePath);
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     try { fs.chmodSync(filePath, 0o600); } catch (_) {}
     return true;
   } catch (_) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    if (tmp) try { fs.unlinkSync(tmp); } catch (_) {}
     return false;
   }
 }
@@ -82,4 +114,4 @@ function agentKey(agentCommand) {
   return base.replace(/\.(exe|cmd|bat|ps1)$/i, '');
 }
 
-module.exports = { shapeServer, readJsonFile, writeJsonFile, buildServerEntry, agentKey };
+module.exports = { shapeServer, readJsonFile, readJsonFileStrict, writeJsonFile, buildServerEntry, agentKey };

--- a/src/lib/mcp/copilot.js
+++ b/src/lib/mcp/copilot.js
@@ -2,7 +2,7 @@
 
 const os = require('os');
 const path = require('path');
-const { shapeServer, readJsonFile, writeJsonFile, buildServerEntry } = require('./common');
+const { shapeServer, readJsonFile, readJsonFileStrict, writeJsonFile, buildServerEntry } = require('./common');
 
 // Copilot's MCP config lives at ~/.copilot/mcp-config.json. Schema is
 // compatible with claude's (mcpServers map, transport+url for remote,
@@ -13,6 +13,15 @@ const CONFIG_PATH = path.join(os.homedir(), '.copilot', 'mcp-config.json');
 
 function readConfig() { return readJsonFile(CONFIG_PATH); }
 function writeConfig(obj) { return writeJsonFile(CONFIG_PATH, obj); }
+
+// Read for the write path. Refuses to proceed when the file exists but
+// cannot be parsed so a mutating op never overwrites a config it could
+// not read.
+function readConfigForWrite() {
+  const r = readJsonFileStrict(CONFIG_PATH);
+  if (!r.ok) return { error: 'Refusing to write: ~/.copilot/mcp-config.json exists but could not be read' };
+  return { cfg: r.data };
+}
 
 function list() {
   const cfg = readConfig();
@@ -28,7 +37,9 @@ function list() {
 function add(payload = {}) {
   const { id } = payload;
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   if (cfg.mcpServers[id] || (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id])) {
     return { ok: false, error: `MCP server "${id}" already exists` };
@@ -42,7 +53,9 @@ function add(payload = {}) {
 
 function remove(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   if (cfg.mcpServers && cfg.mcpServers[id]) delete cfg.mcpServers[id];
   if (cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]) delete cfg._huskMcpDisabled[id];
   writeConfig(cfg);
@@ -53,7 +66,9 @@ function remove(id) {
 // enabled/disabled status. Same contract as the claude adapter.
 function update(id, payload = {}) {
   if (!id || !/^[a-zA-Z0-9_-]+$/.test(id)) return { ok: false, error: 'Invalid server id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   const inEnabled = !!(cfg.mcpServers && cfg.mcpServers[id]);
   const inDisabled = !!(cfg._huskMcpDisabled && cfg._huskMcpDisabled[id]);
   if (!inEnabled && !inDisabled) {
@@ -74,7 +89,9 @@ function update(id, payload = {}) {
 
 function toggle(id) {
   if (!id) return { ok: false, error: 'No id' };
-  const cfg = readConfig();
+  const read = readConfigForWrite();
+  if (read.error) return { ok: false, error: read.error };
+  const cfg = read.cfg;
   cfg.mcpServers = cfg.mcpServers || {};
   cfg._huskMcpDisabled = cfg._huskMcpDisabled || {};
   if (cfg.mcpServers[id]) {

--- a/src/lib/workflow-graph.js
+++ b/src/lib/workflow-graph.js
@@ -96,14 +96,37 @@ function graphToOrderedSteps(graph) {
   if (!g.nodes.length) return [];
   const byId = new Map(g.nodes.map((n) => [n.id, n]));
   const hasIncoming = new Set(g.edges.map((e) => e.to));
-  let cur = g.nodes.find((n) => !hasIncoming.has(n.id)) || g.nodes[0];
+  // Outgoing adjacency in edge-declaration order, so branch order is
+  // stable and follows how the user wired the graph.
+  const out = new Map();
+  for (const e of g.edges) {
+    if (!out.has(e.from)) out.set(e.from, []);
+    out.get(e.from).push(e.to);
+  }
   const order = [];
   const seen = new Set();
-  while (cur && !seen.has(cur.id)) {
-    seen.add(cur.id);
-    order.push(cur);
-    const edge = g.edges.find((e) => e.from === cur.id);
-    cur = edge ? byId.get(edge.to) : null;
+  // Breadth-first from every root (a node with no incoming edge). The
+  // previous version followed only the first outgoing edge of a single
+  // root, which silently dropped every other branch and any
+  // disconnected node. A pure-cycle graph has no root, so seed with the
+  // first node to stay terminating while still emitting every node.
+  const roots = g.nodes.filter((n) => !hasIncoming.has(n.id));
+  const queue = (roots.length ? roots : [g.nodes[0]]).map((n) => n.id);
+  while (queue.length) {
+    const id = queue.shift();
+    if (seen.has(id)) continue;
+    const node = byId.get(id);
+    if (!node) continue;
+    seen.add(id);
+    order.push(node);
+    for (const to of (out.get(id) || [])) {
+      if (!seen.has(to)) queue.push(to);
+    }
+  }
+  // Append any node not reachable from a root (a disconnected
+  // component) so no step is silently lost.
+  for (const n of g.nodes) {
+    if (!seen.has(n.id)) { seen.add(n.id); order.push(n); }
   }
   return order;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
-const { spawn, spawnSync } = require('child_process');
+const { spawn } = require('child_process');
 const pty = require('node-pty');
 
 const { shJoin } = require('./lib/shell-quote');
@@ -14,22 +14,35 @@ const { resolveInside } = require('./lib/path-confine');
 const { parseAgentMd } = require('./lib/agent-md');
 const wfLib = require('./lib/workflow-graph');
 const { buildSpawnSpec } = require('./lib/pty-spawn');
-const { getUserPath } = require('./lib/user-path');
+const { parseShellPathOutput, MARKER_START, MARKER_END } = require('./lib/user-path');
 const { getAdapter: getMcpAdapter } = require('./lib/mcp');
 
 // On macOS in particular, a GUI-launched Electron app inherits a
 // minimal PATH that does not include the npm-global, homebrew, or bun
 // install directories where users keep their agent CLIs. Read the
-// user's actual shell PATH once at startup so subsequent spawns can
-// find their binaries.
-try {
-  const userPath = getUserPath({
-    platform: process.platform,
-    env: process.env,
-    runShell: (shell, args) => spawnSync(shell, args, { encoding: 'utf8', timeout: 5000 }),
-  });
-  if (userPath) process.env.PATH = userPath;
-} catch (_) {}
+// user's actual shell PATH so subsequent spawns can find their
+// binaries.
+//
+// This runs ASYNCHRONOUSLY: an interactive login shell sources the
+// user's full rc chain (nvm, pyenv, conda init), which can take
+// hundreds of ms to seconds. Doing it with spawnSync at module load
+// froze the whole process before the window appeared. Agent spawns
+// happen on user action, well after this resolves, so async is safe.
+function augmentUserPathAsync() {
+  if (process.platform !== 'darwin' && process.platform !== 'linux') return;
+  const shellBin = (typeof process.env.SHELL === 'string' && process.env.SHELL) ? process.env.SHELL : '/bin/zsh';
+  try {
+    const child = spawn(shellBin, ['-ilc', `echo "${MARKER_START}$PATH${MARKER_END}"`], { timeout: 5000 });
+    let out = '';
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.on('error', () => {});
+    child.on('close', () => {
+      const p = parseShellPathOutput(out);
+      if (p) process.env.PATH = p;
+    });
+  } catch (_) {}
+}
+augmentUserPathAsync();
 const {
   sanitizeGraph,
   migrateWorkflow,
@@ -62,6 +75,23 @@ app.commandLine.appendSwitch('ignore-gpu-blocklist');
 
 let mainWindow = null;
 let ptyProc = null;
+// node-pty listener disposables for the current process, so a respawn
+// can detach them instead of leaking emitter registrations.
+let ptyDataDisposable = null;
+let ptyExitDisposable = null;
+// PTY output coalescing buffer (see spawnPty's onData).
+let ptyDataBuf = '';
+let ptyFlushScheduled = false;
+// Timestamp of the last byte the agent emitted, used to detect when its
+// TUI has settled before we paste an autonomy goal into it.
+let ptyLastDataAt = 0;
+function flushPtyData() {
+  ptyFlushScheduled = false;
+  if (!ptyDataBuf) return;
+  const data = ptyDataBuf;
+  ptyDataBuf = '';
+  if (mainWindow) mainWindow.webContents.send('pty:data', data);
+}
 
 // ─── Config ──────────────────────────────────────────────────────────────────────
 
@@ -527,6 +557,16 @@ function killPtyTree() {
 // ─── PTY ─────────────────────────────────────────────────────────────────────────
 
 function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null) {
+  // Dispose the previous process's data/exit listeners before we drop
+  // the reference, otherwise each restart/resume leaks a node-pty
+  // emitter registration. Also drop any buffered output from the old
+  // process so it cannot bleed into the new session.
+  try { if (ptyDataDisposable) ptyDataDisposable.dispose(); } catch (_) {}
+  try { if (ptyExitDisposable) ptyExitDisposable.dispose(); } catch (_) {}
+  ptyDataDisposable = null;
+  ptyExitDisposable = null;
+  ptyDataBuf = '';
+  ptyFlushScheduled = false;
   if (ptyProc) try { ptyProc.kill(); } catch (_) {}
   const shellBin = process.platform === 'win32'
     ? (process.env.ComSpec || 'cmd.exe')
@@ -662,13 +702,28 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null)
 
   ptyProc = pty.spawn(spec.exe, spec.argv, { name: 'xterm-256color', cols, rows, cwd, env });
   activePtyCwd = cwd;
-  ptyProc.onData((data) => {
-    if (mainWindow) mainWindow.webContents.send('pty:data', data);
+  // Coalesce PTY output: a chatty agent (build logs, a big cat) emits
+  // many chunks per tick. Buffer them and flush once per microtask so
+  // the renderer receives one message per burst instead of one IPC send
+  // per chunk, which otherwise floods the channel and janks the UI.
+  ptyDataDisposable = ptyProc.onData((data) => {
+    ptyLastDataAt = Date.now();
+    ptyDataBuf += data;
+    if (!ptyFlushScheduled) { ptyFlushScheduled = true; setImmediate(flushPtyData); }
     autonomyTap(data);
   });
-  ptyProc.onExit(({ exitCode }) => {
+  ptyExitDisposable = ptyProc.onExit(({ exitCode }) => {
+    flushPtyData();
     if (mainWindow) mainWindow.webContents.send('pty:exit', exitCode);
     ptyProc = null;
+    // If an autonomy run was live, the agent process just died. Close
+    // the run so its 1s meter interval stops, the budget stops ticking
+    // wall-clock against a dead process, and a new run can start (the
+    // "already active" guard would otherwise block forever).
+    if (activeRunner && !autonomyFinishing) {
+      if (mainWindow) mainWindow.webContents.send('autonomy:halt', { reason: 'agent-exited' });
+      finishActiveRun({ reason: 'agent-exited' });
+    }
   });
 }
 
@@ -691,13 +746,33 @@ function readActiveSessionStats() {
       .filter((f) => f.endsWith('.jsonl'))
       .map((f) => {
         const p = path.join(dir, f);
-        try { return { p, mtime: fs.statSync(p).mtimeMs }; } catch (_) { return null; }
+        try { const st = fs.statSync(p); return { p, mtime: st.mtimeMs, size: st.size }; } catch (_) { return null; }
       })
       .filter(Boolean)
       .sort((a, b) => b.mtime - a.mtime);
     if (!files.length) return null;
     const latest = files[0].p;
-    const raw = fs.readFileSync(latest, 'utf8').split('\n').filter(Boolean);
+    // Cap the read. A session JSONL grows for the whole conversation and
+    // can reach many megabytes; reading and parsing the entire file on
+    // every status poll stalls the main thread. Read at most the last
+    // CAP bytes (dropping the first partial line) so the cost stays
+    // bounded. For large sessions the turn/char numbers become a
+    // recent-tail estimate, which is acceptable for a coarse readout.
+    const CAP = 1024 * 1024;
+    let raw;
+    const sz = files[0].size;
+    if (Number.isFinite(sz) && sz > CAP) {
+      const fd = fs.openSync(latest, 'r');
+      try {
+        const buf = Buffer.alloc(CAP);
+        fs.readSync(fd, buf, 0, CAP, sz - CAP);
+        const tail = buf.toString('utf8');
+        const nl = tail.indexOf('\n');
+        raw = (nl >= 0 ? tail.slice(nl + 1) : tail).split('\n').filter(Boolean);
+      } finally { fs.closeSync(fd); }
+    } else {
+      raw = fs.readFileSync(latest, 'utf8').split('\n').filter(Boolean);
+    }
     let turns = 0;
     let chars = 0;
     for (const line of raw) {
@@ -744,6 +819,9 @@ ipcMain.handle('pty:restart', (_e, { cols, rows, command, cwd }) => {
 const Autonomy = require('./lib/autonomy');
 const electronApp = require('electron');
 let activeRunner = null;
+// Guards finishActiveRun against re-entry: an agent crash (onExit) and a
+// user cancel can both try to close the same run at once.
+let autonomyFinishing = false;
 function autonomyStorageRoot() {
   return path.join(app.getPath('userData'), 'autonomy');
 }
@@ -890,6 +968,28 @@ function sigintPty() {
   try { ptyProc.write('\x03'); } catch (_) {}
 }
 
+// Resolve once the agent's TUI looks ready for input: it has emitted
+// output and then gone quiet for a short settle window, or maxMs has
+// elapsed. This replaces a fixed wall-clock guess that, on a slow cold
+// start, pasted the goal before the input field had mounted and the run
+// silently did nothing.
+function whenAgentReady(maxMs) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const settleMs = 350; // quiet period after last output = TUI settled
+    const minWaitMs = Math.min(250, maxMs);
+    const check = () => {
+      const now = Date.now();
+      if (now - start >= maxMs) return resolve('timeout');
+      const sawOutput = ptyLastDataAt >= start - 50;
+      const quietFor = now - ptyLastDataAt;
+      if (sawOutput && quietFor >= settleMs && (now - start) >= minWaitMs) return resolve('ready');
+      setTimeout(check, 80);
+    };
+    setTimeout(check, minWaitMs);
+  });
+}
+
 ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
   if (activeRunner) return { ok: false, error: 'an autonomy run is already active' };
   // Autonomy requires an active project. The whole feature is built
@@ -966,9 +1066,8 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
   if (ptyJustBooted) {
     try { spawnPty(100, 30, null, workspaceRoot); } catch (_) {}
   }
-  const injectDelayMs = ptyJustBooted ? 2500 : 400;
   if (goal) {
-    setTimeout(() => {
+    const deliver = () => {
       const ok = injectGoalToPty(goal);
       // Surface delivery to the activity feed so the user has explicit
       // feedback that the goal reached the agent. Without this, an
@@ -980,7 +1079,18 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
           at: Date.now(),
         });
       }
-    }, injectDelayMs);
+    };
+    if (ptyJustBooted) {
+      // Cold start: wait for the freshly spawned agent's banner to
+      // render and settle before pasting, with a hard fallback so the
+      // goal is always delivered even if the readiness signal never
+      // arrives.
+      whenAgentReady(6000).then(deliver);
+    } else {
+      // Agent already running in Chat: a short delay is enough for the
+      // bracketed paste to land in the existing input.
+      setTimeout(deliver, 400);
+    }
   }
   return { ok: true, sessionId, workspaceRoot, fileCount: snap.fileCount, goal };
 });
@@ -1003,27 +1113,41 @@ ipcMain.handle('autonomy:end', (_e, detail = {}) => {
   return finishActiveRun(detail);
 });
 
-function finishActiveRun(detail) {
-  if (!activeRunner) return { ok: false, error: 'no active run' };
-  try { activeRunner.endRun(detail || null); } catch (_) {}
-  try { clearInterval(activeRunner._tickInterval); } catch (_) {}
-  // Drain any pending PTY tap output so the final agent_output event
-  // makes it into the audit log before we null the runner.
-  try { if (autonomyOutputFlushTimer) { clearTimeout(autonomyOutputFlushTimer); autonomyOutputFlushTimer = null; } } catch (_) {}
-  try { flushAutonomyOutput(); } catch (_) {}
-  autonomyOutputBuf = '';
-  autonomyLineTail = '';
-  autonomyLastTailEmit = '';
-  autonomyLastTailEmitAt = 0;
-  const sessionId = activeRunner.sessionId;
-  const workspaceRoot = activeRunner.workspaceRoot;
-  activeRunner = null;
-  const { decrypt } = autonomyCrypto();
-  const sum = Autonomy.supervisor.summarizeRun({
-    sessionId, workspaceRoot, storageRoot: autonomyStorageRoot(), decrypt,
-  });
-  if (mainWindow) mainWindow.webContents.send('autonomy:ended', sum);
-  return { ok: true, sessionId, summary: sum };
+async function finishActiveRun(detail) {
+  if (!activeRunner || autonomyFinishing) return { ok: false, error: 'no active run' };
+  autonomyFinishing = true;
+  const runner = activeRunner;
+  try {
+    try { clearInterval(runner._tickInterval); } catch (_) {}
+    // Drain any pending PTY tap output so the final agent_output event
+    // makes it into the audit log before we close the runner.
+    try { if (autonomyOutputFlushTimer) { clearTimeout(autonomyOutputFlushTimer); autonomyOutputFlushTimer = null; } } catch (_) {}
+    try { flushAutonomyOutput(); } catch (_) {}
+    autonomyOutputBuf = '';
+    autonomyLineTail = '';
+    autonomyLastTailEmit = '';
+    autonomyLastTailEmitAt = 0;
+    // endRunAsync walks the end-of-run diff off the main thread so the
+    // UI does not freeze hashing the workspace at run end.
+    try { await runner.endRunAsync(detail || null); } catch (_) {}
+    const sessionId = runner.sessionId;
+    const workspaceRoot = runner.workspaceRoot;
+    activeRunner = null;
+    const { decrypt } = autonomyCrypto();
+    let sum;
+    try {
+      sum = await Autonomy.supervisor.summarizeRunAsync({
+        sessionId, workspaceRoot, storageRoot: autonomyStorageRoot(), decrypt,
+      });
+    } catch (err) {
+      sum = { ok: false, error: (err && err.message) || String(err) };
+    }
+    if (mainWindow) mainWindow.webContents.send('autonomy:ended', sum);
+    return { ok: true, sessionId, summary: sum };
+  } finally {
+    activeRunner = null;
+    autonomyFinishing = false;
+  }
 }
 
 ipcMain.handle('autonomy:status', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -1460,9 +1460,10 @@ ipcMain.handle('autonomy:summary', async (_e, payload = {}) => {
   const sessionId = String(payload && payload.sessionId || '').trim();
   if (!sessionId) return { ok: false, error: 'sessionId required' };
   const { decrypt } = autonomyCrypto();
-  // Diff the recorded workspace, not a caller fallback. Use the async
-  // walker so loading a past run from history does not freeze the UI.
-  const workspaceRoot = manifestWorkspaceRoot(sessionId) || String(payload.workspaceRoot || '').trim() || null;
+  // Diff the recorded workspace only, never a caller-supplied path, so this
+  // read cannot be used to enumerate an arbitrary directory tree. Use the
+  // async walker so loading a past run from history does not freeze the UI.
+  const workspaceRoot = manifestWorkspaceRoot(sessionId);
   return Autonomy.supervisor.summarizeRunAsync({
     sessionId,
     workspaceRoot,

--- a/src/main.js
+++ b/src/main.js
@@ -946,19 +946,24 @@ function flushAutonomyOutput() {
 
 function injectGoalToPty(goal) {
   if (!ptyProc) return false;
-  // Bracketed paste mode: wraps the goal in CSI 200~ / CSI 201~ so the
-  // agent's TUI treats it as a single pasted block. Without this, each
-  // character is routed through the TUI's keyboard handler and special
-  // characters get intercepted by hotkeys (claude eats SPACE as a
-  // mode-toggle, "/" opens its command palette, etc.). The result was
-  // goals arriving with all spaces stripped, which is why earlier runs
-  // sat idle: the agent could not parse the smashed-together text.
   try {
     const body = String(goal).replace(/\r/g, ' ').replace(/\n/g, ' ');
-    ptyProc.write('\x1b[200~' + body + '\x1b[201~');
-    // Submit with a separate Enter after the TUI has finished
-    // committing the pasted block to its input buffer.
-    setTimeout(() => { try { if (ptyProc) ptyProc.write('\r'); } catch (_) {} }, 120);
+    if (getAgentKind() === 'claude') {
+      // claude routes raw keystrokes through its TUI hotkey handler (SPACE
+      // toggles a mode, "/" opens the command palette), so the goal must
+      // arrive as one bracketed-paste block (CSI 200~ / CSI 201~). A
+      // separate Enter after the paste commits submits it.
+      ptyProc.write('\x1b[200~' + body + '\x1b[201~');
+      setTimeout(() => { try { if (ptyProc) ptyProc.write('\r'); } catch (_) {} }, 120);
+    } else {
+      // Other agents (verified with copilot) DO accept a bracketed paste
+      // but do NOT submit on the Enter that follows it: their composer
+      // treats that Enter as a newline, so the goal just sits in the input
+      // and the run does nothing. Typing the goal directly keeps the input
+      // in its normal single-line state where Enter submits.
+      ptyProc.write(body);
+      setTimeout(() => { try { if (ptyProc) ptyProc.write('\r'); } catch (_) {} }, 150);
+    }
     return true;
   } catch (_) { return false; }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1314,6 +1314,35 @@ ipcMain.handle('autonomy:history', async (_e, payload = {}) => {
   return { ok: true, runs: runs.slice(0, 24) };
 });
 
+// Delete a past run: removes its session directory (manifest, audit log,
+// and all snapshot blobs). Refuses an active run and validates the
+// sessionId so the recursive remove can only ever touch a single session
+// folder under the autonomy storage root.
+ipcMain.handle('autonomy:deleteRun', (_e, payload = {}) => {
+  const sessionId = String(payload && payload.sessionId || '').trim();
+  if (!sessionId || !/^[A-Za-z0-9._-]+$/.test(sessionId)) {
+    return { ok: false, error: 'invalid sessionId' };
+  }
+  if (activeRunner && activeRunner.sessionId === sessionId) {
+    return { ok: false, error: 'cannot delete the run that is still active' };
+  }
+  const dir = path.join(autonomyStorageRoot(), 'sessions', sessionId);
+  const root = path.join(autonomyStorageRoot(), 'sessions');
+  // Belt and suspenders: the resolved target must sit directly under the
+  // sessions root and not be the root itself.
+  const resolved = path.resolve(dir);
+  if (resolved === path.resolve(root) || path.dirname(resolved) !== path.resolve(root)) {
+    return { ok: false, error: 'path escapes autonomy storage' };
+  }
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- resolved confined to sessions root above
+    fs.rmSync(resolved, { recursive: true, force: true });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err && err.message) || 'delete failed' };
+  }
+});
+
 // Per-file diff for a single touched file. Reads the pre-run blob
 // from the snapshot store (decrypts if needed) and the live
 // workspace file. Renderer computes the line-by-line diff for the

--- a/src/main.js
+++ b/src/main.js
@@ -1029,13 +1029,21 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
   }
   if (!snap.ok) return { ok: false, error: snap.error };
 
+  // Derive the agent name from the configured command so the budget
+  // meter prices the run correctly. Vendor-billed agents (copilot, codex,
+  // aider, gemini) carry a $0 rate so the dollar cap does not fire on a
+  // fabricated Sonnet-priced cost; claude falls through to the default
+  // model rate.
+  const agentName = (config.agentCommand || 'claude').trim().split(/\s+/)[0]
+    .split(/[\\/]/).pop().toLowerCase().replace(/\.(exe|cmd|bat|ps1)$/i, '');
+  const vendorBilled = ['copilot', 'codex', 'aider', 'gemini'].includes(agentName);
   const r = Autonomy.supervisor.startRun({
     sessionId,
     workspaceRoot,
     storageRoot: autonomyStorageRoot(),
     goal: typeof payload.goal === 'string' ? payload.goal.slice(0, 4096) : null,
-    agent: payload.agent || null,
-    modelId: payload.modelId || null,
+    agent: payload.agent || agentName,
+    modelId: payload.modelId || (vendorBilled ? agentName : null),
     caps: payload.caps,
     encrypt, decrypt,
     skipSnapshot: true,
@@ -1050,9 +1058,18 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
     if (!activeRunner) return;
     const s = activeRunner.tickClock();
     if (mainWindow) mainWindow.webContents.send('autonomy:budget', s);
-    if (s.hitCap && mainWindow) {
+    if (s.hitCap) {
+      // Cap reached. Stop this interval immediately so we do not inject
+      // a SIGINT and re-broadcast a halt every second (the meter keeps
+      // reporting hitCap once a cap is crossed). Interrupt the agent
+      // once, tell the renderer once, and finalize the run so it leaves
+      // the active state instead of sitting "Running" forever. The agent
+      // stays alive at its prompt; SIGINT interrupts the current turn, it
+      // does not kill the PTY.
+      try { clearInterval(activeRunner._tickInterval); } catch (_) {}
       sigintPty();
-      mainWindow.webContents.send('autonomy:halt', { reason: 'budget', cap: s.hitCap });
+      if (mainWindow) mainWindow.webContents.send('autonomy:halt', { reason: 'budget', cap: s.hitCap });
+      finishActiveRun({ reason: 'budget', cap: s.hitCap });
     }
   }, 1000);
   const goal = typeof payload.goal === 'string' ? payload.goal.slice(0, 4096) : '';
@@ -1142,6 +1159,10 @@ async function finishActiveRun(detail) {
     } catch (err) {
       sum = { ok: false, error: (err && err.message) || String(err) };
     }
+    // Carry the run identity on the payload so the renderer can enter
+    // review / revert / rerun even when its own autonomyLastSession was
+    // lost (e.g. the renderer reloaded while the run was active).
+    if (sum && typeof sum === 'object') { sum.sessionId = sessionId; sum.workspaceRoot = workspaceRoot; }
     if (mainWindow) mainWindow.webContents.send('autonomy:ended', sum);
     return { ok: true, sessionId, summary: sum };
   } finally {
@@ -1161,13 +1182,29 @@ ipcMain.handle('autonomy:status', () => {
   };
 });
 
+// The restore/diff target for a session is the directory the snapshot
+// was captured from, recorded in its manifest. Never trust a caller-
+// supplied workspaceRoot for a destructive revert: an empty value used
+// to fall back to HOME, and the restore deletes every file not in the
+// snapshot, so a wrong root would wipe an unrelated directory.
+function manifestWorkspaceRoot(sessionId) {
+  try {
+    const mp = path.join(autonomyStorageRoot(), 'sessions', sessionId, 'snapshot.json');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded to autonomy storage
+    const m = JSON.parse(fs.readFileSync(mp, 'utf8'));
+    return (m && typeof m.workspaceRoot === 'string' && m.workspaceRoot) ? m.workspaceRoot : null;
+  } catch (_) { return null; }
+}
+
 ipcMain.handle('autonomy:revert', (_e, payload = {}) => {
   const sessionId = String(payload && payload.sessionId || '').trim();
   if (!sessionId) return { ok: false, error: 'sessionId required' };
+  const workspaceRoot = manifestWorkspaceRoot(sessionId);
+  if (!workspaceRoot) return { ok: false, error: 'snapshot manifest has no workspace root; cannot revert safely' };
   const { decrypt } = autonomyCrypto();
   return Autonomy.supervisor.revertRun({
     sessionId,
-    workspaceRoot: String(payload.workspaceRoot || activePtyCwd || HOME),
+    workspaceRoot,
     storageRoot: autonomyStorageRoot(),
     decrypt,
     preserveExtras: !!payload.preserveExtras,
@@ -1385,13 +1422,16 @@ ipcMain.handle('autonomy:liveDiff', async () => {
   }
 });
 
-ipcMain.handle('autonomy:summary', (_e, payload = {}) => {
+ipcMain.handle('autonomy:summary', async (_e, payload = {}) => {
   const sessionId = String(payload && payload.sessionId || '').trim();
   if (!sessionId) return { ok: false, error: 'sessionId required' };
   const { decrypt } = autonomyCrypto();
-  return Autonomy.supervisor.summarizeRun({
+  // Diff the recorded workspace, not a caller fallback. Use the async
+  // walker so loading a past run from history does not freeze the UI.
+  const workspaceRoot = manifestWorkspaceRoot(sessionId) || String(payload.workspaceRoot || '').trim() || null;
+  return Autonomy.supervisor.summarizeRunAsync({
     sessionId,
-    workspaceRoot: String(payload.workspaceRoot || activePtyCwd || HOME),
+    workspaceRoot,
     storageRoot: autonomyStorageRoot(),
     decrypt,
   });

--- a/src/preload.js
+++ b/src/preload.js
@@ -108,6 +108,7 @@ contextBridge.exposeInMainWorld('husk', {
     summary: (opts) => ipcRenderer.invoke('autonomy:summary', opts || {}),
     liveDiff: () => ipcRenderer.invoke('autonomy:liveDiff'),
     history: (opts) => ipcRenderer.invoke('autonomy:history', opts || {}),
+    deleteRun: (opts) => ipcRenderer.invoke('autonomy:deleteRun', opts || {}),
     fileDiff: (opts) => ipcRenderer.invoke('autonomy:fileDiff', opts || {}),
     reportTokens: (n) => ipcRenderer.invoke('autonomy:reportTokens', { tokens: n }),
     onStarted: (cb) => ipcRenderer.on('autonomy:started', (_e, payload) => cb(payload)),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -724,7 +724,8 @@ function paintProjects(items, filter) {
         <div class="project-card-path" title="${escapeHtml(p.path)}">${escapeHtml(p.path)}</div>
         <div class="project-card-meta">last used ${escapeHtml(fmtRelTime(p.lastUsedAt))}</div>
         <div class="project-card-actions">
-          <button class="card-cta project-open" data-id="${escapeHtml(p.id)}" title="Switch to this project">${isActive ? 'Reopen' : 'Open'}<svg class="card-cta-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg></button>
+          ${isActive ? `<button class="card-cta project-leave" title="Stop using this project; the agent runs in your home folder">Leave project</button>` : ''}
+          <button class="card-cta project-open" data-id="${escapeHtml(p.id)}" title="${isActive ? 'Restart the agent in this project' : 'Switch to this project'}">${isActive ? 'Reopen' : 'Open'}<svg class="card-cta-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg></button>
         </div>
       </div>
     `;
@@ -732,6 +733,7 @@ function paintProjects(items, filter) {
   // eslint-disable-next-line no-unsanitized/property -- Every interpolation goes through escapeHtml.
   grid.innerHTML = cards;
   grid.querySelectorAll('.project-open').forEach((btn) => btn.addEventListener('click', (e) => { e.stopPropagation(); openProject(e.currentTarget.dataset.id); }));
+  grid.querySelectorAll('.project-leave').forEach((btn) => btn.addEventListener('click', (e) => { e.stopPropagation(); clearActiveProject(); }));
   grid.querySelectorAll('.project-delete').forEach((btn) => btn.addEventListener('click', (e) => { e.stopPropagation(); deleteProject(e.currentTarget.dataset.id, e.currentTarget.dataset.name); }));
   grid.querySelectorAll('.project-card').forEach((card) => card.addEventListener('click', (e) => {
     if (e.target.closest('.project-card-actions') || e.target.closest('.card-delete')) return;
@@ -751,6 +753,19 @@ async function openProject(id) {
   const project = (res.project && res.project.path) ? res.project : (projectsCache.find((p) => p.id === id) || {});
   await restartPty({ cwd: project.path || null });
   setPage('chat');
+}
+
+// Leave the active project: clear the selection so the agent runs in the
+// default (home / configured) cwd again. Restarts the PTY so the change
+// takes effect, mirroring how switching projects works.
+async function clearActiveProject() {
+  if (!activeProjectId) return;
+  const res = await window.husk.projects.clearActive();
+  if (!res || !res.ok) { toast((res && res.error) || 'Could not leave project', 'error'); return; }
+  activeProjectId = null;
+  await refreshProjectsState();
+  await restartPty({ cwd: null });
+  toast('Left project; the agent runs in your home folder', 'success');
 }
 
 async function refreshProjectsState() {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -16,6 +16,20 @@ function toast(msg, kind = '') {
   toastTimer = setTimeout(() => { el.hidden = true; }, 2800);
 }
 
+// Top-center banner for run-completion. Separate from toast() so it sits
+// where the user is looking when a run ends, and does not collide with
+// ordinary corner toasts. kind: '' (done) | 'budget' | 'stopped'.
+let runBannerTimer = null;
+function runEndBanner(msg, kind = '') {
+  const el = $('#run-banner');
+  if (!el) return;
+  el.textContent = msg;
+  el.className = 'run-banner' + (kind ? ' ' + kind : '');
+  el.hidden = false;
+  if (runBannerTimer) clearTimeout(runBannerTimer);
+  runBannerTimer = setTimeout(() => { el.hidden = true; }, 5000);
+}
+
 // ─── Confirm dialog ─────────────────────────────────────────────────────────
 // Reusable destructive-action confirmation. Replaces the two-click "is-armed"
 // pattern with a proper modal that names what is about to be deleted. Returns
@@ -4605,6 +4619,26 @@ function rerunFromPastRun(run) {
   });
 }
 
+async function deleteRun(run) {
+  if (!run || !run.sessionId) return;
+  const ok = await openConfirmDialog({
+    title: 'Delete this run?',
+    bodyHtml: "This permanently removes the run's snapshot, audit log, and saved file versions. You will no longer be able to review or revert it.",
+    confirmLabel: 'Delete run',
+    cancelLabel: 'Keep',
+  });
+  if (!ok) return;
+  const r = await window.husk.autonomy.deleteRun({ sessionId: run.sessionId });
+  if (!r || !r.ok) { toast((r && r.error) || 'Could not delete run', 'error'); return; }
+  toast('Run deleted', 'success');
+  // If the deleted run is the one currently under review, leave review
+  // mode; otherwise just refresh the list in place.
+  if (autonomyReview && autonomyReviewData && autonomyReviewData.sessionId === run.sessionId) {
+    exitReviewMode();
+  } else {
+    refreshAutonomyHistory();
+  }
+}
 async function refreshAutonomyHistory() {
   const list = $('#aut-recent');
   const meta = $('#aut-recent-meta');
@@ -4687,10 +4721,31 @@ async function refreshAutonomyHistory() {
     rerun.appendChild(rerunSvg);
     rerun.appendChild(rerunLbl);
     rerun.addEventListener('click', (e) => { e.stopPropagation(); rerunFromPastRun(run); });
+    const del = document.createElement('button');
+    del.type = 'button';
+    del.className = 'aut-recent-del';
+    del.title = 'Delete this run';
+    del.setAttribute('aria-label', 'Delete run');
+    const delSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    delSvg.setAttribute('viewBox', '0 0 24 24');
+    delSvg.setAttribute('fill', 'none');
+    delSvg.setAttribute('stroke', 'currentColor');
+    delSvg.setAttribute('stroke-width', '2');
+    delSvg.setAttribute('stroke-linecap', 'round');
+    delSvg.setAttribute('stroke-linejoin', 'round');
+    delSvg.setAttribute('aria-hidden', 'true');
+    for (const d of ['M3 6h18', 'M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6', 'M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2']) {
+      const p = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      p.setAttribute('d', d);
+      delSvg.appendChild(p);
+    }
+    del.appendChild(delSvg);
+    del.addEventListener('click', (e) => { e.stopPropagation(); deleteRun(run); });
     row.appendChild(main);
     row.appendChild(files);
     row.appendChild(pill);
     row.appendChild(rerun);
+    row.appendChild(del);
     row.addEventListener('click', () => openAutonomyRunReview(run.sessionId, run.workspaceRoot));
     list.appendChild(row);
   }
@@ -5352,8 +5407,9 @@ function terminalLooksIdleAtPrompt() {
 async function finalizeAutonomyOnIdle() {
   if (!autonomyActive) return;
   try {
+    // The top-center run-complete banner is shown by onEnded; no corner
+    // toast here so the two do not duplicate.
     await window.husk.autonomy.end({ reason: 'agent_idle' });
-    toast('Run finished automatically (agent returned to idle)', 'success');
   } catch (err) {
     // If the end call fails, allow another idle attempt next tick.
     autonomyAutoEndTriggered = false;
@@ -5538,6 +5594,12 @@ try {
         const sid = (autonomyLastSession && autonomyLastSession.sessionId) || (sum.sessionId || '');
         const wr = (autonomyLastSession && autonomyLastSession.workspaceRoot) || (sum.workspaceRoot || '');
         enterReviewMode({ sessionId: sid, workspaceRoot: wr, summary: sum });
+        // Announce the end top-center where the user is looking.
+        const halt = (sum.summary && sum.summary.haltReason) || 'natural';
+        if (halt === 'budget') runEndBanner('Run stopped at a budget cap', 'budget');
+        else if (halt === 'user') runEndBanner('Run stopped', 'stopped');
+        else if (halt === 'agent-exited') runEndBanner('Run ended: agent exited', 'stopped');
+        else runEndBanner('Run complete', '');
       } else {
         paintAutonomyBanner();
       }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -4405,13 +4405,27 @@ function openAutonomyStart() {
   if (hasProject) setTimeout(() => { try { $('#aut-goal').focus(); } catch (_) {} }, 0);
 }
 function closeAutonomyStart() { $('#autonomy-start-modal').hidden = true; }
+// Read one cap field. Empty -> default. A typed 0 is kept as 0, which
+// the budget meter treats as "no cap for this metric". Negative or
+// non-numeric is invalid: fall back to the default and flag it so the UI
+// and the engine never disagree silently.
+function readCapField(id, def) {
+  const el = $(id);
+  const raw = el ? String(el.value || '').trim() : '';
+  if (raw === '') return { value: def };
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return { value: def, invalid: true };
+  return { value: n };
+}
 async function startAutonomy() {
   const goal = ($('#aut-goal').value || '').trim();
-  const caps = {
-    minutes: Number($('#aut-cap-min').value) || 60,
-    tokens: Number($('#aut-cap-tok').value) || 200000,
-    dollars: Number($('#aut-cap-usd').value) || 5,
-  };
+  const cMin = readCapField('#aut-cap-min', 60);
+  const cTok = readCapField('#aut-cap-tok', 200000);
+  const cUsd = readCapField('#aut-cap-usd', 5);
+  if (cMin.invalid || cTok.invalid || cUsd.invalid) {
+    toast('Caps must be zero or a positive number; invalid values were reset to the default', 'error');
+  }
+  const caps = { minutes: cMin.value, tokens: cTok.value, dollars: cUsd.value };
   const goBtn = $('#aut-start-go');
   const cancelBtn = $('#aut-start-cancel');
   const status = $('#aut-snapshot-status');
@@ -4445,6 +4459,17 @@ async function startAutonomy() {
 }
 async function cancelAutonomy() {
   if (!autonomyActive) return;
+  // Stopping a run is destructive to in-flight work, so confirm first.
+  // This is the explicit Stop action; the chat autonomy button no longer
+  // routes here (it opens the run view instead) so a stray click cannot
+  // end a run by accident.
+  const ok = await openConfirmDialog({
+    title: 'Stop the autonomy run?',
+    bodyHtml: 'The agent will be interrupted and the run will end. Your workspace changes are kept; you can review or revert them afterward.',
+    confirmLabel: 'Stop run',
+    cancelLabel: 'Keep running',
+  });
+  if (!ok) return;
   const r = await window.husk.autonomy.cancel({});
   if (!r || !r.ok) { toast((r && r.error) || 'Cancel failed', 'error'); return; }
 }
@@ -4716,10 +4741,23 @@ const AP_TERM_SEEN_MAX = 400;
 const AP_IDLE_END_MS = 10000;
 const AP_IDLE_END_HARD_MS = 25000;
 const AP_MIN_EVENTS_BEFORE_AUTO_END = 3;
+// The agent's "working" indicator (claude renders "esc to interrupt" and
+// a live "(12s . N tokens . ...)" status line while generating or running
+// a tool). When it is present the agent is busy; when it has been gone
+// this long the turn is finished. Driving auto-end off this is both
+// faster (ends seconds after the agent returns to its prompt) and safer
+// (a busy-but-quiet agent still shows the indicator, so it is not ended
+// mid-flight).
+const AP_WORK_GONE_MS = 6000;
+const AP_WORKING_RE = /esc to interrupt|\(\s*\d+\s*s\s*[·•.]/i;
 let autonomyTermInterval = null;
 let autonomyTermSeenLines = new Set();
 let autonomyTermSeenOrder = [];
 let autonomyLastActivityAt = 0;
+// Last time the agent's working indicator was visible, and whether it has
+// ever been seen this run. Both drive completion detection.
+let autonomyWorkingSeenAt = 0;
+let autonomyEverWorked = false;
 let autonomyAutoEndTriggered = false;
 let autonomyReview = false;
 let autonomyReviewData = null;
@@ -4841,9 +4879,10 @@ function setAutonomyGoal(goal) {
 }
 function setAutonomyCaps(caps) {
   autonomyState.caps = Object.assign({ minutes: 60, tokens: 200000, dollars: 5 }, caps || {});
-  const tc = $('#aut-page-cap-time'); if (tc) tc.textContent = `of ${autonomyState.caps.minutes}m`;
-  const ko = $('#aut-page-cap-tokens'); if (ko) ko.textContent = `of ${formatTokens(autonomyState.caps.tokens)}`;
-  const dc = $('#aut-page-cap-dollars'); if (dc) dc.textContent = `of ${formatDollars(autonomyState.caps.dollars)}`;
+  const c = autonomyState.caps;
+  const tc = $('#aut-page-cap-time'); if (tc) tc.textContent = c.minutes > 0 ? `of ${c.minutes}m` : 'no time limit';
+  const ko = $('#aut-page-cap-tokens'); if (ko) ko.textContent = c.tokens > 0 ? `of ${formatTokens(c.tokens)}` : 'no token limit';
+  const dc = $('#aut-page-cap-dollars'); if (dc) dc.textContent = c.dollars > 0 ? `of ${formatDollars(c.dollars)}` : 'no $ limit';
 }
 function formatTokens(n) {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1) + 'M';
@@ -4873,9 +4912,17 @@ function updateAutonomyBudget(b) {
   const elapsedMin = (Date.now() - autonomyState.startedAt) / 60000;
   const tv = $('#aut-page-val-time');
   if (tv) tv.textContent = elapsedMin < 1 ? `${Math.floor(elapsedMin * 60)}s` : `${elapsedMin.toFixed(1)}m`;
-  updateRing('aut-page-ring-time', elapsedMin / caps.minutes, meters[0]);
+  updateRing('aut-page-ring-time', caps.minutes > 0 ? elapsedMin / caps.minutes : 0, meters[0]);
   const tk = Number(b.totalTokens) || 0;
-  const tv2 = $('#aut-page-val-tokens'); if (tv2) tv2.textContent = formatTokens(tk);
+  // The token figure is read from the agent's own status line and is an
+  // approximation (per-turn / context-relative depending on the agent),
+  // so mark it as approximate rather than presenting an exact count.
+  const approx = !!(b.tokensReported || b.tokensEstimated);
+  const tv2 = $('#aut-page-val-tokens');
+  if (tv2) {
+    tv2.textContent = (approx && tk > 0 ? '~' : '') + formatTokens(tk);
+    tv2.title = approx ? 'Approximate, read from the agent status line' : '';
+  }
   updateRing('aut-page-ring-tokens', caps.tokens > 0 ? tk / caps.tokens : 0, meters[1]);
   const usd = Number(b.dollars) || 0;
   const dv = $('#aut-page-val-dollars');
@@ -5163,6 +5210,11 @@ function parseAgentTokenStatus(line) {
   // before the word "tokens" (case-insensitive). Examples we WANT
   // to match: "1.5k tokens", "↓ 1.5k tokens", "2,300 tokens used",
   // "Tokens: 1234 sent" (handled by inverse below).
+  // "152k/200k tokens" is context-used / context-window. The number
+  // directly before "tokens" is the window SIZE, not usage, so prefer the
+  // used side (the numerator) before falling through to the generic match.
+  const ratio = line.match(/(\d[\d,\.]*)\s*([kKmM]?)\s*\/\s*\d[\d,\.]*\s*[kKmM]?\s*tokens?\b/i);
+  if (ratio) return parseTokenNumber(ratio[1], ratio[2]);
   const after = line.match(/(\d[\d,\.]*)\s*([kKmM]?)\s*tokens?\b/);
   if (after) return parseTokenNumber(after[1], after[2]);
   const before = line.match(/tokens?\s*[:=]\s*(\d[\d,\.]*)\s*([kKmM]?)/i);
@@ -5233,22 +5285,34 @@ function snapshotTermForAutonomy() {
   if (maxReported >= 0 && window.husk && window.husk.autonomy && window.husk.autonomy.reportTokens) {
     try { window.husk.autonomy.reportTokens(maxReported); } catch (_) {}
   }
-  // Idle watchdog. Two thresholds:
-  //   soft:  AP_IDLE_END_MS quiet  +  prompt detected in last 15 rows
-  //   hard:  AP_IDLE_END_HARD_MS quiet (no prompt detection needed)
-  // The soft threshold ends fast when we recognize the agent's
-  // prompt. The hard threshold ends eventually even if the agent's
-  // prompt does not match any pattern we know (claude wraps the
-  // prompt in a box; the last visible row is often an input hint
-  // like "← for agents", not the prompt itself).
+  // Working-indicator detection drives completion. Scan the last rows for
+  // the agent's "busy" marker; while it is present the agent is generating
+  // or running a tool, so the run must not be auto-ended.
+  let working = false;
+  for (let i = Math.max(0, total - AP_TERM_SCAN_WINDOW); i < total; i++) {
+    const ln = b.getLine(i);
+    if (!ln) continue;
+    if (AP_WORKING_RE.test(ln.translateToString(true))) { working = true; break; }
+  }
+  if (working) { autonomyWorkingSeenAt = Date.now(); autonomyEverWorked = true; }
+
+  // Completion watchdog. Primary signal: the agent worked, then its
+  // working indicator went away and stayed away, and the terminal looks
+  // like it is back at a prompt. This ends the run within seconds of the
+  // agent actually finishing, and cannot fire while the agent is busy.
+  // The quiet-only hard net remains as a fallback for agents that show no
+  // recognizable working indicator, but it too waits for "not working".
   if (autonomyActive && !autonomyAutoEndTriggered
       && autonomyState.eventCount >= AP_MIN_EVENTS_BEFORE_AUTO_END
       && autonomyLastActivityAt > 0) {
-    const idleMs = Date.now() - autonomyLastActivityAt;
-    if (idleMs >= AP_IDLE_END_MS && terminalLooksIdleAtPrompt()) {
-      autonomyAutoEndTriggered = true;
-      finalizeAutonomyOnIdle();
-    } else if (idleMs >= AP_IDLE_END_HARD_MS) {
+    const now = Date.now();
+    const idleMs = now - autonomyLastActivityAt;
+    const workGoneMs = autonomyWorkingSeenAt ? now - autonomyWorkingSeenAt : Infinity;
+    const notWorking = !working && workGoneMs >= AP_WORK_GONE_MS;
+    const finishedAfterWork = autonomyEverWorked && notWorking
+      && (terminalLooksIdleAtPrompt() || idleMs >= AP_IDLE_END_MS);
+    const quietFallback = notWorking && idleMs >= AP_IDLE_END_HARD_MS;
+    if (finishedAfterWork || quietFallback) {
       autonomyAutoEndTriggered = true;
       finalizeAutonomyOnIdle();
     }
@@ -5304,6 +5368,8 @@ function startAutonomyTermSnapshotter() {
   autonomyTermSeenOrder = [];
   autonomyLastActivityAt = Date.now();
   autonomyAutoEndTriggered = false;
+  autonomyWorkingSeenAt = 0;
+  autonomyEverWorked = false;
   const b = term.buffer.active;
   const total = b.length;
   for (let i = 0; i < total; i++) {
@@ -5403,6 +5469,19 @@ function openAutonomyEndModal(sum) {
   $('#autonomy-end-modal').hidden = false;
 }
 function closeAutonomyEndModal() { $('#autonomy-end-modal').hidden = true; }
+// Report a revert honestly: a non-empty warnings list means some files
+// were NOT restored (decrypt failure, blob mismatch, fs error). The old
+// unconditional "success" toast hid partial reverts, which is the exact
+// trust violation the feature exists to prevent.
+function reportRevertResult(r) {
+  const restored = (r.restored || []).length;
+  const warned = (r.warnings || []).length;
+  if (warned) {
+    toast(`Reverted ${restored} file${restored === 1 ? '' : 's'}; ${warned} could not be restored`, 'error');
+  } else {
+    toast(`Reverted ${restored} file${restored === 1 ? '' : 's'}`, 'success');
+  }
+}
 async function revertAutonomy() {
   if (!autonomyLastSession) { toast('No run to revert', 'error'); return; }
   const ok = await openConfirmDialog({
@@ -5414,11 +5493,15 @@ async function revertAutonomy() {
   if (!ok) return;
   const r = await window.husk.autonomy.revert(autonomyLastSession);
   if (!r || !r.ok) { toast((r && r.error) || 'Revert failed', 'error'); return; }
-  toast(`Reverted ${(r.restored || []).length} files`, 'success');
+  reportRevertResult(r);
   closeAutonomyEndModal();
 }
 $('#btn-autonomy') && $('#btn-autonomy').addEventListener('click', () => {
-  if (autonomyActive) { cancelAutonomy(); return; }
+  // While a run is active this button takes the user to the run view, it
+  // does NOT stop the run. Stopping is the explicit Stop button on the
+  // autonomy page (which confirms). A second click here used to silently
+  // cancel the run, which read as "open status" to users.
+  if (autonomyActive) { try { setPage('autonomy'); } catch (_) {} return; }
   openAutonomyStart();
 });
 $('#aut-start-close') && $('#aut-start-close').addEventListener('click', closeAutonomyStart);
@@ -5450,7 +5533,7 @@ try {
       // run appears in Recent runs immediately.
       if (sum && sum.ok) {
         const sid = (autonomyLastSession && autonomyLastSession.sessionId) || (sum.sessionId || '');
-        const wr = (autonomyLastSession && autonomyLastSession.workspaceRoot) || '';
+        const wr = (autonomyLastSession && autonomyLastSession.workspaceRoot) || (sum.workspaceRoot || '');
         enterReviewMode({ sessionId: sid, workspaceRoot: wr, summary: sum });
       } else {
         paintAutonomyBanner();
@@ -5458,7 +5541,14 @@ try {
       refreshAutonomyHistory();
     });
     window.husk.autonomy.onHalt((info) => {
-      toast(`Autonomy halted: ${info && info.cap ? info.cap + ' cap reached' : 'budget'}`, 'error');
+      // Report the real cause. A budget cap names the cap; an agent that
+      // exited on its own is not a budget event and must not be labelled
+      // "budget".
+      let why, level;
+      if (info && info.cap) { why = `${info.cap} cap reached`; level = 'error'; }
+      else if (info && info.reason === 'agent-exited') { why = 'agent exited'; level = 'info'; }
+      else { why = 'stopped'; level = 'error'; }
+      toast(`Autonomy halted: ${why}`, level);
     });
     if (window.husk.autonomy.onSnapshotProgress) {
       window.husk.autonomy.onSnapshotProgress((info) => {
@@ -5537,7 +5627,7 @@ $('#aut-review-revert') && $('#aut-review-revert').addEventListener('click', asy
     workspaceRoot: autonomyReviewData.workspaceRoot,
   });
   if (!r || !r.ok) { toast((r && r.error) || 'Revert failed', 'error'); return; }
-  toast(`Reverted ${(r.restored || []).length} files`, 'success');
+  reportRevertResult(r);
   // Refresh the live diff view from disk so it reflects the revert.
   if (autonomyReviewData) {
     const sum = await window.husk.autonomy.summary({

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -4749,7 +4749,10 @@ const AP_MIN_EVENTS_BEFORE_AUTO_END = 3;
 // (a busy-but-quiet agent still shows the indicator, so it is not ended
 // mid-flight).
 const AP_WORK_GONE_MS = 6000;
-const AP_WORKING_RE = /esc to interrupt|\(\s*\d+\s*s\s*[·•.]/i;
+// Busy markers across agents: claude renders "esc to interrupt" and a live
+// "(12s . N tokens)" status; copilot renders a "Working" spinner label.
+// Matching any of them keeps a run alive while the agent is generating.
+const AP_WORKING_RE = /esc to interrupt|\(\s*\d+\s*s\s*[·•.]|\bworking\b/i;
 let autonomyTermInterval = null;
 let autonomyTermSeenLines = new Set();
 let autonomyTermSeenOrder = [];

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -231,14 +231,39 @@ term.attachCustomKeyEventHandler((e) => {
   });
   window.addEventListener('blur', hideMenu);
 }
+// Small trailing debounce: coalesce rapid calls (search keystrokes) so
+// an expensive repaint runs once the user pauses, not per character.
+function debounce(fn, ms) {
+  let t = null;
+  return (...args) => {
+    if (t) clearTimeout(t);
+    t = setTimeout(() => { t = null; fn(...args); }, ms);
+  };
+}
+
+// Coalesce PTY output into one xterm write per animation frame. A
+// chatty agent emits many chunks in quick succession; writing each one
+// separately (with its own scroll callback and speech scan) burned CPU
+// and janked scrolling. Buffering to the next frame collapses a burst
+// into a single write + single scroll + single speech scan.
+let _termWriteBuf = '';
+let _termFlushScheduled = false;
+function _flushTermWrite() {
+  _termFlushScheduled = false;
+  if (!_termWriteBuf) return;
+  const data = _termWriteBuf;
+  _termWriteBuf = '';
+  term.write(data, () => term.scrollToBottom());
+  detectAndSpeak(data);
+}
 window.husk.pty.onData((d) => {
   if (!chatHasInput) {
     chatHasInput = true;
     $('#chat-empty').classList.remove('show');
   }
   if (_restartInProgress) return;
-  term.write(d, () => term.scrollToBottom());
-  detectAndSpeak(d);
+  _termWriteBuf += d;
+  if (!_termFlushScheduled) { _termFlushScheduled = true; requestAnimationFrame(_flushTermWrite); }
 });
 window.husk.pty.onExit((code) => {
   // Suppress the exit notice when we're tearing the old PTY down on purpose,
@@ -695,7 +720,7 @@ async function deleteProject(id, name) {
 // Wire Projects page controls + Add Project modal.
 {
   const search = document.getElementById('projects-search');
-  if (search) search.addEventListener('input', () => paintProjects(projectsCache, search.value));
+  if (search) search.addEventListener('input', debounce(() => paintProjects(projectsCache, search.value), 120));
 
   const newBtn = document.getElementById('btn-projects-new');
   const modal = document.getElementById('new-project-modal');
@@ -2190,7 +2215,7 @@ async function previewPrompt(mdPath) {
 // Wire prompts search + refresh + create.
 {
   const search = document.getElementById('prompts-search');
-  if (search) search.addEventListener('input', () => paintPrompts(promptsCache, search.value));
+  if (search) search.addEventListener('input', debounce(() => paintPrompts(promptsCache, search.value), 120));
   const refresh = document.getElementById('btn-prompts-refresh');
   if (refresh) refresh.addEventListener('click', renderPrompts);
 
@@ -2356,7 +2381,7 @@ function paintSkills(list, query) {
     });
   });
 }
-$('#skills-search').addEventListener('input', (e) => paintSkills(skillsCache, e.target.value));
+$('#skills-search').addEventListener('input', debounce((e) => paintSkills(skillsCache, e.target.value), 120));
 $('#btn-skills-refresh').addEventListener('click', renderSkills);
 $('#btn-skills-open').addEventListener('click', () => lastStats && window.husk.fs.open(lastStats.skillsDir));
 $('#btn-skills-new').addEventListener('click', openCreateSkillModal);
@@ -2514,9 +2539,22 @@ function paintSessions(list, query) {
 
 function toggleSessionSelection(p) {
   if (!p) return;
-  if (sessionsSelected.has(p)) sessionsSelected.delete(p);
+  const wasSelected = sessionsSelected.has(p);
+  if (wasSelected) sessionsSelected.delete(p);
   else sessionsSelected.add(p);
-  paintSessions(sessionsCache, $('#sessions-search').value);
+  // Update only the affected row in place. Repainting the whole list on
+  // every checkbox click was an O(n) DOM teardown and listener rebind.
+  const ul = $('#sessions-list');
+  if (ul) {
+    for (const row of ul.querySelectorAll('.session-row')) {
+      if (row.dataset.path === p) {
+        row.classList.toggle('selected', !wasSelected);
+        const cb = row.querySelector('input[type="checkbox"]');
+        if (cb) cb.checked = !wasSelected;
+        break;
+      }
+    }
+  }
   syncSelectModeUI();
 }
 
@@ -2561,7 +2599,7 @@ async function deleteSelectedSessions() {
   await renderSessions();
 }
 
-$('#sessions-search').addEventListener('input', (e) => paintSessions(sessionsCache, e.target.value));
+$('#sessions-search').addEventListener('input', debounce((e) => paintSessions(sessionsCache, e.target.value), 120));
 $('#btn-sessions-refresh').addEventListener('click', renderSessions);
 $('#btn-sessions-open').addEventListener('click', () => lastStats && window.husk.fs.open(lastStats.sessionsDir));
 $('#btn-sessions-select').addEventListener('click', enterSelectMode);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -724,7 +724,7 @@ function paintProjects(items, filter) {
         <div class="project-card-path" title="${escapeHtml(p.path)}">${escapeHtml(p.path)}</div>
         <div class="project-card-meta">last used ${escapeHtml(fmtRelTime(p.lastUsedAt))}</div>
         <div class="project-card-actions">
-          ${isActive ? `<button class="card-cta project-leave" title="Stop using this project; the agent runs in your home folder">Leave project</button>` : ''}
+          ${isActive ? `<button class="card-cta project-leave" title="Work with no project; the agent runs in your home folder">Switch to no project</button>` : ''}
           <button class="card-cta project-open" data-id="${escapeHtml(p.id)}" title="${isActive ? 'Restart the agent in this project' : 'Switch to this project'}">${isActive ? 'Reopen' : 'Open'}<svg class="card-cta-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg></button>
         </div>
       </div>

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1019,6 +1019,11 @@ function wfEnsureEditor() {
   if (!container || typeof Drawflow === 'undefined') return;
   wfEditor = new Drawflow(container);
   wfEditor.reroute = true;
+  // Dropping a connection anywhere on the target node's body connects it to
+  // that node's input, instead of forcing the user to land exactly on the
+  // small input dot. Each step has a single input, so first-input is the
+  // right target.
+  wfEditor.force_first_input = true;
   wfEditor.start();
   wfEditor.on('nodeSelected', (id) => { hideEdgePanel(); showNodePanel(id); });
   wfEditor.on('nodeUnselected', () => hideNodePanel());

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -5,29 +5,103 @@
 const $ = (s) => document.querySelector(s);
 const $$ = (s) => Array.from(document.querySelectorAll(s));
 
-// ─── Toast ───────────────────────────────────────────────────────────────────────
-let toastTimer = null;
-function toast(msg, kind = '') {
-  const el = $('#toast');
-  el.textContent = msg;
-  el.className = 'toast' + (kind ? ' ' + kind : '');
-  el.hidden = false;
-  if (toastTimer) clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => { el.hidden = true; }, 2800);
+// ─── Notifications ─────────────────────────────────────────────────────────
+// A top-center stack of independent cards. Each slides in, auto-dismisses
+// (errors linger longer), pauses on hover, and can be dismissed by hand.
+// Newest sits on top; the stack is capped so a burst cannot bury the UI.
+const NOTIF_MAX = 4;
+const NOTIF_TTL = { error: 6500, warn: 5500, success: 4000, info: 4000, '': 4000 };
+// Icon path sets (stroke, 24x24 viewBox). Built with createElementNS so no
+// markup is injected as a string.
+const NOTIF_ICONS = {
+  success: [['path', 'M20 6 9 17l-5-5']],
+  error: [['circle', '12 12 9'], ['path', 'M12 8v4'], ['path', 'M12 16h.01']],
+  warn: [['path', 'M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z'], ['path', 'M12 9v4'], ['path', 'M12 17h.01']],
+  info: [['circle', '12 12 9'], ['path', 'M12 11v5'], ['path', 'M12 8h.01']],
+  done: [['path', 'M22 11.08V12a10 10 0 1 1-5.93-9.14'], ['path', 'M22 4 12 14.01l-3-3']],
+};
+function notifSvg(name) {
+  const spec = NOTIF_ICONS[name] || NOTIF_ICONS.info;
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+  for (const [tag, data] of spec) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    if (tag === 'circle') { const [cx, cy, r] = data.split(' '); el.setAttribute('cx', cx); el.setAttribute('cy', cy); el.setAttribute('r', r); }
+    else el.setAttribute('d', data);
+    svg.appendChild(el);
+  }
+  return svg;
 }
-
-// Top-center banner for run-completion. Separate from toast() so it sits
-// where the user is looking when a run ends, and does not collide with
-// ordinary corner toasts. kind: '' (done) | 'budget' | 'stopped'.
-let runBannerTimer = null;
+function dismissNotif(card) {
+  if (!card || card._dismissing) return;
+  card._dismissing = true;
+  if (card._timer) clearTimeout(card._timer);
+  card.classList.add('is-out');
+  setTimeout(() => { try { card.remove(); } catch (_) {} }, 200);
+}
+// Core entry. opts: { title, kind, prominent, ttl }
+function notify(message, opts = {}) {
+  const stack = $('#toast-stack');
+  if (!stack) return;
+  const kind = opts.kind || '';
+  const iconName = opts.icon || (opts.prominent ? 'done' : (kind || 'info'));
+  const card = document.createElement('div');
+  card.className = 'toast is-enter' + (kind ? ' ' + kind : '') + (opts.prominent ? ' is-prominent' : '');
+  const icon = document.createElement('span');
+  icon.className = 'toast-icon';
+  icon.appendChild(notifSvg(iconName));
+  const body = document.createElement('div');
+  body.className = 'toast-body';
+  if (opts.title) {
+    const t = document.createElement('div');
+    t.className = 'toast-title';
+    t.textContent = opts.title;
+    body.appendChild(t);
+  }
+  const m = document.createElement('div');
+  m.className = 'toast-msg';
+  m.textContent = message;
+  body.appendChild(m);
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'toast-close';
+  close.setAttribute('aria-label', 'Dismiss');
+  close.textContent = '×';
+  close.addEventListener('click', () => dismissNotif(card));
+  card.appendChild(icon);
+  card.appendChild(body);
+  card.appendChild(close);
+  // Newest on top.
+  stack.insertBefore(card, stack.firstChild);
+  // Remove the entrance class so the card transitions in. rAF gives clean
+  // first-paint timing on a real display; the setTimeout is a guarantee so
+  // the card never stays stuck hidden if rAF is starved (background window).
+  const reveal = () => card.classList.remove('is-enter');
+  requestAnimationFrame(() => requestAnimationFrame(reveal));
+  setTimeout(reveal, 60);
+  // Cap the stack: drop the oldest beyond the limit.
+  while (stack.children.length > NOTIF_MAX) dismissNotif(stack.lastElementChild);
+  // Auto-dismiss with hover-to-pause.
+  const ttl = opts.ttl || NOTIF_TTL[kind] || NOTIF_TTL[''];
+  const arm = () => { card._timer = setTimeout(() => dismissNotif(card), ttl); };
+  arm();
+  card.addEventListener('mouseenter', () => { if (card._timer) clearTimeout(card._timer); });
+  card.addEventListener('mouseleave', () => { if (!card._dismissing) arm(); });
+  return card;
+}
+// Back-compatible API used across the renderer.
+function toast(msg, kind = '') { notify(msg, { kind }); }
+// Run-completion notification: a prominent card with a title.
 function runEndBanner(msg, kind = '') {
-  const el = $('#run-banner');
-  if (!el) return;
-  el.textContent = msg;
-  el.className = 'run-banner' + (kind ? ' ' + kind : '');
-  el.hidden = false;
-  if (runBannerTimer) clearTimeout(runBannerTimer);
-  runBannerTimer = setTimeout(() => { el.hidden = true; }, 5000);
+  // Map the run outcome to a notification style.
+  const k = kind === 'budget' ? 'warn' : (kind === 'stopped' ? '' : 'success');
+  notify(msg, { kind: k, prominent: true, title: 'Autonomy run', icon: kind === 'budget' ? 'warn' : 'done', ttl: 6000 });
 }
 
 // ─── Confirm dialog ─────────────────────────────────────────────────────────

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -213,16 +213,30 @@ term.options.linkHandler = { activate: openTerminalLink };
 term.open($('#terminal'));
 
 function themeForXterm() {
-  // Fixed dark console in BOTH app themes. The terminal runs a TUI agent
-  // (claude, copilot, ...) that emits light-on-dark ANSI colors, so a light
-  // background would wash its output out. The chat stage is also fixed dark
-  // (.chat-stage) to match. The accent cursor still follows the app accent.
+  // The terminal runs a TUI agent that themes its output through the 16 ANSI
+  // colors. Each app theme gets a matching palette so the output is readable
+  // on its own background: a dark-on-light palette in light mode, a
+  // light-on-dark one in dark mode. Read after body[data-theme] is set.
   const accent = getComputedStyle(document.body).getPropertyValue('--accent').trim() || '#ff7847';
+  const isLight = document.body.getAttribute('data-theme') === 'light';
+  if (isLight) {
+    // Dark, saturated colors readable on a white background. The dim
+    // greys agents use for hints (brightBlack) become a mid grey, not a
+    // near-white that vanishes.
+    return {
+      background: '#ffffff', foreground: '#1f2328',
+      cursor: accent, cursorAccent: '#ffffff',
+      selectionBackground: '#cfe3ff',
+      black: '#1f2328', red: '#cf222e', green: '#116329', yellow: '#7d4e00',
+      blue: '#0969da', magenta: '#8250df', cyan: '#1b7c83', white: '#6e7781',
+      brightBlack: '#57606a', brightRed: '#a40e26', brightGreen: '#1a7f37',
+      brightYellow: '#633c01', brightBlue: '#218bff', brightMagenta: '#8250df',
+      brightCyan: '#1b7c83', brightWhite: '#1f2328',
+    };
+  }
   return {
-    background: '#0b0d12',
-    foreground: '#e6e9ef',
-    cursor: accent,
-    cursorAccent: '#0b0d12',
+    background: '#0b0d12', foreground: '#e6e9ef',
+    cursor: accent, cursorAccent: '#0b0d12',
     selectionBackground: '#2d3447',
     black: '#0b0d12', red: '#fb7185', green: '#4ade80', yellow: '#fbbf24',
     blue: '#818cf8', magenta: '#a78bfa', cyan: '#67e8f9', white: '#e6e9ef',

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -213,14 +213,17 @@ term.options.linkHandler = { activate: openTerminalLink };
 term.open($('#terminal'));
 
 function themeForXterm() {
-  // Use the active CSS theme tokens. Read AFTER body[data-theme] is set.
-  const root = getComputedStyle(document.body);
+  // Fixed dark console in BOTH app themes. The terminal runs a TUI agent
+  // (claude, copilot, ...) that emits light-on-dark ANSI colors, so a light
+  // background would wash its output out. The chat stage is also fixed dark
+  // (.chat-stage) to match. The accent cursor still follows the app accent.
+  const accent = getComputedStyle(document.body).getPropertyValue('--accent').trim() || '#ff7847';
   return {
-    background: root.getPropertyValue('--bg-1').trim() || '#0b0d12',
-    foreground: root.getPropertyValue('--text').trim() || '#e6e9ef',
-    cursor: root.getPropertyValue('--accent').trim() || '#67e8f9',
-    cursorAccent: root.getPropertyValue('--bg-1').trim() || '#0b0d12',
-    selectionBackground: root.getPropertyValue('--line-2').trim() || '#2d3447',
+    background: '#0b0d12',
+    foreground: '#e6e9ef',
+    cursor: accent,
+    cursorAccent: '#0b0d12',
+    selectionBackground: '#2d3447',
     black: '#0b0d12', red: '#fb7185', green: '#4ade80', yellow: '#fbbf24',
     blue: '#818cf8', magenta: '#a78bfa', cyan: '#67e8f9', white: '#e6e9ef',
     brightBlack: '#475063', brightRed: '#fda4af', brightGreen: '#86efac',

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1051,6 +1051,9 @@
 
     <div id="toast" class="toast" hidden></div>
 
+    <!-- Top-center banner used for run-completion notifications. -->
+    <div id="run-banner" class="run-banner" hidden></div>
+
     <!-- Autonomy: per-file diff viewer -->
     <div id="aut-diff-modal" class="modal" hidden>
       <div class="modal-card modal-card-wide aut-diff-card">

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1049,10 +1049,8 @@
       </div>
     </div>
 
-    <div id="toast" class="toast" hidden></div>
-
-    <!-- Top-center banner used for run-completion notifications. -->
-    <div id="run-banner" class="run-banner" hidden></div>
+    <!-- Notification stack: top-center, cards stack and dismiss independently. -->
+    <div id="toast-stack" class="toast-stack" role="status" aria-live="polite"></div>
 
     <!-- Autonomy: per-file diff viewer -->
     <div id="aut-diff-modal" class="modal" hidden>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -803,7 +803,7 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   height: auto;
 }
 .page-autonomy::-webkit-scrollbar { width: 8px; }
-.page-autonomy::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.08); border-radius: 4px; }
+.page-autonomy::-webkit-scrollbar-thumb { background: var(--bg-1); border-radius: 4px; }
 .page-autonomy .page-head { margin-bottom: 22px; }
 .page-autonomy .page-head-right { display: flex; align-items: center; gap: 12px; }
 /* Unified button sizing inside the Autonomy page so every CTA reads
@@ -846,8 +846,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   display: inline-flex; align-items: center; gap: 8px;
   padding: 6px 12px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 10%, rgba(255, 255, 255, 0.04));
-  border: 1px solid color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.08));
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-2));
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--line-2));
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
   color: var(--text);
@@ -857,12 +857,12 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 .aut-page-elapsed { color: var(--text-2); margin-left: 4px; }
 .aut-page-status.is-review {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.10);
+  background: var(--bg-2);
+  border-color: var(--line-2);
   color: var(--text-2);
 }
 .aut-page-status.is-review .ap-dot {
-  background: rgba(255, 255, 255, 0.25);
+  background: var(--text-3);
   animation: none;
   box-shadow: none;
 }
@@ -949,14 +949,14 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   flex: 1; min-height: 0;
   overflow: auto;
   background: rgba(0, 0, 0, 0.22);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--line);
   border-radius: 10px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 12.5px;
   line-height: 1.55;
 }
 .aut-diff-content::-webkit-scrollbar { width: 10px; height: 10px; }
-.aut-diff-content::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.1); border-radius: 5px; }
+.aut-diff-content::-webkit-scrollbar-thumb { background: var(--bg-1); border-radius: 5px; }
 .aut-diff-line {
   display: grid;
   grid-template-columns: 50px 50px 22px 1fr;
@@ -967,11 +967,11 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .aut-diff-ln {
   padding: 1px 8px;
   text-align: right;
-  color: rgba(255, 255, 255, 0.32);
+  color: var(--text-3);
   font-variant-numeric: tabular-nums;
   user-select: none;
-  background: rgba(255, 255, 255, 0.02);
-  border-right: 1px solid rgba(255, 255, 255, 0.04);
+  background: var(--bg-1);
+  border-right: 1px solid var(--line);
 }
 .aut-diff-sign {
   padding: 1px 6px;
@@ -999,9 +999,9 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .aut-diff-line.remove .aut-diff-ln { background: color-mix(in srgb, var(--rose) 18%, transparent); color: var(--rose); }
 .aut-diff-line.context .aut-diff-text { color: var(--text-2); }
 .aut-diff-line.hunk-gap {
-  background: rgba(255, 255, 255, 0.025);
-  border-top: 1px dashed rgba(255, 255, 255, 0.08);
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.08);
+  background: var(--bg-1);
+  border-top: 1px dashed var(--line);
+  border-bottom: 1px dashed var(--line);
   color: var(--text-3);
 }
 .aut-diff-line.hunk-gap .aut-diff-text {
@@ -1061,8 +1061,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   background:
     radial-gradient(120% 100% at 0% 0%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 60%),
     radial-gradient(80% 80% at 100% 100%, color-mix(in srgb, var(--accent) 8%, transparent), transparent 60%),
-    rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+    var(--bg-1);
+  border: 1px solid var(--line);
   overflow: hidden;
 }
 .aut-hero::before {
@@ -1108,22 +1108,22 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 .aut-hero-secondary {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid var(--line);
   color: var(--text);
   font-family: var(--font-display);
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease;
 }
 .aut-hero-secondary:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: rgba(255, 255, 255, 0.32);
+  background: var(--bg-1);
+  border-color: var(--line-2);
 }
 .aut-hero-stats {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, max-content));
   gap: 40px;
   padding-top: 22px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--line);
 }
 .aut-hero-stat-value {
   font-family: var(--font-display);
@@ -1175,8 +1175,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   gap: 10px;
   padding: 20px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
   cursor: pointer;
   text-align: left;
   font-family: inherit;
@@ -1184,8 +1184,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   transition: border-color 180ms ease, background 180ms ease, transform 120ms ease;
 }
 .aut-preset:hover {
-  border-color: color-mix(in srgb, var(--accent) 50%, rgba(255, 255, 255, 0.06));
-  background: color-mix(in srgb, var(--accent) 5%, rgba(255, 255, 255, 0.03));
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line-2));
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-1));
   transform: translateY(-2px);
 }
 .aut-preset:active { transform: translateY(0); }
@@ -1193,7 +1193,7 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   width: 36px; height: 36px;
   display: inline-flex; align-items: center; justify-content: center;
   border-radius: 10px;
-  background: color-mix(in srgb, var(--accent) 16%, rgba(255, 255, 255, 0.04));
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-1));
   color: var(--accent);
 }
 .aut-preset-icon svg { width: 18px; height: 18px; }
@@ -1212,7 +1212,7 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .aut-preset-caps {
   display: flex; gap: 12px;
   padding-top: 10px;
-  border-top: 1px dashed rgba(255, 255, 255, 0.06);
+  border-top: 1px dashed var(--line);
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
   color: var(--text-3);
@@ -1225,8 +1225,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .aut-recent {
   display: flex; flex-direction: column;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(255, 255, 255, 0.022);
+  border: 1px solid var(--line);
+  background: var(--bg-1);
   overflow: hidden;
 }
 .aut-recent .aut-page-feed-empty {
@@ -1241,8 +1241,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   cursor: pointer;
   transition: background 160ms ease;
 }
-.aut-recent-row + .aut-recent-row { border-top: 1px solid rgba(255, 255, 255, 0.05); }
-.aut-recent-row:hover { background: rgba(255, 255, 255, 0.035); }
+.aut-recent-row + .aut-recent-row { border-top: 1px solid var(--line); }
+.aut-recent-row:hover { background: var(--bg-1); }
 .aut-recent-main { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .aut-recent-goal {
   font-family: var(--font-display);
@@ -1286,9 +1286,9 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 .aut-recent-pill[data-status="cancelled"],
 .aut-recent-pill[data-status="user"] {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-1);
   color: var(--text-2);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--line);
 }
 
 .aut-recent-row { grid-template-columns: 1fr auto auto auto; }
@@ -1296,8 +1296,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   display: inline-flex; align-items: center; gap: 6px;
   padding: 6px 12px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--line);
+  background: var(--bg-1);
   color: var(--text-2);
   font-family: var(--font-display);
   font-size: 11.5px;
@@ -1306,9 +1306,9 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
 }
 .aut-recent-rerun:hover {
-  background: color-mix(in srgb, var(--accent) 14%, rgba(255, 255, 255, 0.04));
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-1));
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.12));
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line-2));
 }
 .aut-recent-rerun svg { width: 12px; height: 12px; }
 
@@ -1316,16 +1316,16 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   display: inline-flex; align-items: center; justify-content: center;
   width: 30px; height: 30px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--line);
+  background: var(--bg-1);
   color: var(--text-3);
   cursor: pointer;
   transition: background var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out), border-color var(--motion-fast) var(--ease-out);
 }
 .aut-recent-del:hover {
-  background: color-mix(in srgb, var(--rose) 14%, rgba(255, 255, 255, 0.04));
+  background: color-mix(in srgb, var(--rose) 14%, var(--bg-1));
   color: var(--rose);
-  border-color: color-mix(in srgb, var(--rose) 40%, rgba(255, 255, 255, 0.12));
+  border-color: color-mix(in srgb, var(--rose) 40%, var(--line-2));
 }
 .aut-recent-del svg { width: 13px; height: 13px; }
 
@@ -1345,14 +1345,12 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   display: flex; flex-direction: column; gap: 8px;
 }
 .aut-page-goal-text {
-  font-family: var(--font-display);
-  font-size: 17px; line-height: 1.5;
-  letter-spacing: -0.008em;
+  font-size: 15px; line-height: 1.55;
   color: var(--text);
   padding: 16px 18px;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
 }
 
 /* Big ring trio */
@@ -1369,16 +1367,16 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   gap: 18px;
   padding: 18px 20px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
   transition: border-color 200ms ease, background 200ms ease;
 }
 .aut-page-meter.is-warn {
-  border-color: color-mix(in srgb, var(--rose) 45%, rgba(255, 255, 255, 0.06));
-  background: color-mix(in srgb, var(--rose) 6%, rgba(255, 255, 255, 0.025));
+  border-color: color-mix(in srgb, var(--rose) 45%, var(--line));
+  background: color-mix(in srgb, var(--rose) 6%, var(--bg-1));
 }
 .aut-page-ring { width: 84px; height: 84px; transform: rotate(-90deg); }
-.aut-page-ring-track { fill: none; stroke: rgba(255, 255, 255, 0.07); stroke-width: 6; }
+.aut-page-ring-track { fill: none; stroke: var(--line-2); stroke-width: 6; }
 .aut-page-ring-fill {
   fill: none;
   stroke: var(--accent);
@@ -1429,15 +1427,15 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .aut-page-pane {
   display: flex; flex-direction: column;
   min-height: 0;
-  background: rgba(255, 255, 255, 0.022);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
   border-radius: 14px;
   overflow: hidden;
 }
 .aut-page-pane-head {
   display: flex; align-items: center; justify-content: space-between;
   padding: 10px 14px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--line);
 }
 .aut-page-pane-meta {
   font-family: 'JetBrains Mono', monospace;
@@ -1454,12 +1452,11 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 .aut-page-files::-webkit-scrollbar { width: 6px; }
 .aut-page-feed::-webkit-scrollbar-thumb,
 .aut-page-files::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08); border-radius: 3px;
+  background: var(--line-2); border-radius: 3px;
 }
 .aut-page-feed-empty {
   color: var(--text-3); font-size: 12.5px;
   padding: 22px 6px; text-align: center;
-  font-family: var(--font-display);
 }
 
 /* Activity row (reuses ap-row-in keyframe). */
@@ -1473,8 +1470,8 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   animation: ap-row-in 280ms cubic-bezier(0.16, 1, 0.3, 1);
   word-break: break-word;
 }
-.ap-feed-row + .ap-feed-row { border-top: 1px dashed rgba(255, 255, 255, 0.04); }
-.ap-feed-row:hover { background: rgba(255, 255, 255, 0.03); }
+.ap-feed-row + .ap-feed-row { border-top: 1px solid var(--line); }
+.ap-feed-row:hover { background: var(--bg-2); }
 .ap-feed-row .ap-row-glyph {
   flex: 0 0 10px;
   margin-top: 7px;
@@ -1517,15 +1514,14 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   animation: ap-row-in 280ms cubic-bezier(0.16, 1, 0.3, 1);
   word-break: break-all;
 }
-.aut-file-row + .aut-file-row { border-top: 1px dashed rgba(255, 255, 255, 0.04); }
-.aut-file-row:hover { background: rgba(255, 255, 255, 0.03); }
+.aut-file-row + .aut-file-row { border-top: 1px solid var(--line); }
+.aut-file-row:hover { background: var(--bg-2); }
 .aut-file-row .aut-file-status {
   flex: 0 0 auto;
   font-size: 10px; font-weight: 700;
   letter-spacing: 0.08em; text-transform: uppercase;
   padding: 2px 8px;
   border-radius: 999px;
-  font-family: var(--font-display);
 }
 .aut-file-row[data-status="added"] .aut-file-status {
   background: color-mix(in srgb, #5bd994 14%, transparent);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1310,6 +1310,23 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
 }
 .aut-recent-rerun svg { width: 12px; height: 12px; }
 
+.aut-recent-del {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-3);
+  cursor: pointer;
+  transition: background var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out), border-color var(--motion-fast) var(--ease-out);
+}
+.aut-recent-del:hover {
+  background: color-mix(in srgb, var(--rose) 14%, rgba(255, 255, 255, 0.04));
+  color: var(--rose);
+  border-color: color-mix(in srgb, var(--rose) 40%, rgba(255, 255, 255, 0.12));
+}
+.aut-recent-del svg { width: 13px; height: 13px; }
+
 /* Live layout */
 .aut-page-live {
   display: flex; flex-direction: column;
@@ -3962,6 +3979,30 @@ kbd {
 .toast.error { border-color: var(--rose); }
 .toast.success { border-color: var(--emerald); }
 @keyframes toast-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+
+/* Run-completion banner: pinned to the top center so the end of a run is
+   announced where the user is looking, not tucked into the corner. */
+.run-banner {
+  position: fixed; top: 18px; left: 50%; transform: translateX(-50%);
+  display: flex; align-items: center; gap: 9px;
+  padding: 11px 20px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  color: var(--text);
+  font-size: 13px; font-weight: 600;
+  box-shadow: var(--elev-3);
+  animation: run-banner-in var(--motion-base) var(--ease-out);
+  z-index: 300;
+  max-width: 90vw;
+}
+.run-banner::before {
+  content: ''; width: 8px; height: 8px; border-radius: 50%;
+  background: var(--emerald); flex: none;
+}
+.run-banner.budget::before { background: var(--amber, #f0a020); }
+.run-banner.stopped::before { background: var(--text-3, #8a93a3); }
+@keyframes run-banner-in { from { opacity: 0; transform: translate(-50%, -10px); } to { opacity: 1; transform: translate(-50%, 0); } }
 
 /* ─── Scrollbar ─────────────────────────────────────────────────────────── */
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -29,6 +29,7 @@
   --rose:    #ff6b7e;
   --emerald: #5bd49a;
   --amber:   #f6b73c;
+  --notif-bg: #12162e;
   --shadow:      0 30px 60px -30px rgba(0,0,0,0.7), 0 0 0 1px rgba(255,255,255,0.06);
   --shadow-soft: 0 1px 2px rgba(0,0,0,0.4);
   /* Ambient gradient lighting under the chrome. Four radial pools
@@ -65,6 +66,7 @@
   --rose: #dc2626;
   --emerald: #16a34a;
   --amber: #ca8a04;
+  --notif-bg: #ffffff;
   --shadow: 0 0 0 1px var(--line), 0 4px 12px rgba(0,0,0,0.06);
   --shadow-soft: 0 1px 2px rgba(0,0,0,0.04);
   --bg-radial: radial-gradient(1200px 720px at 100% 100%,
@@ -3973,12 +3975,15 @@ kbd {
 .dp-foot button { flex: 1; }
 
 /* ─── Notifications ─────────────────────────────────────────────────────── */
+/* Top-right stack. All surfaces, borders, text and status colors come from
+   the theme tokens (--surface/--line/--text/--emerald/...), so the cards
+   match Husk in both dark and light without per-theme overrides below. */
 
 .toast-stack {
-  position: fixed; top: 16px; left: 50%; transform: translateX(-50%);
-  display: flex; flex-direction: column; align-items: center; gap: 10px;
+  position: fixed; top: 60px; right: 16px; left: auto; transform: none;
+  display: flex; flex-direction: column; align-items: stretch; gap: 10px;
   z-index: 300;
-  width: max-content; max-width: min(440px, 92vw);
+  width: min(380px, calc(100vw - 32px));
   pointer-events: none;
 }
 .toast {
@@ -3986,50 +3991,46 @@ kbd {
   display: grid; grid-template-columns: auto 1fr auto; align-items: start; gap: 11px;
   width: 100%;
   padding: 12px 13px 12px 14px;
-  background: var(--bg-2);
+  background: var(--notif-bg);
   border: 1px solid var(--line-2);
-  border-left: 3px solid var(--text-3, #8a93a3);
+  border-left: 3px solid var(--text-3);
   border-radius: 12px;
   color: var(--text);
-  box-shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.45), 0 2px 8px -4px rgba(0, 0, 0, 0.35);
-  opacity: 1; transform: translateY(0) scale(1);
+  box-shadow: var(--elev-3);
+  opacity: 1; transform: translateX(0);
   transition: opacity 200ms var(--ease-out), transform 200ms var(--ease-out);
 }
 /* Entrance: inserted with .is-enter, removed on the next frame so the card
-   transitions in. Exit adds .is-out. Using a transition (not a keyframe)
+   slides in from the right. Exit adds .is-out. A transition (not a keyframe)
    keeps the resting state visible even if the compositor is not animating. */
-.toast.is-enter { opacity: 0; transform: translateY(-10px) scale(0.98); }
-.toast.is-out { opacity: 0; transform: translateY(-8px) scale(0.98); }
-.toast-icon { display: flex; align-items: center; justify-content: center; width: 18px; height: 18px; margin-top: 1px; color: var(--text-3, #8a93a3); flex: none; }
+.toast.is-enter { opacity: 0; transform: translateX(16px); }
+.toast.is-out { opacity: 0; transform: translateX(16px); }
+.toast-icon { display: flex; align-items: center; justify-content: center; width: 18px; height: 18px; margin-top: 1px; color: var(--text-3); flex: none; }
 .toast-icon svg { width: 18px; height: 18px; }
 .toast-body { min-width: 0; }
-.toast-title { font-size: 12px; font-weight: 700; letter-spacing: 0.01em; margin-bottom: 2px; }
+.toast-title { font-size: 12px; font-weight: 700; letter-spacing: 0.01em; margin-bottom: 2px; color: var(--text); }
 .toast-msg { font-size: 13px; line-height: 1.45; color: var(--text); word-break: break-word; }
 .toast-title + .toast-msg { color: var(--text-2); }
 .toast-close {
   display: flex; align-items: center; justify-content: center;
   width: 20px; height: 20px; margin: -2px -2px 0 0;
-  border: none; background: transparent; color: var(--text-3, #8a93a3);
+  border: none; background: transparent; color: var(--text-3);
   font-size: 17px; line-height: 1; border-radius: 6px; cursor: pointer; flex: none;
   transition: background var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out);
 }
-.toast-close:hover { background: rgba(255, 255, 255, 0.08); color: var(--text); }
+.toast-close:hover { background: var(--bg-3); color: var(--text); }
 
 .toast.success { border-left-color: var(--emerald); }
 .toast.success .toast-icon { color: var(--emerald); }
 .toast.error { border-left-color: var(--rose); }
 .toast.error .toast-icon { color: var(--rose); }
-.toast.warn { border-left-color: var(--amber, #f0a020); }
-.toast.warn .toast-icon { color: var(--amber, #f0a020); }
+.toast.warn { border-left-color: var(--amber); }
+.toast.warn .toast-icon { color: var(--amber); }
 .toast.info { border-left-color: var(--accent); }
 .toast.info .toast-icon { color: var(--accent); }
 
 /* Prominent variant for significant events (autonomy run completion). */
-.toast.is-prominent {
-  padding: 14px 15px 14px 16px;
-  border-left-width: 4px;
-  box-shadow: 0 16px 40px -14px rgba(0, 0, 0, 0.55), 0 3px 10px -4px rgba(0, 0, 0, 0.4);
-}
+.toast.is-prominent { padding: 14px 15px 14px 16px; border-left-width: 4px; box-shadow: var(--elev-4); }
 .toast.is-prominent .toast-icon, .toast.is-prominent .toast-icon svg { width: 22px; height: 22px; }
 .toast.is-prominent .toast-title { font-size: 13px; }
 .toast.is-prominent .toast-msg { font-size: 13.5px; }
@@ -4392,15 +4393,6 @@ kbd {
   transform: translateY(-2px);
 }
 
-/* Toast: same glass treatment. */
-[data-theme="dark"] .toast {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  border-radius: 14px;
-  color: var(--text);
-}
 
 /* Page headings use the serif voice moment by default. */
 [data-theme="dark"] .modal-title {
@@ -4464,19 +4456,6 @@ kbd {
   background: #141838;
   border-color: rgba(255, 255, 255, 0.20);
 }
-
-/* Toast: floats over arbitrary content, must be solid for the same
-   reason as popovers. */
-[data-theme="dark"] .toast {
-  background: #0e1126;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
-  border-radius: 14px;
-  box-shadow: 0 30px 60px -20px rgba(0, 0, 0, 0.85);
-}
-[data-theme="dark"] .toast.error { border-color: rgba(255, 107, 126, 0.55); }
-[data-theme="dark"] .toast.success { border-color: rgba(91, 212, 154, 0.55); }
 
 /* Rail tooltip in collapsed mode: also floats, also needs solid bg. */
 [data-theme="dark"] body[data-rail="collapsed"] .rail-item::after {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -637,7 +637,7 @@ body[data-rail="collapsed"] .rail-agent-menu { display: none !important; }
   text-align: left;
   transition: background 0.14s ease, color 0.14s ease;
 }
-.rail-agent-config:hover { background: rgba(255, 255, 255, 0.07); color: var(--text); }
+.rail-agent-config:hover { background: var(--bg-3); color: var(--text); }
 
 /* Recent sessions list */
 .rail-section-recent { display: none; }
@@ -1558,13 +1558,13 @@ body[data-rail="expanded"] .rail-section-recent:not([hidden]) { display: flex; }
   letter-spacing: -0.005em;
   color: var(--text);
   background: rgba(255, 92, 122, 0.12);
-  border: 1px solid color-mix(in srgb, var(--rose) 50%, rgba(255, 255, 255, 0.08));
+  border: 1px solid color-mix(in srgb, var(--rose) 50%, var(--line));
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease, transform 80ms ease;
 }
 .btn-stop:hover {
   background: rgba(255, 92, 122, 0.20);
-  border-color: color-mix(in srgb, var(--rose) 70%, rgba(255, 255, 255, 0.08));
+  border-color: color-mix(in srgb, var(--rose) 70%, var(--line));
 }
 .btn-stop:active { transform: translateY(1px); }
 .btn-stop svg { width: 14px; height: 14px; }
@@ -1592,8 +1592,8 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   margin-top: 14px;
   padding: 12px 14px;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
   font-size: 12.5px;
   color: var(--text-2);
   line-height: 1.55;
@@ -1619,8 +1619,8 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   border-radius: 16px;
   background:
     radial-gradient(80% 80% at 30% 20%, color-mix(in srgb, var(--accent) 28%, transparent), transparent 60%),
-    rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.09);
+    var(--bg-2);
+  border: 1px solid var(--line-2);
   color: var(--accent);
 }
 .aut-empty-icon svg { width: 28px; height: 28px; }
@@ -1711,7 +1711,12 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   position: relative;
   border-radius: var(--radius-lg);
   border: 1px solid var(--line);
-  background: var(--bg-1);
+  /* The chat surface hosts a terminal running a TUI agent, which emits
+     light-on-dark ANSI colors. The console therefore stays dark in BOTH
+     app themes (the welcome layer already uses this exact color) so the
+     agent's output is always readable. The xterm theme is fixed dark to
+     match (see themeForXterm). */
+  background: #0b0d12;
   overflow: hidden;
   box-shadow: none;
 }
@@ -2499,7 +2504,7 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   padding: 1px 4px; border-radius: 3px;
   background: var(--bg-3); color: var(--text);
 }
-.ra-status.ra-status-info { border-color: rgba(255, 255, 255, 0.12); }
+.ra-status.ra-status-info { border-color: var(--line-2); }
 .ra-status.ra-status-error { border-color: rgba(255, 92, 122, 0.35); color: var(--text); }
 /* The footer of the repo-install modal has three toggles + two buttons;
    let it wrap on narrow window widths rather than stretching off-screen. */
@@ -2890,7 +2895,7 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
 .card-cta.project-leave:hover {
   color: var(--text);
   border-color: var(--line);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--bg-2);
 }
 .card-cta {
   display: inline-flex; align-items: center; gap: 6px;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2883,6 +2883,17 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
 /* Card CTA: small calm primary action with a trailing arrow. Replaces the
    flex:1 orange banner button that screamed for attention. The card itself is
    the affordance; this is the explicit commit. */
+/* Secondary CTA (e.g. Leave project): neutral, not accent-colored, so the
+   primary Open/Reopen action stays visually dominant. */
+.card-cta.project-leave {
+  color: var(--text-2);
+  border-color: var(--line-2);
+}
+.card-cta.project-leave:hover {
+  color: var(--text);
+  border-color: var(--line);
+  background: rgba(255, 255, 255, 0.05);
+}
 .card-cta {
   display: inline-flex; align-items: center; gap: 6px;
   background: transparent;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3961,48 +3961,67 @@ kbd {
 }
 .dp-foot button { flex: 1; }
 
-/* ─── Toast ─────────────────────────────────────────────────────────────── */
+/* ─── Notifications ─────────────────────────────────────────────────────── */
 
-.toast {
-  position: fixed; bottom: 22px; right: 22px;
-  padding: 12px 16px;
-  background: var(--bg-2);
-  border: 1px solid var(--line-2);
-  border-radius: var(--radius-lg);
-  color: var(--text);
-  font-size: 13px;
-  box-shadow: var(--elev-3);
-  animation: toast-in var(--motion-base) var(--ease-out);
-  z-index: 250;
-  max-width: 380px;
-}
-.toast.error { border-color: var(--rose); }
-.toast.success { border-color: var(--emerald); }
-@keyframes toast-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
-
-/* Run-completion banner: pinned to the top center so the end of a run is
-   announced where the user is looking, not tucked into the corner. */
-.run-banner {
-  position: fixed; top: 18px; left: 50%; transform: translateX(-50%);
-  display: flex; align-items: center; gap: 9px;
-  padding: 11px 20px;
-  background: var(--bg-2);
-  border: 1px solid var(--line-2);
-  border-radius: 999px;
-  color: var(--text);
-  font-size: 13px; font-weight: 600;
-  box-shadow: var(--elev-3);
-  animation: run-banner-in var(--motion-base) var(--ease-out);
+.toast-stack {
+  position: fixed; top: 16px; left: 50%; transform: translateX(-50%);
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
   z-index: 300;
-  max-width: 90vw;
+  width: max-content; max-width: min(440px, 92vw);
+  pointer-events: none;
 }
-.run-banner::before {
-  content: ''; width: 8px; height: 8px; border-radius: 50%;
-  background: var(--emerald); flex: none;
+.toast {
+  pointer-events: auto;
+  display: grid; grid-template-columns: auto 1fr auto; align-items: start; gap: 11px;
+  width: 100%;
+  padding: 12px 13px 12px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-left: 3px solid var(--text-3, #8a93a3);
+  border-radius: 12px;
+  color: var(--text);
+  box-shadow: 0 10px 30px -12px rgba(0, 0, 0, 0.45), 0 2px 8px -4px rgba(0, 0, 0, 0.35);
+  opacity: 1; transform: translateY(0) scale(1);
+  transition: opacity 200ms var(--ease-out), transform 200ms var(--ease-out);
 }
-.run-banner.budget::before { background: var(--amber, #f0a020); }
-.run-banner.stopped::before { background: var(--text-3, #8a93a3); }
-@keyframes run-banner-in { from { opacity: 0; transform: translate(-50%, -10px); } to { opacity: 1; transform: translate(-50%, 0); } }
+/* Entrance: inserted with .is-enter, removed on the next frame so the card
+   transitions in. Exit adds .is-out. Using a transition (not a keyframe)
+   keeps the resting state visible even if the compositor is not animating. */
+.toast.is-enter { opacity: 0; transform: translateY(-10px) scale(0.98); }
+.toast.is-out { opacity: 0; transform: translateY(-8px) scale(0.98); }
+.toast-icon { display: flex; align-items: center; justify-content: center; width: 18px; height: 18px; margin-top: 1px; color: var(--text-3, #8a93a3); flex: none; }
+.toast-icon svg { width: 18px; height: 18px; }
+.toast-body { min-width: 0; }
+.toast-title { font-size: 12px; font-weight: 700; letter-spacing: 0.01em; margin-bottom: 2px; }
+.toast-msg { font-size: 13px; line-height: 1.45; color: var(--text); word-break: break-word; }
+.toast-title + .toast-msg { color: var(--text-2); }
+.toast-close {
+  display: flex; align-items: center; justify-content: center;
+  width: 20px; height: 20px; margin: -2px -2px 0 0;
+  border: none; background: transparent; color: var(--text-3, #8a93a3);
+  font-size: 17px; line-height: 1; border-radius: 6px; cursor: pointer; flex: none;
+  transition: background var(--motion-fast) var(--ease-out), color var(--motion-fast) var(--ease-out);
+}
+.toast-close:hover { background: rgba(255, 255, 255, 0.08); color: var(--text); }
+
+.toast.success { border-left-color: var(--emerald); }
+.toast.success .toast-icon { color: var(--emerald); }
+.toast.error { border-left-color: var(--rose); }
+.toast.error .toast-icon { color: var(--rose); }
+.toast.warn { border-left-color: var(--amber, #f0a020); }
+.toast.warn .toast-icon { color: var(--amber, #f0a020); }
+.toast.info { border-left-color: var(--accent); }
+.toast.info .toast-icon { color: var(--accent); }
+
+/* Prominent variant for significant events (autonomy run completion). */
+.toast.is-prominent {
+  padding: 14px 15px 14px 16px;
+  border-left-width: 4px;
+  box-shadow: 0 16px 40px -14px rgba(0, 0, 0, 0.55), 0 3px 10px -4px rgba(0, 0, 0, 0.4);
+}
+.toast.is-prominent .toast-icon, .toast.is-prominent .toast-icon svg { width: 22px; height: 22px; }
+.toast.is-prominent .toast-title { font-size: 13px; }
+.toast.is-prominent .toast-msg { font-size: 13.5px; }
 
 /* ─── Scrollbar ─────────────────────────────────────────────────────────── */
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1711,12 +1711,10 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   position: relative;
   border-radius: var(--radius-lg);
   border: 1px solid var(--line);
-  /* The chat surface hosts a terminal running a TUI agent, which emits
-     light-on-dark ANSI colors. The console therefore stays dark in BOTH
-     app themes (the welcome layer already uses this exact color) so the
-     agent's output is always readable. The xterm theme is fixed dark to
-     match (see themeForXterm). */
-  background: #0b0d12;
+  /* Theme-aware: light in light mode, dark in dark mode. The terminal
+     gets a matching light/dark ANSI palette (see themeForXterm) so its
+     output is readable on whichever background this is. */
+  background: var(--bg-1);
   overflow: hidden;
   box-shadow: none;
 }
@@ -1725,9 +1723,9 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 18px; padding: 40px;
   /* Opaque background prevents the under-layer from showing through
-     during the pre-fit flicker. Two-layer translucent stacking was
-     causing a half-tinted "rectangle" on refresh. */
-  background: #0b0d12;
+     during the pre-fit flicker. Uses --bg (the page color) because it is
+     opaque in both themes, where --bg-1 is translucent in dark mode. */
+  background: var(--bg);
   overflow-y: auto;
   pointer-events: none;
   opacity: 0; transition: opacity var(--motion-slow) var(--ease-out);

--- a/test/unit/autonomy-snapshot.test.js
+++ b/test/unit/autonomy-snapshot.test.js
@@ -461,3 +461,23 @@ test('captureSnapshotAsync aborts when workspace exceeds maxEntries', async () =
   assert.equal(res.ok, false);
   assert.match(res.error || '', /exceeds 5 files/);
 });
+
+// ─── restore safety: workspaceRoot must match the manifest ────────────────
+
+test('restore refuses when the target dir differs from the captured manifest root', () => {
+  writeFile('keep.txt', 'original');
+  const cap = captureSnapshot(work, store, SID);
+  assert.equal(cap.ok, true);
+  // A second, unrelated directory that happens to hold the user's files.
+  const other = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-snap-other-'));
+  try {
+    fs.writeFileSync(path.join(other, 'precious.txt'), 'do not delete me');
+    const res = restoreFromSnapshot(other, store, SID);
+    assert.equal(res.ok, false);
+    assert.match(res.error || '', /does not match the snapshot manifest/);
+    // The unrelated directory's file must be untouched.
+    assert.equal(fs.readFileSync(path.join(other, 'precious.txt'), 'utf8'), 'do not delete me');
+  } finally {
+    try { fs.rmSync(other, { recursive: true, force: true }); } catch (_) {}
+  }
+});

--- a/test/unit/mcp-common.test.js
+++ b/test/unit/mcp-common.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { readJsonFile, readJsonFileStrict, writeJsonFile } = require('../../src/lib/mcp/common');
+
+function tmpFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-mcp-common-'));
+  return path.join(dir, 'config.json');
+}
+
+// ─── readJsonFileStrict ────────────────────────────────────────────────────
+
+test('readJsonFileStrict: missing file is a clean empty config', () => {
+  const r = readJsonFileStrict(tmpFile());
+  assert.equal(r.ok, true);
+  assert.equal(r.missing, true);
+  assert.deepEqual(r.data, {});
+});
+
+test('readJsonFileStrict: valid file parses', () => {
+  const p = tmpFile();
+  fs.writeFileSync(p, JSON.stringify({ mcpServers: { a: { command: 'x' } } }));
+  const r = readJsonFileStrict(p);
+  assert.equal(r.ok, true);
+  assert.equal(r.data.mcpServers.a.command, 'x');
+});
+
+test('readJsonFileStrict: a corrupt existing file is an error, not empty', () => {
+  const p = tmpFile();
+  fs.writeFileSync(p, '{ this is not json');
+  const r = readJsonFileStrict(p);
+  assert.equal(r.ok, false);
+  // The lenient reader would silently return {} here, which is exactly
+  // the path that lets a mutating op overwrite a config it could not read.
+  assert.deepEqual(readJsonFile(p), {});
+});
+
+// ─── writeJsonFile (atomic) ──────────────────────────────────────────────────
+
+test('writeJsonFile: writes valid parseable JSON', () => {
+  const p = tmpFile();
+  assert.equal(writeJsonFile(p, { mcpServers: { a: 1 } }), true);
+  const back = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.deepEqual(back, { mcpServers: { a: 1 } });
+});
+
+test('writeJsonFile: leaves no temp file behind on success', () => {
+  const p = tmpFile();
+  writeJsonFile(p, { ok: true });
+  const leftovers = fs.readdirSync(path.dirname(p)).filter((f) => f.includes('.tmp'));
+  assert.deepEqual(leftovers, []);
+});
+
+test('writeJsonFile: preserves the original when the target dir is unwritable', () => {
+  const p = tmpFile();
+  fs.writeFileSync(p, JSON.stringify({ original: true }));
+  // Point at a path whose parent does not exist: the write must fail
+  // cleanly and never produce a half-written file.
+  const bad = path.join(p, 'nope', 'config.json');
+  assert.equal(writeJsonFile(bad, { changed: true }), false);
+  // Original untouched.
+  assert.deepEqual(JSON.parse(fs.readFileSync(p, 'utf8')), { original: true });
+});

--- a/test/unit/workflow-graph.test.js
+++ b/test/unit/workflow-graph.test.js
@@ -176,6 +176,32 @@ test('graphToOrderedSteps: empty graph returns []', () => {
   assert.deepEqual(wf.graphToOrderedSteps({ nodes: [], edges: [] }), []);
 });
 
+test('graphToOrderedSteps: a branching node keeps every branch', () => {
+  // a -> b, a -> c. The old single-edge walk dropped the second branch.
+  const g = {
+    nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+    edges: [
+      { from: 'a', to: 'b', condition: { type: 'always' } },
+      { from: 'a', to: 'c', condition: { type: 'always' } },
+    ],
+  };
+  const ids = wf.graphToOrderedSteps(g).map((n) => n.id);
+  assert.equal(ids.length, 3);
+  assert.ok(ids.includes('b') && ids.includes('c'));
+  assert.equal(ids[0], 'a');
+});
+
+test('graphToOrderedSteps: disconnected nodes are not dropped', () => {
+  // b is wired to a; c stands alone. Both must appear.
+  const g = {
+    nodes: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+    edges: [{ from: 'a', to: 'b', condition: { type: 'always' } }],
+  };
+  const ids = wf.graphToOrderedSteps(g).map((n) => n.id);
+  assert.equal(ids.length, 3);
+  assert.ok(ids.includes('c'));
+});
+
 // ─── wfEdgeMatches ───────────────────────────────────────────────────────────
 
 test('wfEdgeMatches: contains is case-insensitive', () => {


### PR DESCRIPTION
Fixes the validated issues from the autonomy audit plus two reported UX problems. Stacks on #53 (depends on its async finish/summary changes); review after #53 or merge #53 first.

## Reported UX issues
- The chat autonomy button stopped the run when clicked again. It now opens the run view while a run is active; stopping is the explicit Stop button, which now confirms.
- A finished agent (returned to its prompt, "what's next?") left the run counter ticking with nothing saying it ended. Completion is now detected from the agent's working indicator: the run ends shortly after the indicator disappears and the terminal is back at a prompt.

## Lifecycle and caps
- A reached cap no longer leaves the run stuck active injecting a SIGINT and re-firing a halt every second. The tick stops itself, interrupts the agent once, and finalizes the run.
- The idle auto-end no longer abandons a busy-but-quiet agent: while the working indicator is present the run is never auto-ended.

## Revert safety
- Revert refuses to restore into any directory other than the snapshot's recorded root, and the main process derives that root from the manifest instead of falling back to the terminal cwd or the home directory.
- A pre-run file that was momentarily unreadable at capture is no longer reported as agent-created and deleted on revert.
- Revert reports warnings instead of always claiming success, so a partial revert is visible.

## Presentation and accounting
- Halt toast reports the real cause instead of always "budget".
- Caps form: a typed zero means "no limit", invalid or negative values reset with feedback, and the rings no longer divide by a zero cap.
- The scraped token figure is marked approximate, and an "X/Y tokens" context indicator reads the used side.
- Vendor-billed agents are priced at zero so the dollar cap does not fire on a fabricated cost.
- Loading a past run from history uses the async diff and no longer freezes the UI; review/revert/rerun survive a renderer reload.

## Verification
- 349 unit tests pass (1 added for the revert-root safety check).
- Strict security lint clean.
- Electron e2e smoke boots clean with no console errors.