### PR TITLE
fix(ui): bulk-select agents and dialog polish

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -751,27 +751,12 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
       } catch (_) {}
     }
   }
-  // Active-profile repoRoot wins over agentCwd / activeProject, but loses to
-  // an explicit overrideCwd (e.g. Resume re-entering a session). This is what
-  // makes agents installed from a repo land in the right working directory:
-  // relative paths inside the agent's prompt (e.g. `skills/<test_id>.md`)
-  // resolve against the cloned repo, regardless of which CLI is active.
-  try {
-    const activeIds = Array.isArray(config.activeProfileIds)
-      ? config.activeProfileIds
-      : (config.activeProfileId ? [config.activeProfileId] : []);
-    if (activeIds.length && Array.isArray(config.profiles)) {
-      for (const id of activeIds) {
-        const prof = config.profiles.find((p) => p && p.id === id);
-        if (prof && prof.repoRoot && typeof prof.repoRoot === 'string') {
-          if (fs.existsSync(prof.repoRoot) && fs.statSync(prof.repoRoot).isDirectory()) {
-            cwd = prof.repoRoot;
-            break;
-          }
-        }
-      }
-    }
-  } catch (_) {}
+  // Note: selecting a repo-installed agent does NOT change the working
+  // directory. The agent is loaded by its CLI natively (Husk mirrors it into
+  // each CLI's agents dir), and the cwd stays whatever the user configured
+  // (agentCwd / active project / home). If a user wants the agent's relative
+  // `skills/<id>/SKILL.md` reads to resolve, they point Working directory at
+  // that repo themselves in Preferences.
   if (overrideCwd) {
     try {
       if (fs.existsSync(overrideCwd) && fs.statSync(overrideCwd).isDirectory()) {
@@ -2499,6 +2484,10 @@ ipcMain.handle('profiles:listImportableAgents', () => {
   try {
     const existing = new Set(getProfiles().map((p) => String(p.name || '').toLowerCase()));
     const out = [];
+    // Dedupe by agent name (case-insensitive). The same agent can appear as
+    // more than one file in a dir (e.g. an original `Algorithm.md` plus a
+    // slug-mirrored `algorithm.md`); list it once.
+    const seen = new Set();
     for (const src of AGENT_SOURCES) {
       if (!fs.existsSync(src.dir)) continue;
       for (const entry of fs.readdirSync(src.dir, { withFileTypes: true })) {
@@ -2507,13 +2496,16 @@ ipcMain.handle('profiles:listImportableAgents', () => {
           const text = fs.readFileSync(path.join(src.dir, entry.name), 'utf8');
           const parsed = parseAgentMd(text);
           const name = (parsed.name || entry.name.replace(/\.md$/, '')).slice(0, 64);
+          const key = name.toLowerCase();
+          if (seen.has(key)) continue;
+          seen.add(key);
           out.push({
             source: src.label,
             filename: entry.name,
             name,
             description: (parsed.description || '').slice(0, 256),
             systemPrompt: (parsed.body || '').slice(0, 4096),
-            alreadyImported: existing.has(name.toLowerCase()),
+            alreadyImported: existing.has(key),
           });
         } catch (_) {}
       }
@@ -2988,6 +2980,13 @@ ipcMain.handle('profiles:deactivate', (_e, id) => {
 ipcMain.handle('profiles:deactivateAll', () => {
   writeActiveIds([]);
   return { ok: true, activeIds: [] };
+});
+
+// Select every profile (bulk).
+ipcMain.handle('profiles:activateAll', () => {
+  const ids = getProfiles().map((p) => p.id).filter(Boolean);
+  writeActiveIds(ids);
+  return { ok: true, activeIds: ids };
 });
 
 // Returns just the curated Husk prompts (the markdown files seeded from

--- a/src/preload.js
+++ b/src/preload.js
@@ -94,6 +94,7 @@ contextBridge.exposeInMainWorld('husk', {
     update: (payload) => ipcRenderer.invoke('profiles:update', payload),
     delete: (id) => ipcRenderer.invoke('profiles:delete', id),
     activate: (id) => ipcRenderer.invoke('profiles:activate', id),
+    activateAll: () => ipcRenderer.invoke('profiles:activateAll'),
     deactivate: (id) => ipcRenderer.invoke('profiles:deactivate', id),
     deactivateAll: () => ipcRenderer.invoke('profiles:deactivateAll'),
     generate: (description) => ipcRenderer.invoke('profiles:generate', description),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1836,7 +1836,7 @@ function paintAgents() {
   const cards = sorted.map((p) => {
     const isActive = activeIds.has(p.id);
     return `
-    <div class="agent-card${isActive ? ' is-active' : ''}" data-id="${escapeHtml(p.id)}" role="button" aria-pressed="${isActive}" tabindex="0" title="${isActive ? 'Click to deactivate' : 'Click to activate'}">
+    <div class="agent-card${isActive ? ' is-active' : ''}" data-id="${escapeHtml(p.id)}" role="button" aria-pressed="${isActive}" tabindex="0" title="${isActive ? 'Selected. Click to deselect.' : 'Click to select.'}">
       ${!p.builtin ? `
         <div class="agent-card-corner">
           <button class="agent-card-icon agent-edit" data-id="${escapeHtml(p.id)}" title="Edit agent" aria-label="Edit agent">${editIcon}</button>
@@ -1844,11 +1844,11 @@ function paintAgents() {
         </div>` : ''}
       <div class="agent-card-head">
         <div class="agent-card-title">${escapeHtml(p.name)}</div>
-        ${isActive ? '<span class="agent-card-pill">Active</span>' : ''}
+        ${isActive ? '<span class="agent-card-pill">Selected</span>' : ''}
         ${p.builtin ? '<span class="agent-card-builtin">Built-in</span>' : ''}
       </div>
       ${p.description ? `<div class="agent-card-desc">${escapeHtml(p.description)}</div>` : ''}
-      ${p.repoRoot ? `<div class="agent-card-repo" title="${escapeAttr(p.repoRoot)}">cwd: ${escapeHtml(p.repoRoot.replace(/^\/home\/[^/]+/, '~'))}</div>` : ''}
+      ${p.repoRoot ? `<div class="agent-card-repo" title="Installed from ${escapeAttr(p.repoRoot)}">repo: ${escapeHtml(p.repoRoot.replace(/^\/home\/[^/]+/, '~'))}</div>` : ''}
       ${p.systemPrompt ? `<div class="agent-card-prompt">${escapeHtml(p.systemPrompt)}</div>` : ''}
     </div>
   `;
@@ -1856,7 +1856,7 @@ function paintAgents() {
   // eslint-disable-next-line no-unsanitized/property
   grid.innerHTML = cards;
 
-  // Whole-card click toggles activation; clicks on inner buttons fall through.
+  // Whole-card click toggles selection; clicks on inner buttons fall through.
   grid.querySelectorAll('.agent-card').forEach((card) => {
     const id = card.dataset.id;
     const toggle = () => {
@@ -1865,7 +1865,6 @@ function paintAgents() {
     };
     card.addEventListener('click', (e) => {
       if (e.target.closest('button')) return;
-      // Skip toggle when the user just selected text inside the card.
       if (window.getSelection && window.getSelection().toString().length > 0) return;
       toggle();
     });
@@ -1897,6 +1896,15 @@ async function deactivateProfile(id) {
 
 async function deactivateAllProfiles() {
   const res = await window.husk.profiles.deactivateAll();
+  if (!res || !res.ok) return;
+  cfg = await window.husk.config.get();
+  paintAgents();
+  updateAgentBanner();
+  updateActiveChatProfile();
+}
+
+async function activateAllProfiles() {
+  const res = await window.husk.profiles.activateAll();
   if (!res || !res.ok) return;
   cfg = await window.husk.config.get();
   paintAgents();
@@ -2104,6 +2112,14 @@ async function openAgentsImportModal() {
     if (confirmBtn) { confirmBtn.disabled = n === 0; confirmBtn.textContent = `Import ${n} agent${n !== 1 ? 's' : ''}`; }
   };
   listEl.querySelectorAll('.ai-check').forEach((el) => el.addEventListener('change', updateCount));
+  const setAll = (checked) => {
+    listEl.querySelectorAll('.ai-check').forEach((el) => { el.checked = checked; });
+    updateCount();
+  };
+  const selAll = $('#ai-select-all');
+  const deselAll = $('#ai-deselect-all');
+  if (selAll) selAll.onclick = () => setAll(true);
+  if (deselAll) deselAll.onclick = () => setAll(false);
   updateCount();
 }
 
@@ -2252,6 +2268,14 @@ async function scanRepoRoot(root) {
     confirmBtn.textContent = `Install ${n} agent${n !== 1 ? 's' : ''}`;
   };
   listEl.querySelectorAll('.ra-pick').forEach((el) => el.addEventListener('change', updateCount));
+  const tools = $('#ra-list-tools');
+  if (tools) tools.hidden = !listEl.querySelector('.ra-pick');
+  const setAll = (checked) => {
+    listEl.querySelectorAll('.ra-pick').forEach((el) => { el.checked = checked; });
+    updateCount();
+  };
+  if ($('#ra-select-all')) $('#ra-select-all').onclick = () => setAll(true);
+  if ($('#ra-deselect-all')) $('#ra-deselect-all').onclick = () => setAll(false);
   updateCount();
 }
 async function confirmRepoAgentsInstall() {
@@ -2526,6 +2550,8 @@ $('#agent-modal-close') && $('#agent-modal-close').addEventListener('click', clo
 $('#agent-modal-cancel') && $('#agent-modal-cancel').addEventListener('click', closeAgentModal);
 $('#agent-modal-save') && $('#agent-modal-save').addEventListener('click', saveAgentModal);
 $('#btn-deactivate-all') && $('#btn-deactivate-all').addEventListener('click', () => deactivateAllProfiles());
+$('#btn-select-all-agents') && $('#btn-select-all-agents').addEventListener('click', () => activateAllProfiles());
+$('#btn-deselect-all-agents') && $('#btn-deselect-all-agents').addEventListener('click', () => deactivateAllProfiles());
 $('#agent-modal') && $('#agent-modal').addEventListener('click', (e) => { if (e.target === $('#agent-modal')) closeAgentModal(); });
 $('#btn-generate-agent') && $('#btn-generate-agent').addEventListener('click', generateAgentWithAI);
 $('#btn-manual-agent') && $('#btn-manual-agent').addEventListener('click', () => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -516,7 +516,7 @@
           <div class="page-head">
             <div class="page-head-left">
               <h1 class="page-title">Agents</h1>
-              <span class="page-sub">saved configurations that shape how the AI works for a task</span>
+              <span class="page-sub">all agents here are available to whichever AI you run · select agents to feature them in your chat header</span>
             </div>
             <div class="page-head-right">
               <button class="ghost-btn" id="btn-install-from-repo" title="Install an agent pack from a cloned repo">
@@ -531,10 +531,17 @@
             </div>
           </div>
           <div class="page-body">
+            <div class="agents-bulk">
+              <span class="agents-bulk-label">Selected agents are shown in your chat header. All agents are available to the AI regardless.</span>
+              <span class="agents-bulk-actions">
+                <button class="ghost-link" id="btn-select-all-agents">Select all</button>
+                <button class="ghost-link" id="btn-deselect-all-agents">Deselect all</button>
+              </span>
+            </div>
             <div id="agents-active-banner" class="agents-active-banner" hidden>
               <div class="aab-meta">
                 <span class="aab-dot"></span>
-                <span class="aab-meta-text">Active for next session</span>
+                <span class="aab-meta-text">Selected</span>
               </div>
               <div class="aab-chips" id="aab-chips"></div>
               <button class="ghost-link aab-clear" id="btn-deactivate-all">Clear all</button>
@@ -552,6 +559,10 @@
             </div>
             <div class="modal-body">
               <p class="ai-hint" id="ai-hint">Husk found these agents on your machine. Pick the ones to bring in as Husk profiles.</p>
+              <div class="ai-list-tools">
+                <button class="ghost-link" id="ai-select-all" type="button">Select all</button>
+                <button class="ghost-link" id="ai-deselect-all" type="button">Deselect all</button>
+              </div>
               <div id="ai-list" class="ai-list"></div>
             </div>
             <div class="modal-foot">
@@ -599,27 +610,35 @@
               <button class="modal-close" id="ra-close" aria-label="Close">&times;</button>
             </div>
             <div class="modal-body">
-              <p class="ra-hint">Point Husk at a cloned repo that ships an agents directory (<code>.github/agents/</code> or <code>agents/</code>). Picked agents are installed into every AI tool you have (Claude, Copilot, ...) using each tool's native agents folder. Each Husk profile is stamped with the repo path so the active CLI launches there, which is what makes the agent's relative <code>skills/&lt;id&gt;/SKILL.md</code> reads resolve.</p>
+              <p class="ra-hint">Point Husk at a cloned repo that ships an agents directory (<code>.github/agents/</code> or <code>agents/</code>). Picked agents are installed into every AI tool you have (Claude, Copilot, ...) using each tool's native agents folder. Your working directory is unchanged; if an agent reads a relative <code>skills/&lt;id&gt;/SKILL.md</code>, point Preferences &rsaquo; Working directory at that repo.</p>
               <div class="ra-pathrow">
                 <input type="text" id="ra-root" class="ra-root" placeholder="/path/to/agent-pack-repo" autocomplete="off" spellcheck="false" />
                 <button class="ghost-btn" id="ra-browse">Browse…</button>
               </div>
               <div id="ra-status" class="ra-status" hidden></div>
+              <div class="ai-list-tools" id="ra-list-tools" hidden>
+                <button class="ghost-link" id="ra-select-all" type="button">Select all</button>
+                <button class="ghost-link" id="ra-deselect-all" type="button">Deselect all</button>
+              </div>
               <div id="ra-list" class="ai-list"></div>
             </div>
             <div class="modal-foot ra-foot">
-              <label class="ai-foot-toggle" title="Install each picked agent into every detected AI tool's native agents folder (Claude, Copilot, ...)">
-                <input type="checkbox" id="ra-claude" class="ai-check" checked />
-                <span class="ai-check-box" aria-hidden="true"></span>
-                Install into all AI tools
-              </label>
-              <label class="ai-foot-toggle" title="Activate imported agents for the next chat session">
-                <input type="checkbox" id="ra-activate" class="ai-check" checked />
-                <span class="ai-check-box" aria-hidden="true"></span>
-                Activate after install
-              </label>
-              <button class="ghost-btn" id="ra-cancel">Cancel</button>
-              <button class="btn-primary" id="ra-confirm" disabled>Install 0 agents</button>
+              <div class="ra-foot-toggles">
+                <label class="ai-foot-toggle" title="Install each picked agent into every detected AI tool's native agents folder (Claude, Copilot, ...)">
+                  <input type="checkbox" id="ra-claude" class="ai-check" checked />
+                  <span class="ai-check-box" aria-hidden="true"></span>
+                  Install into all AI tools
+                </label>
+                <label class="ai-foot-toggle" title="Activate imported agents for the next chat session">
+                  <input type="checkbox" id="ra-activate" class="ai-check" checked />
+                  <span class="ai-check-box" aria-hidden="true"></span>
+                  Activate after install
+                </label>
+              </div>
+              <div class="ra-foot-actions">
+                <button class="ghost-btn" id="ra-cancel">Cancel</button>
+                <button class="btn-primary" id="ra-confirm" disabled>Install 0 agents</button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2614,7 +2614,17 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
 .ra-status.ra-status-error { border-color: rgba(255, 92, 122, 0.35); color: var(--text); }
 /* The footer of the repo-install modal has three toggles + two buttons;
    let it wrap on narrow window widths rather than stretching off-screen. */
-.modal-foot.ra-foot { flex-wrap: wrap; gap: 10px; }
+.modal-foot.ra-foot { flex-direction: column; align-items: stretch; gap: 12px; }
+.ra-foot-toggles { display: flex; flex-wrap: wrap; align-items: center; gap: 16px; }
+.ra-foot-actions { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+
+/* Bulk select/deselect toolbar above the agent grid. */
+.agents-bulk {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  margin-bottom: 12px;
+}
+.agents-bulk-label { font-size: 12px; color: var(--text-3); }
+.agents-bulk-actions { display: inline-flex; gap: 14px; flex: 0 0 auto; }
 
 /* Active-for-next-session banner with one chip per active agent. */
 .agents-active-banner {
@@ -3339,7 +3349,7 @@ input[type="checkbox"]:disabled {
   flex: 1; background: transparent; color: var(--text);
   border: 0; outline: 0;
   font-family: 'JetBrains Mono', monospace; font-size: 13px;
-  text-align: right; min-width: 0;
+  text-align: left; min-width: 0;
 }
 .pref-row select { font-family: inherit; }
 .pref-row select option { color: #111; background: #ffffff; }


### PR DESCRIPTION
Part of v2.6.0.

- Select all / Deselect all in the Agents page and both agent pickers (Import, Install-from-repo).
- Dedupe the Import list.
- Left-align Preferences inputs.
- Install-from-repo dialog: Cancel bottom-left, Install bottom-right.
- Selecting an agent no longer changes the working directory.