### PR TITLE
release: v2.8.7

### DIFF
--- a/installer/after-install.sh
+++ b/installer/after-install.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
-# Post-install: install icon at standard hicolor sizes GNOME/KDE recognise,
+# Post-install: configure Chromium's sandbox, install icons, refresh caches,
+# and pin to the GNOME Dash.
+
+# Chromium's SUID sandbox helper must be owned by root with mode 4755.
+# electron-builder injects this into its DEFAULT deb/rpm postinst, but supplying
+# a custom afterInstall script REPLACES that default, so we must set it here
+# ourselves. Without it the app aborts immediately on launch (only the launcher
+# icon shows, no window) with:
+#   FATAL ... The SUID sandbox helper binary was found, but is not configured
+#   correctly ... /opt/Husk/chrome-sandbox is owned by root and has mode 4755.
+SANDBOX="/opt/Husk/chrome-sandbox"
+if [ -f "$SANDBOX" ]; then
+  chown root:root "$SANDBOX" || true
+  chmod 4755 "$SANDBOX" || true
+fi
+
+# Install icon at standard hicolor sizes GNOME/KDE recognise,
 # then refresh caches so the icon appears immediately without a logout.
 SRC="/usr/share/icons/hicolor/1024x1024/apps/husk.png"
 if [ -f "$SRC" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "husk",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "husk",
-      "version": "2.8.6",
+      "version": "2.8.7",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",

--- a/src/lib/autopilot-apply.js
+++ b/src/lib/autopilot-apply.js
@@ -40,7 +40,9 @@ function copyInto(worktreePath, workspaceRoot, rel) {
     return { path: rel, ok: false, reason: 'source escapes worktree root' };
   }
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst re-confined under workspaceRoot above
     fs.mkdirSync(path.dirname(dst), { recursive: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- src and dst both re-confined above
     fs.copyFileSync(src, dst);
     return { path: rel, ok: true, status: 'written' };
   } catch (err) {

--- a/src/lib/autopilot-worktree.js
+++ b/src/lib/autopilot-worktree.js
@@ -67,6 +67,7 @@ function createRunWorktree(userData, runId, workspaceRoot) {
   }
 
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- wtRoot is <userData>/autopilot-worktrees, confined above
     fs.mkdirSync(wtRoot, { recursive: true });
     execFileSync('git', ['worktree', 'add', wtPath, 'HEAD'], { cwd: resolvedWs, stdio: 'pipe' });
     return { ok: true, worktreePath: wtPath };

--- a/src/lib/highlight.js
+++ b/src/lib/highlight.js
@@ -162,6 +162,7 @@ const LANGUAGES = {
 // whole input. `kind` is null for text matched by no rule.
 function tokenize(code, rules) {
   const pattern = rules.map((r) => '(' + r.src + ')').join('|');
+  // eslint-disable-next-line security/detect-non-literal-regexp -- pattern is built from the static LANGUAGES rule table, never user input
   const re = new RegExp(pattern, 'gm');
   const segments = [];
   let last = 0;


### PR DESCRIPTION
Version bump for v2.8.7. Carries the CI lint fix, the chrome-sandbox deb/rpm fix (Closes #80), and the Phase 0 agent fixes. Tag follows on the merged commit.