### PR TITLE
release: v2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "husk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "husk",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",

--- a/src/lib/autonomy/audit.js
+++ b/src/lib/autonomy/audit.js
@@ -63,16 +63,16 @@ function sha256Hex(data) {
 // filePath, or null if the file is empty or missing. Used to resume
 // the hash chain when re-opening an existing audit log.
 function readLastLineSync(filePath) {
-  let stat;
+  // Read directly in a single call rather than stat-then-read, so there is
+  // no check-then-use window. A missing or empty file yields null.
+  let buf;
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded under sessionDir
-    stat = fs.statSync(filePath);
+    buf = fs.readFileSync(filePath);
   } catch (_) {
     return null;
   }
-  if (!stat || !stat.size) return null;
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded under sessionDir
-  const buf = fs.readFileSync(filePath);
+  if (!buf || !buf.length) return null;
   let end = buf.length;
   // Strip any trailing newlines.
   while (end > 0 && (buf[end - 1] === 0x0a || buf[end - 1] === 0x0d)) end--;
@@ -91,7 +91,6 @@ function createAuditLog(storageRoot, sessionId, opts = {}) {
   if (typeof storageRoot !== 'string' || !path.isAbsolute(storageRoot)) {
     return { ok: false, error: 'storageRoot must be an absolute path' };
   }
-  const sdir = sessionDir(storageRoot, sessionId);
   const bdir = blobsDir(storageRoot, sessionId);
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded under storageRoot
@@ -133,10 +132,15 @@ function createAuditLog(storageRoot, sessionId, opts = {}) {
         const blobAbs = path.join(bdir, sha);
         try {
           // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded under bdir
-          if (!fs.existsSync(blobAbs)) {
-            const toWrite = encrypt ? encrypt(buf) : buf;
+          const toWrite = encrypt ? encrypt(buf) : buf;
+          try {
+            // wx (O_CREAT|O_EXCL) creates the blob only if absent in one
+            // syscall, so there is no check-then-write race. EEXIST means
+            // the identical content is already stored (keyed by its sha).
             // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded under bdir
-            fs.writeFileSync(blobAbs, toWrite);
+            fs.writeFileSync(blobAbs, toWrite, { flag: 'wx' });
+          } catch (e) {
+            if (e.code !== 'EEXIST') throw e;
           }
           blobRef = sha;
           payload = null;

--- a/src/lib/autonomy/snapshot.js
+++ b/src/lib/autonomy/snapshot.js
@@ -66,6 +66,30 @@ function sha256OfBuffer(buf) {
   return crypto.createHash('sha256').update(buf).digest('hex');
 }
 
+// Write a content-addressed blob atomically. The `wx` flag is
+// O_CREAT|O_EXCL: it creates the file only if it does not already exist,
+// in a single syscall, so there is no check-then-write race. An EEXIST
+// just means the identical content is already stored (blobs are keyed by
+// their own sha256), so it is ignored.
+//
+// `seen` is an in-memory Set of shas already handled this run. It dedupes
+// the (potentially expensive) encrypt + write so identical content is
+// encrypted once per run, without an fs existence check.
+function writeBlobAtomic(bdir, sha, content, encrypt, seen) {
+  if (seen) {
+    if (seen.has(sha)) return;
+    seen.add(sha);
+  }
+  const blobAbs = path.join(bdir, sha);
+  const toWrite = typeof encrypt === 'function' ? encrypt(content) : content;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- blobAbs is path.join(bdir, sha) bounded to bdir
+    fs.writeFileSync(blobAbs, toWrite, { flag: 'wx' });
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+}
+
 // shouldIgnore returns true when the relative path (as walked) starts
 // with any of the ignore entries. Match is "starts with the entry as
 // a full path segment", so an ignore entry of 'dist' matches 'dist'
@@ -102,7 +126,6 @@ function captureSnapshot(workspaceRoot, storageRoot, sessionId, opts = {}) {
   const ignores = DEFAULT_IGNORE.slice();
   if (Array.isArray(opts.ignore)) for (const p of opts.ignore) if (typeof p === 'string' && p) ignores.push(p);
 
-  const sdir = sessionDir(storageRoot, sessionId);
   const bdir = blobsDir(storageRoot, sessionId);
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded to storageRoot subdirs
@@ -113,7 +136,8 @@ function captureSnapshot(workspaceRoot, storageRoot, sessionId, opts = {}) {
 
   const entries = {};
   const warnings = [];
-  walk(workspaceRoot, '', ignores, entries, warnings, opts, bdir);
+  const seen = new Set();
+  walk(workspaceRoot, '', ignores, entries, warnings, opts, bdir, seen);
 
   const manifest = {
     v: 1,
@@ -131,7 +155,7 @@ function captureSnapshot(workspaceRoot, storageRoot, sessionId, opts = {}) {
   return { ok: true, manifest, warnings };
 }
 
-function walk(absRoot, rel, ignores, entries, warnings, opts, bdir) {
+function walk(absRoot, rel, ignores, entries, warnings, opts, bdir, seen) {
   const here = rel ? path.join(absRoot, rel) : absRoot;
   let dirents;
   try {
@@ -153,18 +177,12 @@ function walk(absRoot, rel, ignores, entries, warnings, opts, bdir) {
         const target = fs.readlinkSync(abs);
         entries[relChild] = { type: 'symlink', target };
       } else if (ent.isDirectory()) {
-        walk(absRoot, relChild, ignores, entries, warnings, opts, bdir);
+        walk(absRoot, relChild, ignores, entries, warnings, opts, bdir, seen);
       } else if (ent.isFile()) {
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- abs is bounded to absRoot
         const content = fs.readFileSync(abs);
         const sha = sha256OfBuffer(content);
-        const blobAbs = path.join(bdir, sha);
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- blobAbs is bounded to bdir
-        if (!fs.existsSync(blobAbs)) {
-          const toWrite = typeof opts.encrypt === 'function' ? opts.encrypt(content) : content;
-          // eslint-disable-next-line security/detect-non-literal-fs-filename -- bdir is bounded
-          fs.writeFileSync(blobAbs, toWrite);
-        }
+        writeBlobAtomic(bdir, sha, content, opts.encrypt, seen);
         entries[relChild] = { type: 'file', sha };
       } else {
         // Sockets, devices, fifos. Ignore: not meaningful for the
@@ -492,7 +510,6 @@ async function captureSnapshotAsync(workspaceRoot, storageRoot, sessionId, opts 
   const ignores = DEFAULT_IGNORE.slice();
   if (Array.isArray(opts.ignore)) for (const p of opts.ignore) if (typeof p === 'string' && p) ignores.push(p);
 
-  const sdir = sessionDir(storageRoot, sessionId);
   const bdir = blobsDir(storageRoot, sessionId);
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- bounded to storageRoot subdirs
@@ -504,7 +521,7 @@ async function captureSnapshotAsync(workspaceRoot, storageRoot, sessionId, opts 
   const entries = {};
   const warnings = [];
   const maxEntries = Number.isFinite(opts.maxEntries) && opts.maxEntries > 0 ? opts.maxEntries : DEFAULT_MAX_ENTRIES;
-  const state = { count: 0, aborted: false, maxEntries, onProgress: typeof opts.onProgress === 'function' ? opts.onProgress : null };
+  const state = { count: 0, aborted: false, maxEntries, seen: new Set(), onProgress: typeof opts.onProgress === 'function' ? opts.onProgress : null };
   await walkAsync(workspaceRoot, '', ignores, entries, warnings, opts, bdir, state);
   if (state.aborted) {
     return { ok: false, error: `workspace exceeds ${maxEntries} files; pick a narrower scope` };
@@ -547,13 +564,7 @@ async function walkAsync(absRoot, rel, ignores, entries, warnings, opts, bdir, s
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- abs is bounded
         const content = fs.readFileSync(abs);
         const sha = sha256OfBuffer(content);
-        const blobAbs = path.join(bdir, sha);
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- blobAbs bounded to bdir
-        if (!fs.existsSync(blobAbs)) {
-          const toWrite = typeof opts.encrypt === 'function' ? opts.encrypt(content) : content;
-          // eslint-disable-next-line security/detect-non-literal-fs-filename -- bdir is bounded
-          fs.writeFileSync(blobAbs, toWrite);
-        }
+        writeBlobAtomic(bdir, sha, content, opts.encrypt, state.seen);
         entries[relChild] = { type: 'file', sha };
         state.count++;
         if (state.count >= state.maxEntries) { state.aborted = true; return; }

--- a/src/lib/autonomy/supervisor.js
+++ b/src/lib/autonomy/supervisor.js
@@ -36,7 +36,6 @@ function startRun(opts = {}) {
   if (!path.isAbsolute(storageRoot)) return { ok: false, error: 'storageRoot must be absolute' };
 
   const encrypt = typeof opts.encrypt === 'function' ? opts.encrypt : null;
-  const decrypt = typeof opts.decrypt === 'function' ? opts.decrypt : null;
   const now = typeof opts.now === 'function' ? opts.now : () => Date.now();
 
   // 1. capture pre-run snapshot. Caller may set opts.skipSnapshot when
@@ -199,7 +198,7 @@ function startRun(opts = {}) {
       state.endedAt = now();
       auditWriter.append({ kind: 'end_run', payload: detail || null });
     }
-    let diff = { ok: false, changes: [] };
+    let diff;
     try {
       diff = await Snapshot.diffWorkspaceAsync(workspaceRoot, storageRoot, sessionId, { ignore: opts.ignore });
     } catch (_) { diff = { ok: false, changes: [] }; }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const http = require('http');
+const crypto = require('crypto');
 const { spawn } = require('child_process');
 const pty = require('node-pty');
 
@@ -837,19 +838,6 @@ function autonomyCrypto() {
   return { encrypt: null, decrypt: null };
 }
 
-// ANSI escape stripper for the autonomy activity feed. Terminal
-// emulators interpret the CSI / OSC sequences; the activity panel
-// wants the plain text underneath. Tight ranges, no greedy regex.
-function stripAnsi(s) {
-  return String(s)
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
-    // eslint-disable-next-line no-control-regex
-    .replace(/\x1b\][^\x07]*\x07/g, '')
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, '');
-}
-
 // Autonomy PTY tap: while a run is active, every chunk of agent
 // output is buffered and flushed once per quarter-second. The
 // flush appends an `agent_output` event to the hash-chained audit
@@ -876,30 +864,6 @@ function autonomyTap(data) {
 let autonomyLineTail = '';
 let autonomyLastTailEmit = '';
 let autonomyLastTailEmitAt = 0;
-
-// Permissive activity-line filter. The previous strict filter
-// (require 2 word-tokens + 8 alnum) dropped real claude output that
-// did not match the expected shape, leaving the feed empty even
-// while the agent was clearly working. Now: only obvious garbage
-// gets dropped, the rest is shown.
-function isLowSignalLine(s) {
-  if (!s) return true;
-  const trimmed = s.trim();
-  if (trimmed.length < 3) return true;
-  const alnum = trimmed.replace(/[^A-Za-z0-9]/g, '').length;
-  if (alnum < 2) return true;
-  // 80%+ of one non-alpha char = separator run (___, ===, ---, ...).
-  const first = trimmed[0];
-  if (!/[A-Za-z0-9]/.test(first)) {
-    let same = 0;
-    for (const ch of trimmed) if (ch === first) same++;
-    if (same / trimmed.length > 0.8) return true;
-  }
-  // Looks like a UI-only fragment: short AND only 1 token AND no
-  // letters at all (e.g. "+12", "-5"). Real status lines have words.
-  if (trimmed.length < 6 && !/[A-Za-z]/.test(trimmed)) return true;
-  return false;
-}
 
 function flushAutonomyOutput() {
   autonomyOutputFlushTimer = null;
@@ -1014,7 +978,7 @@ ipcMain.handle('autonomy:start', async (_e, payload = {}) => {
   if (path.resolve(workspaceRoot) === path.resolve(HOME)) {
     return { ok: false, error: 'autonomy refuses to snapshot the entire home folder' };
   }
-  const sessionId = 'auto-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 7);
+  const sessionId = 'auto-' + Date.now().toString(36) + '-' + crypto.randomBytes(4).toString('hex');
   const { encrypt, decrypt } = autonomyCrypto();
 
   // Snapshot off-cycle via the async path so the main process keeps
@@ -2453,8 +2417,6 @@ ipcMain.handle('repoAgents:scan', (_e, payload = {}) => {
     };
   } catch (err) { return { ok: false, error: err.message }; }
 });
-
-const renderHuskAgentsBlock = PaiState.renderHuskAgentsBlock;
 
 ipcMain.handle('repoAgents:install', (_e, payload = {}) => {
   const root = String((payload && payload.root) || '').trim();


### PR DESCRIPTION
Maintenance release. Internal hardening (CSPRNG session id, atomic content-addressed blob writes, stat-free audit tail read) and dead-code cleanup. No user-facing changes. Version bumped to 2.2.1; tag follows on the merged commit.