### PR TITLE
fix: resolve agent CLI on GUI launch + correct 1M context window

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -91,7 +91,8 @@ function resolveAgentExe(exe, envPath) {
       res = spawnSync('where', [exe], { encoding: 'utf8', timeout: 4000, windowsHide: true });
     } else {
       const shellBin = (typeof process.env.SHELL === 'string' && process.env.SHELL) ? process.env.SHELL : '/bin/bash';
-      res = spawnSync(shellBin, ['-ilc', `command -v ${exe}`], { encoding: 'utf8', timeout: 4000 });
+      const quotedExe = shJoin(exe, []);
+      res = spawnSync(shellBin, ['-ilc', `command -v -- ${quotedExe}`], { encoding: 'utf8', timeout: 4000 });
     }
     const lines = ((res && res.stdout) || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
     for (const line of lines) {

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,61 @@ function augmentUserPathAsync() {
   } catch (_) {}
 }
 augmentUserPathAsync();
+
+// resolveAgentExe(exe, envPath) turns a bare program name (e.g. 'claude') into
+// an absolute path so the spawn never depends on the child's PATH being right.
+// A GUI/desktop launch inherits a systemd PATH that omits ~/.local/bin etc, so
+// a bare 'claude' would not resolve even though it is installed. Strategy:
+//   1. walk envPath ourselves (cheap, no subprocess)
+//   2. fall back to asking a login shell `command -v` (POSIX) / `where` (win32),
+//      which sources the user's full rc chain and finds CLIs the inherited PATH
+//      misses -- this is the `which claude` / `where claude` lookup.
+// Returns exe unchanged when it is already a path, already resolvable, or when
+// the lookup fails (let the spawn surface the real error). The subprocess only
+// runs in the failure path, so a healthy PATH pays nothing.
+function resolveAgentExe(exe, envPath) {
+  if (typeof exe !== 'string' || !exe) return exe;
+  if (path.isAbsolute(exe) || exe.includes('/') || exe.includes('\\')) return exe;
+  const isWin = process.platform === 'win32';
+  const exts = isWin
+    ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+    : [''];
+
+  const asExecFile = (p) => {
+    try {
+      const st = fs.statSync(p);
+      return st.isFile() && (isWin || (st.mode & 0o111)) ? p : null;
+    } catch (_) { return null; }
+  };
+
+  // 1. Walk the PATH we are about to hand the child.
+  for (const dir of (envPath || '').split(path.delimiter).filter(Boolean)) {
+    for (const ext of exts) {
+      const hit = asExecFile(path.join(dir, exe + ext));
+      if (hit) return hit;
+    }
+  }
+
+  // 2. Ask a login shell where it lives (which/where through the user's rc chain).
+  try {
+    const { spawnSync } = require('child_process');
+    let res;
+    if (isWin) {
+      res = spawnSync('where', [exe], { encoding: 'utf8', timeout: 4000, windowsHide: true });
+    } else {
+      const shellBin = (typeof process.env.SHELL === 'string' && process.env.SHELL) ? process.env.SHELL : '/bin/bash';
+      res = spawnSync(shellBin, ['-ilc', `command -v ${exe}`], { encoding: 'utf8', timeout: 4000 });
+    }
+    const lines = ((res && res.stdout) || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+    for (const line of lines) {
+      const hit = asExecFile(line);
+      if (hit) return hit;
+    }
+  } catch (_) {}
+
+  return exe;
+}
+
 const {
   sanitizeGraph,
   migrateWorkflow,
@@ -692,6 +747,12 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   });
   const bunBin = path.join(HOME, '.bun', 'bin');
   if (env.PATH && !env.PATH.includes(bunBin)) env.PATH = `${bunBin}:${env.PATH}`;
+  // ~/.local/bin is where the native claude installer (and other user CLIs)
+  // land, but a GUI/desktop launch inherits a systemd PATH that omits it.
+  // augmentUserPathAsync recovers it from a login shell, but that's async and
+  // racy against the first agent spawn. Force-prepend it the same way as bun.
+  const localBin = path.join(HOME, '.local', 'bin');
+  if (env.PATH && !env.PATH.includes(localBin)) env.PATH = `${localBin}:${env.PATH}`;
 
   const rawCmd = (overrideCmd || config.agentCommand || 'claude').trim();
 
@@ -702,6 +763,11 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   const userTokens = rawCmd.split(/\s+/).filter(Boolean);
   let agentExe = userTokens.shift() || 'claude';
   let agentArgs = userTokens;
+
+  // Resolve a bare program name to an absolute path up front (which/where via a
+  // login shell if needed) so the spawn does not depend on the child PATH being
+  // correct. No-op when already a path or already on env.PATH.
+  agentExe = resolveAgentExe(agentExe, env.PATH);
 
   // For claude commands, inject the Husk runtime context: a settings override
   // that silences the inline statusline, and an appended system prompt that
@@ -907,6 +973,9 @@ function readClaudeSettings() {
 // 400K product cap, GPT-4.1 1M, GPT-4o 128K, o-series 200K); Google Gemini docs
 // (Gemini 2.x/3 = 1M); GitHub Copilot CLI docs (128K default, 1M extended).
 const MODEL_CONTEXT_WINDOWS = [
+  // Anthropic / Claude Opus: 1M context window (the Opus tier ships with the
+  // long-context window, so it is the base here, not an opt-in [1m] tier).
+  [/^claude-opus/, 1000000],
   // Anthropic / Claude: 200K default; 1M only when the [1m] tier is selected.
   [/^claude-/, 200000],
   // OpenAI / Codex CLI.
@@ -933,13 +1002,31 @@ function baseContextWindow(model) {
 // signalled by a "[1m]" suffix that Claude Code persists in ~/.claude.json
 // under projects[cwd].lastModelUsage. So: prefer an explicit 1M tier (from the
 // id or that usage record), else look up the family's base size, else infer.
+// Claude Code accepts short model aliases in settings.json ("opus", "sonnet",
+// "haiku", "opusplan"). We prefer settings.json over the transcript for the
+// active model, but a bare alias matches none of the claude-* family regexes,
+// so the window wrongly falls back to the 200K default -- e.g. "opus" never hit
+// the [/^claude-opus/, 1000000] rule and showed 200K instead of 1M. Expand
+// known aliases to a canonical family id before matching; any tier suffix
+// ("opus[1m]") is preserved. Full ids ("claude-opus-4-8", "gpt-5-codex") and
+// unknown values pass through untouched.
+function normalizeModelId(id) {
+  const s = String(id || '').toLowerCase().trim();
+  if (!s || s.includes('-')) return s; // full ids already contain a hyphen
+  const tier = (s.match(/\[[^\]]*\]/) || [''])[0];
+  const base = s.replace(/\[[^\]]*\]/g, '');
+  const ALIAS = { opus: 'claude-opus', opusplan: 'claude-opus', sonnet: 'claude-sonnet', haiku: 'claude-haiku' };
+  return ALIAS[base] ? ALIAS[base] + tier : s;
+}
+
 function resolveContextWindow(cwd, model, ctxTokens) {
+  const norm = normalizeModelId(model);
   const stripTier = (id) => id.replace(/\[[^\]]*\]/g, '');
   const is1m = (id) => /\[1m\]/i.test(id);
-  const bare = stripTier(model || '');
+  const bare = stripTier(norm);
   try {
     // Explicit 1M tier on the id itself.
-    if (is1m(model || '')) return 1000000;
+    if (is1m(norm)) return 1000000;
     // Recover the tier from Claude Code's usage record. lastModelUsage is only
     // written on session end, so the active project is empty mid-session: check
     // it first, then the user's full history. If this model was ever run on the
@@ -1842,9 +1929,48 @@ const KNOWN_AGENTS = [
   },
 ];
 
+// loginShellPath() returns the PATH a login+interactive shell produces (which
+// sources .profile/.bashrc and so includes ~/.local/bin, nvm, etc). A
+// GUI/desktop launch inherits a stripped systemd PATH, so a bare process.env
+// .PATH check misreports CLIs like claude (installed in ~/.local/bin) as
+// missing -- which is exactly what the first-launch wizard showed when Husk was
+// started from the taskbar instead of a terminal. Cached: one subprocess for
+// the whole session. Returns '' on win32 or on failure.
+let _loginShellPathCache;
+function loginShellPath() {
+  if (_loginShellPathCache !== undefined) return _loginShellPathCache;
+  _loginShellPathCache = '';
+  if (process.platform === 'win32') return _loginShellPathCache;
+  try {
+    const { spawnSync } = require('child_process');
+    const shellBin = (typeof process.env.SHELL === 'string' && process.env.SHELL) ? process.env.SHELL : '/bin/bash';
+    const res = spawnSync(shellBin, ['-ilc', `echo "${MARKER_START}$PATH${MARKER_END}"`], { encoding: 'utf8', timeout: 5000 });
+    const p = parseShellPathOutput((res && res.stdout) || '');
+    if (p) _loginShellPathCache = p;
+  } catch (_) {}
+  return _loginShellPathCache;
+}
+
+// extraAgentBinDirs() are user-install locations that a GUI/desktop launch's
+// PATH omits and that even a login shell does not reliably restore (bash login
+// shells read .bash_profile, not .profile/.bashrc, so ~/.local/bin can be
+// missing). These are the SAME dirs the agent spawn force-prepends, so that
+// "FOUND" in the wizard always implies the spawn will actually resolve the CLI.
+function extraAgentBinDirs() {
+  if (process.platform === 'win32') return [];
+  return [path.join(HOME, '.local', 'bin'), path.join(HOME, '.bun', 'bin')];
+}
+
 function isOnPath(binName) {
-  const dirs = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
   const isWin = process.platform === 'win32';
+  // Union of: the inherited PATH, the login-shell PATH (nvm/pyenv/etc), and the
+  // known user-install dirs. Deduped in order, so detection is correct whether
+  // Husk was launched from a terminal or the GUI.
+  const seen = new Set();
+  const dirs = [process.env.PATH || '', isWin ? '' : loginShellPath()]
+    .flatMap((p) => p.split(path.delimiter))
+    .concat(extraAgentBinDirs())
+    .filter((d) => d && !seen.has(d) && seen.add(d));
   const candidates = isWin
     ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean).map((e) => binName + e)
     : [binName];
@@ -2252,6 +2378,8 @@ function buildAgentEnv() {
   const env = Object.assign({}, process.env, { CLAUDE_DIR, HUSK_HOST: '1' });
   const bunBin = path.join(HOME, '.bun', 'bin');
   if (env.PATH && !env.PATH.includes(bunBin)) env.PATH = `${bunBin}:${env.PATH}`;
+  const localBin = path.join(HOME, '.local', 'bin');
+  if (env.PATH && !env.PATH.includes(localBin)) env.PATH = `${localBin}:${env.PATH}`;
   return env;
 }
 

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -172,6 +172,9 @@ if (typeof Terminal === 'undefined' || typeof window.husk === 'undefined') {
 let cfg = null;
 let huskHome = '~';
 let lastStats = null;
+// Last non-empty context-window reading, kept so the Usage panel never flickers
+// the block out on a transient poll (see refreshStatusline).
+let lastGoodCtx = null;
 let currentPage = 'chat';
 let chatHasInput = false;
 
@@ -269,6 +272,9 @@ function createTab() {
 function activateTab(id) {
   const tab = TABS.get(id);
   if (!tab) return;
+  // Drop the cached context reading so the next poll shows the newly-focused
+  // session's window, never the previous tab's stale number.
+  if (activeTabId !== id) lastGoodCtx = null;
   activeTabId = id;
   term = tab.term;
   fitAddon = tab.fitAddon;
@@ -954,10 +960,19 @@ async function refreshStatusline() {
     : '';
   const u = s.usage || {};
   const L = s.learning || {};
+  // Stabilize the context reading. A poll taken while the agent is mid-turn can
+  // transiently return no session or ctxTokens===0 (the newest-by-mtime
+  // transcript momentarily being a sidechain/fresh file, or a tail read landing
+  // before the next usage record). Without this the whole Context Window block
+  // flickers out and back. Cache the last good reading and fall back to it; a
+  // real change overwrites it on the next good poll, and activateTab() clears it
+  // on a session switch so we never show a stale cross-session number.
+  if (u.session && u.session.ctxTokens > 0) lastGoodCtx = u.session;
+  const ctx = (u.session && u.session.ctxTokens > 0) ? u.session : lastGoodCtx;
   // The active model. Trim the vendor prefix and the context-tier suffix so the
   // readout stays compact and matches the banner (e.g. "fable-5", not
   // "claude-fable-5[1m]"). Empty when no model is known, which hides the row.
-  const modelLabel = ((u.session && u.session.model) || '').replace(/^claude-/, '').replace(/\[[^\]]*\]/g, '');
+  const modelLabel = ((u.session && u.session.model) || (ctx && ctx.model) || '').replace(/^claude-/, '').replace(/\[[^\]]*\]/g, '');
 
   const html = `
     <div class="sp-section">
@@ -973,7 +988,7 @@ async function refreshStatusline() {
       <div class="sp-section-head"><span class="sp-h-icon">▣</span><span>Build</span></div>
       <div class="sp-section-body">
         <div class="sp-row"><span class="sp-muted">Claude ${spInfo('Installed Claude Code CLI version.')}</span><span class="sp-mono">2.1.129</span></div>
-        ${modelLabel ? `<div class="sp-row"><span class="sp-muted">Model ${spInfo('The AI model the active session is running.')}</span><span class="sp-mono sp-accent" title="${escapeHtml((u.session && u.session.model) || '')}">${escapeHtml(modelLabel)}</span></div>` : ''}
+        ${modelLabel ? `<div class="sp-row"><span class="sp-muted">Model ${spInfo('The AI model the active session is running.')}</span><span class="sp-mono sp-accent" title="${escapeHtml((u.session && u.session.model) || (ctx && ctx.model) || '')}">${escapeHtml(modelLabel)}</span></div>` : ''}
         <div class="sp-row"><span class="sp-muted">Husk ${spInfo('Installed Husk app version.')}</span><span class="sp-mono">${escapeHtml(s.huskVer || '0.2')}</span></div>
       </div>
     </div>
@@ -990,13 +1005,13 @@ async function refreshStatusline() {
     <div class="sp-section">
       <div class="sp-section-head"><span class="sp-h-icon">⏱</span><span>Usage</span></div>
       <div class="sp-section-body">
-        ${(u.session && u.session.ctxTokens > 0) ? `
+        ${(ctx && ctx.ctxTokens > 0) ? `
         <div class="sp-row"><span class="sp-muted">Context Window ${spInfo('Tokens currently held in the model context window versus the model capacity. This is what fills up during a conversation and triggers compaction.')}</span></div>
         <div class="sp-row sp-ctx-head" title="Context window used">
-          <span class="sp-mono" style="color:${ctxPctColor(u.session.ctxPct)}; font-weight:600;">${fmtPct(u.session.ctxPct)}</span>
-          <span class="sp-mono sp-muted">${escapeHtml(fmtCtx(u.session.ctxTokens))} / ${escapeHtml(fmtCtx(u.session.ctxWindow))}</span>
+          <span class="sp-mono" style="color:${ctxPctColor(ctx.ctxPct)}; font-weight:600;">${fmtPct(ctx.ctxPct)}</span>
+          <span class="sp-mono sp-muted">${escapeHtml(fmtCtx(ctx.ctxTokens))} / ${escapeHtml(fmtCtx(ctx.ctxWindow))}</span>
         </div>
-        ${ctxBarHTML(u.session.ctxPct)}
+        ${ctxBarHTML(ctx.ctxPct)}
         <div class="sp-divider"></div>
         ` : ''}
         ${u.cache_present ? `


### PR DESCRIPTION
## Summary

When Husk is launched from the **desktop/taskbar**, it inherits a stripped systemd `PATH` that omits `~/.local/bin` — where the native `claude` installer places its binary. This caused a cluster of related issues, plus two unrelated Usage-panel bugs. This PR fixes all of them.

| Symptom | Cause | Fix |
|---|---|---|
| `claude` fails to launch (only from taskbar, works from terminal) | Spawn env PATH lacks `~/.local/bin`; the async login-shell PATH recovery is racy and, on bash, doesn't restore `~/.local/bin` anyway (login shells read `.bash_profile`, not `.profile`/`.bashrc`) | Force-prepend `~/.local/bin` to the spawn env (mirrors the existing `~/.bun/bin` handling) **and** resolve the agent program to an absolute path before spawn |
| First-run wizard shows installed CLIs as **Not installed** | `isOnPath()` read only `process.env.PATH` | `isOnPath()` now unions the inherited PATH, the login-shell PATH, and the known user-install dirs |
| Usage panel caps Opus context at **200K** instead of 1M | `settings.json` model is the short alias `"opus"`, which matches none of the `claude-*` family regexes and falls through to the 200K default | `normalizeModelId()` expands short aliases before lookup |
| Context Window block **disappears while the agent is thinking**, reappears later | Block gated on `ctxTokens > 0`; a mid-turn poll transiently returns 0/null | Cache the last good reading and fall back to it; cleared on session switch |

## Changes

**`src/main.js`**
- Force-prepend `~/.local/bin` to the agent spawn env at both spawn sites (PTY spawn + `buildAgentEnv`).
- Add `resolveAgentExe(exe, envPath)` — resolves a bare program name to an absolute path via a PATH walk, then a login-shell `command -v` / `where` fallback. The subprocess only runs when the name isn't already resolvable, so a healthy PATH pays nothing.
- `isOnPath()` now consults `process.env.PATH` ∪ login-shell PATH ∪ `extraAgentBinDirs()` (`~/.local/bin`, `~/.bun/bin`), so detection matches what the spawn can actually launch.
- Add `normalizeModelId()` to expand Claude Code short model aliases (`opus`/`opusplan` → `claude-opus`, `sonnet` → `claude-sonnet`, `haiku` → `claude-haiku`), preserving any `[1m]` tier suffix.

**`src/renderer/app.js`**
- Add `lastGoodCtx` cache; `refreshStatusline()` updates it only on a real reading and falls back to it otherwise, so the Context Window block no longer flickers out mid-turn. Cleared in `activateTab()` on a session switch to avoid stale cross-session numbers.

## Testing

All fixes were verified headlessly under a simulated GUI/taskbar PATH (no `~/.local/bin`):
- `resolveAgentExe` + the real `buildSpawnSpec` + node-pty launch `claude --version` → `2.1.178 (Claude Code)`, exit 0.
- Detection reports `claude → FOUND` (was `NOT INSTALLED`), genuinely-missing CLIs still `NOT INSTALLED`.
- Context window: `opus → 1M`, `sonnet → 200K`, `sonnet[1m] → 1M`, full ids unchanged.
- `node --check` passes on both files.
