### PR TITLE
release: v2.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "husk",
-  "version": "2.9.0",
+  "version": "2.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "husk",
-      "version": "2.9.0",
+      "version": "2.8.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "2.9.0",
+  "version": "2.8.3",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",

--- a/src/main.js
+++ b/src/main.js
@@ -1157,6 +1157,11 @@ function readActiveSessionStats() {
     } else if (files[0]) {
       latest = files[0].p;
     }
+    // If nothing resolved above (a non-claude tab, or a tab whose own file
+    // predates its spawn), fall back to the newest transcript in the project
+    // dir so the readout reflects the latest known session instead of going
+    // blank.
+    if (!latest && files[0]) latest = files[0].p;
     // Cap the read. A session JSONL grows for the whole conversation and
     // can reach many megabytes; reading and parsing the entire file on
     // every status poll stalls the main thread. Read at most the last


### PR DESCRIPTION
Patch release v2.8.3: status panel model fix. Supersedes the mistaken v2.9.0 tag.