### PR TITLE
fix(packaging): set setuid bit on chrome-sandbox in deb postinstall

### DIFF
--- a/installer/after-install.sh
+++ b/installer/after-install.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
-# Post-install: install icon at standard hicolor sizes GNOME/KDE recognise,
+# Post-install: configure Chromium's sandbox, install icons, refresh caches,
+# and pin to the GNOME Dash.
+
+# Chromium's SUID sandbox helper must be owned by root with mode 4755.
+# electron-builder injects this into its DEFAULT deb/rpm postinst, but supplying
+# a custom afterInstall script REPLACES that default — so we must set it here
+# ourselves. Without it the app aborts immediately on launch (only the launcher
+# icon shows, no window) with:
+#   FATAL ... The SUID sandbox helper binary was found, but is not configured
+#   correctly ... /opt/Husk/chrome-sandbox is owned by root and has mode 4755.
+SANDBOX="/opt/Husk/chrome-sandbox"
+if [ -f "$SANDBOX" ]; then
+  chown root:root "$SANDBOX" || true
+  chmod 4755 "$SANDBOX" || true
+fi
+
+# Install icon at standard hicolor sizes GNOME/KDE recognise,
 # then refresh caches so the icon appears immediately without a logout.
 SRC="/usr/share/icons/hicolor/1024x1024/apps/husk.png"
 if [ -f "$SRC" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "husk",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "husk",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",


### PR DESCRIPTION
## Problem

A fresh `sudo dpkg -i husk_*_amd64.deb` installs cleanly but the app won't launch — clicking it shows only the dock icon, no window. Running `/opt/Husk/husk` from a terminal reveals the cause:

```
FATAL:setuid_sandbox_host.cc(166)] The SUID sandbox helper binary was found, but
is not configured correctly. Rather than run without sandboxing I'm aborting now.
You need to make sure that /opt/Husk/chrome-sandbox is owned by root and has mode 4755.
```

The shipped `chrome-sandbox` ends up mode `0755` instead of `4755` (no setuid bit).

## Root cause

electron-builder normally injects the `chmod 4755 chrome-sandbox` step into its **default** deb/rpm postinstall. Husk supplies a **custom** `afterInstall` script (`installer/after-install.sh`, for icon sizing + GNOME Dash pinning), which **replaces** that default — silently dropping the sandbox step. Every Linux `.deb` user hits this.

## Fix

Re-add the `chown root:root` + `chmod 4755` for `chrome-sandbox` to the custom post-install script. Idempotent and guarded by a file check.

> Note: `--no-sandbox` is deliberately **not** used — that would disable Chromium's sandbox for all users. The setuid bit is the correct fix.

## Testing

- **Before:** `dpkg -i` → launch → silent fail; terminal shows the FATAL above; `ls -l /opt/Husk/chrome-sandbox` → `-rwxr-xr-x`.
- **After:** postinstall sets the bit → `ls -l` → `-rwsr-xr-x` → app launches normally.

Also bumps version `2.8.4` → `2.8.5`.