### PR TITLE
feat: session management (parallel chat tabs, agent-aware sessions)

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -777,7 +777,7 @@ function setPage(name) {
   document.body.dataset.page = name;
   $$('.page').forEach((p) => { p.hidden = p.dataset.page !== name; });
   $$('.rail-item').forEach((it) => it.classList.toggle('active', it.dataset.page === name));
-  if (name === 'chat') { setTimeout(fitNow, 30); term.focus(); }
+  if (name === 'chat') { setTimeout(fitNow, 30); if (term) term.focus(); }
   if (name === 'agents') renderAgents();
   if (name === 'workflows') renderWorkflows();
   if (name === 'autonomy') renderAutonomyPage();
@@ -4527,7 +4527,7 @@ function openPalette() {
   renderPalette('');
   $('#palette-input').focus();
 }
-function closePalette() { $('#palette').hidden = true; term.focus(); }
+function closePalette() { $('#palette').hidden = true; if (term) term.focus(); }
 function renderPalette(query) {
   const q = query.toLowerCase().trim();
   const matches = PALETTE_ACTIONS.filter((a) => !q || a.label.toLowerCase().includes(q));
@@ -4858,7 +4858,7 @@ async function launchAgent({ initialPrompt = null } = {}) {
     setTimeout(() => {
       armRecap();
       window.husk.pty.write(initialPrompt);
-      term.focus();
+      if (term) term.focus();
     }, 250);
   }
 }

--- a/test/e2e/ux-fixes.spec.js
+++ b/test/e2e/ux-fixes.spec.js
@@ -105,6 +105,10 @@ test('copy from the terminal context menu keeps focus in the terminal (issue 5)'
   const win = await ready(app);
   const focused = await win.evaluate(async () => {
     setPage('chat');
+    // Cold boot shows the welcome screen with no terminal yet; start the agent
+    // so a tab (and its terminal) exists before exercising copy.
+    try { await startPty(); } catch (_) {}
+    for (let i = 0; i < 100 && !term; i++) await new Promise((r) => setTimeout(r, 20));
     try { term.write('hello selection'); } catch (_) {}
     await new Promise((r) => setTimeout(r, 50));
     try { term.selectAll(); } catch (_) {}


### PR DESCRIPTION
Session management for v2.6.0.

- Parallel chat tabs: each chat runs its own agent in its own tab. Click a tab to switch focus, rename it via the hover control, close it with a confirmation.
- Sessions page follows the active agent (claude and copilot), with a graceful empty state for agents Husk does not read yet and for a missing session directory.
- Hardened agent-file writes and removed an unused argument.

Releases as v2.6.0 (no version bump).