### PR TITLE
release: v2.7.0

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -568,6 +568,18 @@ function createWindow() {
     }
     return { action: 'deny' };
   });
+  // A bare Alt press moves focus to the application menu bar, which
+  // silently swallows every keystroke after it until the user hits
+  // Escape; in a terminal-first app that reads as "typing broke".
+  // Swallow bare Alt before the menu sees it. Alt+key combos still
+  // arrive as their own events (input.key is the combo key), so
+  // terminal Alt-sequences keep working.
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.key === 'Alt' && !input.control && !input.shift && !input.meta) {
+      event.preventDefault();
+    }
+  });
+
   // Belt-and-suspenders: also catch top-level navigation attempts so
   // the main window cannot be hijacked away from its loaded index.html.
   mainWindow.webContents.on('will-navigate', (event, url) => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -4640,7 +4640,13 @@ async function savePluginFile() {
   toast(`${peCurrent.relPath} saved · restart agent to apply`, 'success');
 }
 
-function closePluginEditor() {
+async function closePluginEditor() {
+  if (peCurrent.dirty && !(await openConfirmDialog({
+    title: 'Discard unsaved changes?',
+    bodyHtml: 'The current file has edits that are not saved.',
+    confirmLabel: 'Discard',
+    cancelLabel: 'Stay',
+  }))) return;
   $('#plugin-editor').hidden = true;
   peCurrent = { id: null, relPath: null, dirty: false };
 }
@@ -4653,6 +4659,7 @@ $('#pe-content').addEventListener('input', () => {
 });
 $('#pe-save').addEventListener('click', savePluginFile);
 $('#pe-close').addEventListener('click', closePluginEditor);
+$('#pe-close-x').addEventListener('click', closePluginEditor);
 $('#pe-open-folder').addEventListener('click', () => { if (peCurrent.id) window.husk.plugins.openFolder(peCurrent.id); });
 $('#plugin-editor').addEventListener('click', (e) => { if (e.target.id === 'plugin-editor') closePluginEditor(); });
 $('#plugins-search').addEventListener('input', debounce((e) => paintPlugins(e.target.value), 120));

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -889,7 +889,10 @@
         <!-- Plugin editor modal -->
         <div id="plugin-editor" class="modal" hidden>
           <div class="modal-card plugin-editor-card">
-            <div class="modal-title" id="pe-title">Edit plugin</div>
+            <div class="modal-head">
+              <div class="modal-title" id="pe-title">Edit plugin</div>
+              <button class="modal-close" id="pe-close-x" aria-label="Close">&times;</button>
+            </div>
             <div class="modal-sub" id="pe-sub">edits live in the plugin cache and may be overwritten when the plugin updates</div>
             <div class="pe-layout">
               <div class="pe-files" id="pe-files"></div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1760,14 +1760,30 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 18px; padding: 40px;
   /* Opaque background prevents the under-layer from showing through
-     during the pre-fit flicker. Matches the status panel's background
-     (var(--bg)), which is opaque in both themes. */
+     during the pre-fit flicker. Matches the status panel: flat var(--bg)
+     in light mode; the dark glass variant is below. */
   background: var(--bg);
   overflow-y: auto;
   pointer-events: none;
   opacity: 0; transition: opacity var(--motion-slow) var(--ease-out);
 }
 .chat-empty.show { opacity: 1; pointer-events: auto; }
+/* Dark mode: the status panel is glass (a 2.5% white tint over the body's
+   radial-gradient backdrop, blurred and saturated 140%). The welcome overlay
+   must stay opaque (it hides the terminal beneath), so instead of real
+   translucency a ::before layer repaints the same stack: body gradient,
+   fixed-attached so the color blobs land where the backdrop's would, under
+   the same tint, with the same saturation boost. */
+[data-theme="dark"] .chat-empty::before {
+  content: '';
+  position: absolute; inset: 0; z-index: -1;
+  background-color: var(--bg);
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0.025)),
+    var(--bg-radial);
+  background-attachment: fixed;
+  filter: saturate(140%);
+}
 .ce-logo-img {
   width: 64px; height: 64px;
   display: block;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1760,10 +1760,9 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 18px; padding: 40px;
   /* Opaque background prevents the under-layer from showing through
-     during the pre-fit flicker. Layering --bg-1 over --bg composites the
-     same color as the stage card in both themes while staying opaque
-     (--bg-1 alone is translucent in dark mode). */
-  background: linear-gradient(var(--bg-1), var(--bg-1)), var(--bg);
+     during the pre-fit flicker. Matches the status panel's background
+     (var(--bg)), which is opaque in both themes. */
+  background: var(--bg);
   overflow-y: auto;
   pointer-events: none;
   opacity: 0; transition: opacity var(--motion-slow) var(--ease-out);
@@ -3546,6 +3545,10 @@ input[type="checkbox"]:disabled {
 /* Footer buttons stay natural width; the base modal rule stretches
    .btn-primary to 100% which is wrong next to Open folder / Close. */
 .modal-card.plugin-editor-card .btn-primary { width: auto; padding: 0 18px; }
+.modal-card.plugin-editor-card .modal-head { margin-bottom: 4px; }
+/* The base .modal-card textarea rule re-enables the vertical resize grip
+   and a 160px floor; the editor pane scrolls instead. */
+.modal-card.plugin-editor-card .pe-content { resize: none; min-height: 0; }
 .pe-layout {
   display: flex; gap: 12px; margin-top: 12px;
   height: clamp(420px, 72vh, 820px);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1760,15 +1760,15 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 18px; padding: 40px;
   /* Opaque background prevents the under-layer from showing through
-     during the pre-fit flicker. Uses --bg (the page color) because it is
-     opaque in both themes, where --bg-1 is translucent in dark mode. */
-  background: var(--bg);
+     during the pre-fit flicker. Layering --bg-1 over --bg composites the
+     same color as the stage card in both themes while staying opaque
+     (--bg-1 alone is translucent in dark mode). */
+  background: linear-gradient(var(--bg-1), var(--bg-1)), var(--bg);
   overflow-y: auto;
   pointer-events: none;
   opacity: 0; transition: opacity var(--motion-slow) var(--ease-out);
 }
 .chat-empty.show { opacity: 1; pointer-events: auto; }
-[data-theme="dark"] .chat-empty { background: #1C1A1A; }
 .ce-logo-img {
   width: 64px; height: 64px;
   display: block;
@@ -3539,8 +3539,8 @@ input[type="checkbox"]:disabled {
    which is declared later in this sheet and would otherwise shrink the
    editor to 460px and center-align it. */
 .modal-card.plugin-editor-card {
-  width: min(920px, 92vw);
-  max-width: 92vw;
+  width: min(1180px, 94vw);
+  max-width: 94vw;
   text-align: left;
 }
 /* Footer buttons stay natural width; the base modal rule stretches
@@ -3548,20 +3548,21 @@ input[type="checkbox"]:disabled {
 .modal-card.plugin-editor-card .btn-primary { width: auto; padding: 0 18px; }
 .pe-layout {
   display: flex; gap: 12px; margin-top: 12px;
-  height: min(520px, 60vh);
+  height: clamp(420px, 72vh, 820px);
 }
 .pe-files {
-  flex: 0 0 240px; overflow: auto;
+  flex: 0 0 300px; overflow: auto;
   display: flex; flex-direction: column; gap: 2px;
   border: 1px solid var(--line); border-radius: 8px;
   background: var(--bg-1); padding: 6px;
 }
 .pe-file {
   background: transparent; border: 0; cursor: pointer;
-  text-align: left; padding: 6px 8px; border-radius: 6px;
+  text-align: left; padding: 7px 10px; border-radius: 6px;
   color: var(--text-2);
-  font-family: 'JetBrains Mono', monospace; font-size: 11px;
+  font-family: 'JetBrains Mono', monospace; font-size: 12px; line-height: 1.4;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  flex-shrink: 0;
 }
 .pe-file:hover { background: var(--bg-2); color: var(--text); }
 .pe-file.active { background: color-mix(in srgb, var(--accent) 16%, var(--bg-2)); color: var(--text); }

--- a/test/e2e/layout-overflow.spec.js
+++ b/test/e2e/layout-overflow.spec.js
@@ -16,6 +16,9 @@ test('short window keeps the rail bottom and status footer visible (issue 4)', a
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-e2e-'));
   fs.mkdirSync(path.join(homeDir, '.config', 'husk'), { recursive: true });
   fs.mkdirSync(path.join(homeDir, '.claude'), { recursive: true });
+  // Without firstRunDone, boot() blocks on the welcome wizard (no agent CLI
+  // on CI runners), leaving the status panel empty and stealing clicks.
+  fs.writeFileSync(path.join(homeDir, '.config', 'husk', 'config.json'), JSON.stringify({ firstRunDone: true }));
   const app = await electron.launch({
     args: [path.join(REPO_ROOT, 'src', 'main.js'), '--no-sandbox'],
     cwd: REPO_ROOT,

--- a/test/e2e/plugins-editor.spec.js
+++ b/test/e2e/plugins-editor.spec.js
@@ -14,6 +14,9 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 function makeIsolatedHome() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-e2e-'));
   fs.mkdirSync(path.join(dir, '.config', 'husk'), { recursive: true });
+  // Without firstRunDone, boot() blocks on the welcome wizard (no agent CLI
+  // on CI runners) and its modal intercepts the edit-button click.
+  fs.writeFileSync(path.join(dir, '.config', 'husk', 'config.json'), JSON.stringify({ firstRunDone: true }));
   const pluginsRoot = path.join(dir, '.claude', 'plugins');
   const installPath = path.join(pluginsRoot, 'cache', 'caveman');
   fs.mkdirSync(path.join(installPath, 'skills'), { recursive: true });

--- a/test/e2e/plugins-editor.spec.js
+++ b/test/e2e/plugins-editor.spec.js
@@ -75,5 +75,19 @@ test('plugin editor modal opens wide with a usable file list and editor', async 
   expect(editorState.disabled).toBe(false);
   expect(editorState.hasContent).toBe(true);
 
+  // The header X closes, but dirty edits demand confirmation first.
+  await win.fill('#pe-content', '# edited');
+  await win.click('#pe-close-x');
+  await win.waitForSelector('#confirm-modal:not([hidden])', { timeout: 5_000 });
+  await win.click('#confirm-cancel');
+  let state = await win.evaluate(() => document.getElementById('plugin-editor').hidden);
+  expect(state).toBe(false); // stayed open after "Stay"
+  await win.click('#pe-close-x');
+  await win.waitForSelector('#confirm-modal:not([hidden])', { timeout: 5_000 });
+  await win.click('#confirm-ok');
+  await win.waitForSelector('#plugin-editor', { state: 'hidden', timeout: 5_000 });
+  state = await win.evaluate(() => document.getElementById('plugin-editor').hidden);
+  expect(state).toBe(true); // discarded and closed
+
   await app.close();
 });

--- a/test/e2e/plugins-editor.spec.js
+++ b/test/e2e/plugins-editor.spec.js
@@ -1,0 +1,76 @@
+'use strict';
+
+// Regression: the plugin editor modal must render wide and left-aligned.
+// The base .modal-card rule (460px, centered) used to win the cascade over
+// .plugin-editor-card, squeezing the file list and editor into a sliver.
+
+const { test, expect, _electron: electron } = require('@playwright/test');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function makeIsolatedHome() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-e2e-'));
+  fs.mkdirSync(path.join(dir, '.config', 'husk'), { recursive: true });
+  const pluginsRoot = path.join(dir, '.claude', 'plugins');
+  const installPath = path.join(pluginsRoot, 'cache', 'caveman');
+  fs.mkdirSync(path.join(installPath, 'skills'), { recursive: true });
+  fs.writeFileSync(path.join(installPath, 'README.md'), '# caveman\n');
+  fs.writeFileSync(path.join(installPath, 'skills', 'SKILL.md'), '# skill\nbody\n');
+  fs.writeFileSync(path.join(pluginsRoot, 'installed_plugins.json'), JSON.stringify({
+    plugins: {
+      'caveman@local': [{ scope: 'user', version: '1.0.0', installPath, installedAt: new Date().toISOString() }],
+    },
+  }));
+  fs.writeFileSync(path.join(dir, '.claude', 'settings.json'), JSON.stringify({
+    enabledPlugins: { 'caveman@local': true },
+  }));
+  return dir;
+}
+
+test('plugin editor modal opens wide with a usable file list and editor', async () => {
+  const homeDir = makeIsolatedHome();
+  const app = await electron.launch({
+    args: [path.join(REPO_ROOT, 'src', 'main.js'), '--no-sandbox'],
+    cwd: REPO_ROOT,
+    env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir, ELECTRON_DISABLE_SANDBOX: '1', HUSK_E2E: '1' },
+    timeout: 30_000,
+  });
+  const win = await app.firstWindow({ timeout: 30_000 });
+  await win.waitForLoadState('domcontentloaded');
+
+  await win.evaluate(() => { document.querySelectorAll('.modal').forEach((m) => { m.hidden = true; }); });
+  await win.evaluate(() => setPage('plugins'));
+  await win.waitForSelector('.plugin-row', { timeout: 10_000 });
+  await win.click('.plugin-row [data-act="edit"]');
+  await win.waitForSelector('.pe-file', { timeout: 10_000 });
+
+  const layout = await win.evaluate(() => {
+    const card = document.querySelector('.plugin-editor-card');
+    const cs = getComputedStyle(card);
+    return {
+      cardWidth: Math.round(card.getBoundingClientRect().width),
+      textAlign: cs.textAlign,
+      filesWidth: Math.round(document.querySelector('.pe-files').getBoundingClientRect().width),
+      editorWidth: Math.round(document.querySelector('.pe-content').getBoundingClientRect().width),
+    };
+  });
+  // Wide layout, not the 460px centered base modal.
+  expect(layout.cardWidth).toBeGreaterThanOrEqual(700);
+  expect(layout.textAlign).toBe('left');
+  expect(layout.filesWidth).toBeGreaterThanOrEqual(200);
+  expect(layout.editorWidth).toBeGreaterThanOrEqual(400);
+
+  // Selecting a file loads it into an enabled editor.
+  await win.click('.pe-file');
+  const editorState = await win.evaluate(() => {
+    const ta = document.getElementById('pe-content');
+    return { disabled: ta.disabled, hasContent: ta.value.length > 0 };
+  });
+  expect(editorState.disabled).toBe(false);
+  expect(editorState.hasContent).toBe(true);
+
+  await app.close();
+});

--- a/test/e2e/sessions-detail-panel.spec.js
+++ b/test/e2e/sessions-detail-panel.spec.js
@@ -15,6 +15,9 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 function makeIsolatedHome() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'husk-e2e-'));
   fs.mkdirSync(path.join(dir, '.config', 'husk'), { recursive: true });
+  // Without firstRunDone, boot() blocks on the welcome wizard (no agent CLI
+  // on CI runners) and its modal intercepts the session-row click.
+  fs.writeFileSync(path.join(dir, '.config', 'husk', 'config.json'), JSON.stringify({ firstRunDone: true }));
   fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
   const proj = path.join(dir, '.claude', 'projects', '-home-test-proj');
   fs.mkdirSync(proj, { recursive: true });

--- a/test/e2e/sessions-detail-panel.spec.js
+++ b/test/e2e/sessions-detail-panel.spec.js
@@ -18,8 +18,13 @@ function makeIsolatedHome() {
   fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
   const proj = path.join(dir, '.claude', 'projects', '-home-test-proj');
   fs.mkdirSync(proj, { recursive: true });
-  const line = JSON.stringify({ timestamp: new Date().toISOString(), cwd: '/home/test/proj', type: 'user', message: { content: 'hello world first message' } });
-  fs.writeFileSync(path.join(proj, '11111111-2222-3333-4444-555555555555.jsonl'), line + '\n');
+  // sessions:list skips user-only files as queue-operation receipts, so the
+  // fixture needs an assistant turn to count as a real conversation.
+  const lines = [
+    JSON.stringify({ timestamp: new Date().toISOString(), cwd: '/home/test/proj', type: 'user', message: { content: 'hello world first message' } }),
+    JSON.stringify({ timestamp: new Date().toISOString(), type: 'assistant', message: { content: [{ type: 'text', text: 'hello back' }] } }),
+  ];
+  fs.writeFileSync(path.join(proj, '11111111-2222-3333-4444-555555555555.jsonl'), lines.join('\n') + '\n');
   return dir;
 }
 


### PR DESCRIPTION
Plugins manager page (marketplace browse, install/enable/disable/update/uninstall, in-app plugin file editor with unsaved-changes guard), themed welcome screen, bare-Alt menu focus fix, e2e coverage. Version was bumped to 2.7.0 in the previous merge window; tag follows on the merged commit.