### PR TITLE
feat: workflow step drawer, light-terminal contrast, and form validation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1470,7 +1470,17 @@ ipcMain.handle('pty:list', () => {
   const list = [];
   for (const [id, s] of sessions) {
     if (!s.pty) continue;
-    list.push({ sessionId: id, cwd: s.cwd || null, claudeSessionId: s.claudeSessionId || null, active: id === activeSessionId });
+    // Only mark a claude session resumable if its transcript actually exists. A
+    // chat whose claude exited 0 before writing leaves no .jsonl, and
+    // `claude --resume <id>` on it fails with "No conversation found".
+    let resumable = false;
+    if (s.claudeSessionId && s.cwd) {
+      try {
+        const enc = s.cwd.replace(/[^a-zA-Z0-9]/g, '-');
+        resumable = fs.existsSync(path.join(CLAUDE_DIR, 'projects', enc, `${s.claudeSessionId}.jsonl`));
+      } catch (_) {}
+    }
+    list.push({ sessionId: id, cwd: s.cwd || null, claudeSessionId: s.claudeSessionId || null, resumable, active: id === activeSessionId });
   }
   return { ok: true, sessions: list, activeSessionId };
 });
@@ -6876,12 +6886,20 @@ function parseSessionHead(fullPath) {
   let aiTitle = latestAiTitle(fullPath);
   let userMessage = ''; let queueContent = '';
   let startedISO = ''; let originalCwd = '';
+  // An interactive session opens with the terminal preamble the CLI writes when
+  // a person is driving it. One-shot helper runs (title generation, hooks that
+  // summarise a conversation) land in the same project directory with the same
+  // cwd and a fresh timestamp, but never emit that preamble. Without this the
+  // two are indistinguishable, and a helper transcript can be mistaken for a
+  // chat the user just started.
+  let interactive = false;
   try {
     const text = readHead(fullPath, 32768);
     for (const line of text.split('\n')) {
       if (!line.trim()) continue;
       let obj;
       try { obj = JSON.parse(line); } catch (_) { continue; }
+      if (obj.type === 'mode' || obj.type === 'permission-mode' || obj.type === 'file-history-snapshot') interactive = true;
       if (!startedISO && obj.timestamp) startedISO = obj.timestamp;
       if (!originalCwd && typeof obj.cwd === 'string') originalCwd = obj.cwd;
       if (!userMessage && obj.type === 'user' && obj.message) {
@@ -6898,10 +6916,10 @@ function parseSessionHead(fullPath) {
         if (text && !isCommandWrapperText(text)) userMessage = text;
       }
       if (!queueContent && obj.type === 'queue-operation' && typeof obj.content === 'string') queueContent = obj.content.trim();
-      if (aiTitle && startedISO && userMessage && originalCwd) break;
+      if (interactive && aiTitle && startedISO && userMessage && originalCwd) break;
     }
   } catch (_) { return null; }
-  return { aiTitle, userMessage, queueContent, startedISO, originalCwd };
+  return { aiTitle, userMessage, queueContent, startedISO, originalCwd, interactive };
 }
 
 // The display title a session would show, given its parsed head fields. Same
@@ -7491,6 +7509,11 @@ ipcMain.handle('sessions:resolveLiveTitle', (_e, payload = {}) => {
       if (st.mtimeMs < startedAt - 10_000) continue;
       const info = parseSessionHead(full);
       if (!info) continue;
+      // Only a real chat can back a tab. Helper runs share this directory, this
+      // cwd and this minute, and they carry a title describing whatever chat
+      // they were summarising, so binding to one renames the tab after a
+      // different conversation.
+      if (!info.interactive) continue;
       if (info.originalCwd && info.originalCwd !== s.cwd) continue;
       const startedMs = info.startedISO ? Date.parse(info.startedISO) : st.mtimeMs;
       // Must have begun around or after this tab launched (not a resumed older

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -40,19 +40,28 @@ function notifSvg(name) {
   }
   return svg;
 }
+// Live cards that own a `key`. A repeat notification under the same key edits
+// that card in place instead of stacking another one, so a value the user is
+// stepping through (zoom, volume) reads as one readout that keeps changing.
+const keyedNotifs = new Map();
 function dismissNotif(card) {
   if (!card || card._dismissing) return;
   card._dismissing = true;
   if (card._timer) clearTimeout(card._timer);
+  if (card._key && keyedNotifs.get(card._key) === card) keyedNotifs.delete(card._key);
   card.classList.add('is-out');
   setTimeout(() => { try { card.remove(); } catch (_) {} }, 200);
 }
-// Core entry. opts: { title, kind, prominent, ttl }
+// Core entry. opts: { title, kind, prominent, ttl, key }
 function notify(message, opts = {}) {
   const stack = $('#toast-stack');
   if (!stack) return;
   const kind = opts.kind || '';
   const iconName = opts.icon || (opts.prominent ? 'done' : (kind || 'info'));
+  const existing = opts.key ? keyedNotifs.get(opts.key) : null;
+  if (existing && !existing._dismissing && existing.isConnected) {
+    return updateNotif(existing, message, { ...opts, kind, iconName });
+  }
   const card = document.createElement('div');
   card.className = 'toast is-enter' + (kind ? ' ' + kind : '') + (opts.prominent ? ' is-prominent' : '');
   const icon = document.createElement('span');
@@ -94,12 +103,34 @@ function notify(message, opts = {}) {
   // the loop always terminates.
   const live = Array.from(stack.children).filter((c) => !c._dismissing);
   for (let i = NOTIF_MAX; i < live.length; i++) dismissNotif(live[i]);
-  // Auto-dismiss with hover-to-pause.
-  const ttl = opts.ttl || NOTIF_TTL[kind] || NOTIF_TTL[''];
-  const arm = () => { card._timer = setTimeout(() => dismissNotif(card), ttl); };
+  // Auto-dismiss with hover-to-pause. The ttl lives on the card so an in-place
+  // update can restart the countdown with its own value.
+  card._ttl = opts.ttl || NOTIF_TTL[kind] || NOTIF_TTL[''];
+  const arm = () => { card._timer = setTimeout(() => dismissNotif(card), card._ttl); };
+  card._arm = arm;
   arm();
   card.addEventListener('mouseenter', () => { if (card._timer) clearTimeout(card._timer); });
   card.addEventListener('mouseleave', () => { if (!card._dismissing) arm(); });
+  if (opts.key) { card._key = opts.key; keyedNotifs.set(opts.key, card); }
+  return card;
+}
+// Re-use a keyed card: swap the text, the kind and the icon, restart the
+// countdown, and pulse once so a changed value is noticed without the card
+// moving or re-entering.
+function updateNotif(card, message, opts) {
+  const msg = card.querySelector('.toast-msg');
+  if (msg) msg.textContent = message;
+  const title = card.querySelector('.toast-title');
+  if (title && opts.title) title.textContent = opts.title;
+  for (const k of ['success', 'error', 'warn', 'info']) card.classList.toggle(k, opts.kind === k);
+  const icon = card.querySelector('.toast-icon');
+  if (icon) { icon.replaceChildren(notifSvg(opts.iconName)); }
+  card._ttl = opts.ttl || NOTIF_TTL[opts.kind] || NOTIF_TTL[''];
+  if (card._timer) clearTimeout(card._timer);
+  if (!card.matches(':hover')) card._arm();
+  card.classList.remove('is-bump');
+  void card.offsetWidth;
+  card.classList.add('is-bump');
   return card;
 }
 // Back-compatible API used across the renderer.
@@ -319,6 +350,7 @@ function createTab(idOverride) {
     fontFamily: '"JetBrains Mono", "Fira Code", "Menlo", "Consolas", monospace',
     fontSize: 13,
     theme: themeForXterm(),
+    minimumContrastRatio: contrastForXterm(),
   });
   const fa = new FitAddon.FitAddon();
   t.loadAddon(fa);
@@ -426,6 +458,98 @@ $('#terminal').addEventListener('wheel', (e) => {
   e.stopPropagation();
 }, { capture: true, passive: false });
 
+// Auto-scroll while drag-selecting. xterm only scrolls the viewport once the
+// pointer leaves the screen element: anywhere inside it the scroll amount is
+// zero, so holding at the top of a terminal that fills its pane selects nothing
+// further. Treat a band at each edge as if the pointer were already outside by
+// re-sending the move with a clamped Y. xterm then runs its own drag-scroll,
+// which extends the selection as it scrolls; a plain scrollLines call moves
+// the viewport but leaves the selection behind.
+// Which scroller moves depends on the agent. A TUI that draws its own viewport
+// (it prints its own jump-to-bottom hint and turns mouse reporting on) keeps no
+// terminal scrollback, so xterm has nothing to scroll and only wheel input the
+// agent understands moves it. Everything else scrolls xterm's own scrollback.
+const DRAG_EDGE_PX = 24;
+const DRAG_EDGE_MS = 60;
+let selDragging = false;
+let selSynthetic = false;
+let selEdge = null;          // { x, y, dir } while the pointer sits in an edge band
+let selEdgeTimer = null;
+
+function selEdgeStop() {
+  if (selEdgeTimer) { clearInterval(selEdgeTimer); selEdgeTimer = null; }
+  selEdge = null;
+}
+
+// One scroll step, repeated on a timer so holding still keeps scrolling: a
+// stationary pointer fires no further mousemove of its own.
+function selEdgeTick() {
+  if (!selDragging || !selEdge) { selEdgeStop(); return; }
+  const tab = TABS.get(activeTabId);
+  const screen = tab && tab.el.querySelector('.xterm-screen');
+  if (!screen || !term) return;
+  const r = screen.getBoundingClientRect();
+  // Prefer xterm's own scroller whenever it has somewhere to go: only xterm
+  // grows the selection as it scrolls. Forwarding to the agent instead makes it
+  // repaint the screen, which xterm never hears about, so the selection keeps
+  // its old anchor and the marked text scrolls out of the buffer entirely.
+  // The alternate screen a full-screen TUI runs in holds no scrollback, so
+  // there the agent is the only thing that can move.
+  const buf = term.buffer.active;
+  const xtermCanScroll = buf.type === 'normal'
+    && (selEdge.dir < 0 ? buf.viewportY > 0 : buf.viewportY < buf.baseY);
+  if (!xtermCanScroll && agentMouseOn) {
+    // Agent owns the viewport: hand it wheel input, the same path the wheel
+    // listener above uses, so it redraws one step further back.
+    const cw = r.width / term.cols || 1;
+    const ch = r.height / term.rows || 1;
+    let col = Math.floor((selEdge.x - r.left) / cw) + 1;
+    let row = Math.floor((selEdge.y - r.top) / ch) + 1;
+    col = Math.min(Math.max(col, 1), term.cols);
+    row = Math.min(Math.max(row, 1), term.rows);
+    window.husk.pty.wheel({ deltaY: selEdge.dir * 120, deltaMode: 0, col, row }, activeTabId);
+    return;
+  }
+  // Already past the edge: xterm scrolls on its own there, so leave it alone
+  // rather than driving it twice as fast.
+  if (selEdge.y < r.top || selEdge.y > r.bottom) return;
+  // xterm owns the scrollback: its drag-scroll amount is zero for any pointer
+  // inside the screen, so feed it one that reads as outside. Going through
+  // xterm keeps the selection growing as it scrolls; scrollLines would move the
+  // viewport and leave the selection behind.
+  const outsideY = selEdge.dir < 0
+    ? r.top - 1 - (DRAG_EDGE_PX - (selEdge.y - r.top))
+    : r.bottom + 1 + (DRAG_EDGE_PX - (r.bottom - selEdge.y));
+  selSynthetic = true;
+  try {
+    screen.ownerDocument.dispatchEvent(new MouseEvent('mousemove', {
+      bubbles: true, cancelable: true, clientX: selEdge.x, clientY: outsideY, buttons: 1, detail: 1,
+    }));
+  } finally { selSynthetic = false; }
+}
+
+// Capture phase: the drag must be registered even if something downstream
+// stops the event from bubbling.
+$('#terminal').addEventListener('mousedown', (e) => { if (e.button === 0) selDragging = true; }, true);
+window.addEventListener('mouseup', () => { selDragging = false; selEdgeStop(); });
+document.addEventListener('mousemove', (e) => {
+  if (!selDragging || selSynthetic) return;
+  const tab = TABS.get(activeTabId);
+  const screen = tab && tab.el.querySelector('.xterm-screen');
+  if (!screen) { selEdgeStop(); return; }
+  const r = screen.getBoundingClientRect();
+  const y = e.clientY;
+  // Open-ended on purpose: dragging "to the top" usually overshoots past the
+  // terminal into the tab strip above it. Anything at or beyond each edge keeps
+  // scrolling, which is what a text editor does.
+  let dir = 0;
+  if (y < r.top + DRAG_EDGE_PX) dir = -1;
+  else if (y > r.bottom - DRAG_EDGE_PX) dir = 1;
+  if (!dir) { selEdgeStop(); return; }
+  selEdge = { x: e.clientX, y, dir };
+  if (!selEdgeTimer) selEdgeTimer = setInterval(selEdgeTick, DRAG_EDGE_MS);
+});
+
 function themeForXterm() {
   // The terminal runs a TUI agent that themes its output through the 16 ANSI
   // colors. The canvas background/foreground come from the active theme's
@@ -457,6 +581,18 @@ function themeForXterm() {
         brightCyan: '#a5f3fc', brightWhite: '#f1f5f9',
       };
   return { background: bg, foreground: fg, cursor: accent, cursorAccent: bg, ...ansi };
+}
+
+// An agent CLI has no way to learn the terminal went light, so it keeps
+// emitting colours chosen for a dark background: pale greys for diff context
+// and, for some tokens, outright white. Those turn invisible on a light
+// terminal. Remapping the sixteen ANSI slots cannot help, because the text
+// arrives as 256-colour and truecolour codes that name their colour outright.
+// xterm re-tones any foreground that falls under this ratio against the real
+// background, which reaches those codes too. Dark themes already contrast, so
+// they keep xterm's default of 1 (off) and render exactly as before.
+function contrastForXterm() {
+  return getComputedStyle(document.body).getPropertyValue('--term-light').trim() === '1' ? 4.5 : 1;
 }
 
 function fitNow() {
@@ -622,6 +758,32 @@ function mountWhatsNewKernel(slot) {
     hk.classList.add('is-pop');
   }, 4200);
   return () => { clearInterval(sparks); };
+}
+// Clone Kernel into an empty-state stage, posed peeking from the open pod with
+// an idle blink and a wiggle+spark that lands as the page's prop animation
+// loops, so he reads as "doing" the task rather than just sitting there. Ids are
+// re-prefixed per mount so clones never collide with the onboarding original or
+// each other. Returns an unmount fn that stops the timers.
+let emptyKernelSeq = 0;
+function mountEmptyKernel(slot) {
+  const src = $('#ob-kernel');
+  if (!src || !slot) return null;
+  const prefix = `ek${++emptyKernelSeq}`;
+  const markup = src.outerHTML
+    .replaceAll('id="hk-', `id="${prefix}-`)
+    .replaceAll('url(#hk-', `url(#${prefix}-`)
+    .replace('id="ob-kernel"', '');
+  // eslint-disable-next-line no-unsanitized/property -- own static SVG markup, id-prefixed
+  slot.innerHTML = markup;
+  const hk = slot.querySelector('svg');
+  if (!hk) return null;
+  hk.removeAttribute('style');
+  // Bare, static Kernel: just the seed character, no pod/husk shell and no idle
+  // motion (CSS `.is-bare` hides the shell and disables animation). The viewBox
+  // is retightened around the seed so the hidden shell leaves no gap below him.
+  hk.className.baseVal = 'hk is-bare';
+  hk.setAttribute('viewBox', '40 -14 120 176');
+  return null;
 }
 function showWhatsNew(version) {
   return new Promise((resolve) => {
@@ -833,6 +995,7 @@ function _flushTabWrite(tab) {
   // Only the focused tab drives voice, so background agents stay silent.
   if (tab.id === activeTabId) detectAndSpeak();
 }
+
 window.husk.pty.onData((sessionId, d) => {
   const tab = TABS.get(sessionId) || TABS.get(activeTabId);
   if (!tab || tab.restarting) return;
@@ -884,7 +1047,10 @@ async function reattachSessions() {
     // form; otherwise the live PTY is kept and reattached below. Closing
     // first and failing to resume would destroy a healthy session.
     let resumeCmd = null;
-    if (sess.claudeSessionId) {
+    // Only resume when the transcript still exists. Resuming a session that was
+    // never written (claude exited 0 without a conversation) surfaces the
+    // "No conversation found with session ID" error and a dead tab.
+    if (sess.claudeSessionId && sess.resumable) {
       try {
         const r = await window.husk.sessions.resumeCommand({ agent, id: sess.claudeSessionId, cwd: sess.cwd || '' });
         if (r && r.ok && r.command) resumeCmd = r.command;
@@ -1314,8 +1480,11 @@ setInterval(syncTabTitles, 5000);
 // ─── Theme + accent ─────────────────────────────────────────────────────────────
 function retintAllTabs() {
   const theme = themeForXterm();
-  for (const t of TABS.values()) { try { t.term.options.theme = theme; } catch (_) {} }
-  try { if (wfTerm) wfTerm.options.theme = theme; } catch (_) {}
+  const contrast = contrastForXterm();
+  for (const t of TABS.values()) {
+    try { t.term.options.theme = theme; t.term.options.minimumContrastRatio = contrast; } catch (_) {}
+  }
+  try { if (wfTerm) { wfTerm.options.theme = theme; wfTerm.options.minimumContrastRatio = contrast; } } catch (_) {}
 }
 function applyTheme(theme) {
   document.body.dataset.theme = theme;
@@ -1980,7 +2149,7 @@ async function deleteProject(id, name) {
   function openProjectModal() {
     if (!modal) return;
     if (nameEl) nameEl.value = '';
-    if (pathEl) pathEl.value = '';
+    if (pathEl) { pathEl.value = ''; pathEl.classList.remove('field-invalid'); }
     modal.hidden = false;
     setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30);
   }
@@ -1988,11 +2157,17 @@ async function deleteProject(id, name) {
   async function submit() {
     let name = (nameEl && nameEl.value || '').trim();
     const projPath = (pathEl && pathEl.value || '').trim();
-    if (!name && projPath) name = projPath.split('/').filter(Boolean).pop() || 'project';
+    // Folder is required; the name is optional and derived from the path.
+    if (pathEl) pathEl.classList.remove('field-invalid');
+    if (!projPath) {
+      if (pathEl) { pathEl.classList.add('field-invalid'); pathEl.focus(); }
+      toast('Folder is required', 'error');
+      return;
+    }
+    if (!name) name = projPath.split('/').filter(Boolean).pop() || 'project';
     const res = await window.husk.projects.create({ name, path: projPath });
     if (!res || !res.ok) {
-      const t = document.getElementById('toast');
-      if (t) { t.textContent = (res && res.error) || 'Could not add project'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
+      toast((res && res.error) || 'Could not add project', 'error');
       return;
     }
     closeProjectModal();
@@ -2003,9 +2178,13 @@ async function deleteProject(id, name) {
   if (cancelBtn) cancelBtn.addEventListener('click', closeProjectModal);
   if (createBtn) createBtn.addEventListener('click', submit);
   if (pickEl) pickEl.addEventListener('click', async () => {
-    try { const picked = await window.husk.dialog2.pickDir(); if (picked && pathEl) pathEl.value = picked; } catch (_) {}
+    try { const picked = await window.husk.dialog2.pickDir(); if (picked && pathEl) { pathEl.value = picked; pathEl.classList.remove('field-invalid'); } } catch (_) {}
   });
-  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeProjectModal(); });
+  if (pathEl) pathEl.addEventListener('input', () => pathEl.classList.remove('field-invalid'));
+  // Close only via Cancel or Escape; a backdrop click must not discard the form.
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal && !modal.hidden) closeProjectModal();
+  });
 
   // Topbar chip click navigates to Projects page.
   const chip = document.getElementById('topbar-project');
@@ -2048,7 +2227,9 @@ function wfShowView(name) {
   $('#wf-run-view').hidden = name !== 'run';
 }
 
+let wfKernelUnmount = null;
 async function renderWorkflows() {
+  if (wfKernelUnmount) { wfKernelUnmount(); wfKernelUnmount = null; }
   const grid = $('#wf-grid');
   if (!grid) return;
   workflowsCache = await window.husk.workflows.list();
@@ -2193,8 +2374,84 @@ function paintWorkflowList() {
   }
 
   if (!workflowsCache.length) {
-    // eslint-disable-next-line no-unsanitized/property -- static markup
-    grid.innerHTML = `<div class="empty-state"><div class="es-icon">${ICONS.workflows}</div><div class="es-title">No workflows yet</div><div class="es-msg">Build a pipeline by chaining agents together. Each step feeds its output to the next.</div></div>`;
+    // eslint-disable-next-line no-unsanitized/property -- static markup, no interpolation
+    grid.innerHTML = `<div class="empty-state es-kernel">
+      <div class="ek-stage">
+        <svg class="ek-graph" viewBox="0 0 480 280" aria-hidden="true">
+          <defs>
+            <linearGradient id="ek-ic" x1="0" y1="0" x2="1" y2="1"><stop offset="0" class="ek-ic0"/><stop offset="1" class="ek-ic1"/></linearGradient>
+          </defs>
+          <path class="ek-wire" d="M222,128 C 202,102 192,80 178,64"/>
+          <path class="ek-wire" d="M218,164 C 198,188 184,206 164,216"/>
+          <path class="ek-wire" d="M258,128 C 278,102 288,80 302,64"/>
+          <path class="ek-wire" d="M262,164 C 282,188 298,206 316,216"/>
+          <path class="ek-wire ek-wire-2" d="M118,64 C 98,74 82,92 64,103"/>
+          <path class="ek-wire ek-wire-2" d="M104,216 C 86,228 72,242 56,251"/>
+          <path class="ek-wire ek-wire-2" d="M362,64 C 382,74 398,92 416,103"/>
+          <path class="ek-wire ek-wire-2" d="M376,216 C 394,228 408,242 424,251"/>
+          <path class="ek-flow" pathLength="100" d="M222,128 C 202,102 192,80 178,64"/>
+          <path class="ek-flow" pathLength="100" d="M218,164 C 198,188 184,206 164,216"/>
+          <path class="ek-flow" pathLength="100" d="M258,128 C 278,102 288,80 302,64"/>
+          <path class="ek-flow" pathLength="100" d="M262,164 C 282,188 298,206 316,216"/>
+          <g class="ek-node" transform="translate(118,44)">
+            <rect class="ek-card" x="0" y="0" width="60" height="40" rx="10"/>
+            <rect class="ek-node-icon" x="10" y="11" width="12" height="12" rx="3.5"/>
+            <rect class="ek-node-l1" x="27" y="12.5" width="23" height="4.5" rx="2.25"/>
+            <rect class="ek-node-l2" x="10" y="28" width="40" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node" transform="translate(104,196)">
+            <rect class="ek-card" x="0" y="0" width="60" height="40" rx="10"/>
+            <rect class="ek-node-icon" x="10" y="11" width="12" height="12" rx="3.5"/>
+            <rect class="ek-node-l1" x="27" y="12.5" width="20" height="4.5" rx="2.25"/>
+            <rect class="ek-node-l2" x="10" y="28" width="36" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node" transform="translate(302,44)">
+            <rect class="ek-card" x="0" y="0" width="60" height="40" rx="10"/>
+            <rect class="ek-node-icon" x="10" y="11" width="12" height="12" rx="3.5"/>
+            <rect class="ek-node-l1" x="27" y="12.5" width="24" height="4.5" rx="2.25"/>
+            <rect class="ek-node-l2" x="10" y="28" width="34" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node" transform="translate(316,196)">
+            <rect class="ek-card" x="0" y="0" width="60" height="40" rx="10"/>
+            <rect class="ek-node-icon" x="10" y="11" width="12" height="12" rx="3.5"/>
+            <rect class="ek-node-l1" x="27" y="12.5" width="22" height="4.5" rx="2.25"/>
+            <rect class="ek-node-l2" x="10" y="28" width="38" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node ek-sub" transform="translate(18,88)">
+            <rect class="ek-card" x="0" y="0" width="46" height="30" rx="8"/>
+            <rect class="ek-node-icon" x="8" y="9" width="10" height="10" rx="3"/>
+            <rect class="ek-node-l1" x="22" y="11" width="15" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node ek-sub" transform="translate(10,236)">
+            <rect class="ek-card" x="0" y="0" width="46" height="30" rx="8"/>
+            <rect class="ek-node-icon" x="8" y="9" width="10" height="10" rx="3"/>
+            <rect class="ek-node-l1" x="22" y="11" width="13" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node ek-sub" transform="translate(416,88)">
+            <rect class="ek-card" x="0" y="0" width="46" height="30" rx="8"/>
+            <rect class="ek-node-icon" x="8" y="9" width="10" height="10" rx="3"/>
+            <rect class="ek-node-l1" x="22" y="11" width="16" height="3.5" rx="1.75"/>
+          </g>
+          <g class="ek-node ek-sub" transform="translate(424,236)">
+            <rect class="ek-card" x="0" y="0" width="46" height="30" rx="8"/>
+            <rect class="ek-node-icon" x="8" y="9" width="10" height="10" rx="3"/>
+            <rect class="ek-node-l1" x="22" y="11" width="14" height="3.5" rx="1.75"/>
+          </g>
+          <circle class="ek-dot" cx="178" cy="64" r="3.4"/>
+          <circle class="ek-dot" cx="164" cy="216" r="3.4"/>
+          <circle class="ek-dot" cx="302" cy="64" r="3.4"/>
+          <circle class="ek-dot" cx="316" cy="216" r="3.4"/>
+          <circle class="ek-dot ek-dot-2" cx="64" cy="103" r="2.8"/>
+          <circle class="ek-dot ek-dot-2" cx="56" cy="251" r="2.8"/>
+          <circle class="ek-dot ek-dot-2" cx="416" cy="103" r="2.8"/>
+          <circle class="ek-dot ek-dot-2" cx="424" cy="251" r="2.8"/>
+        </svg>
+        <div class="ek-slot"></div>
+      </div>
+      <div class="es-title">No workflows yet</div>
+      <div class="es-msg">Build a pipeline by chaining agents together. Each step feeds its output to the next.</div>
+    </div>`;
+    wfKernelUnmount = mountEmptyKernel(grid.querySelector('.ek-slot'));
     return;
   }
 
@@ -2364,7 +2621,27 @@ function wfEnsureEditor() {
   // removed from its config panel, and the popover rendered as a stray black box.
   const cont = $('#wf-canvas');
   if (cont) cont.addEventListener('contextmenu', (e) => e.preventDefault());
-  wfEditor.on('nodeSelected', (id) => { hideEdgePanel(); showNodePanel(id); });
+  // Open the config modal only on a real click: mousedown then mouseup on the
+  // same node without dragging. Dragging a node to reposition it must NOT open
+  // the wizard. Drawflow keeps owning selection and drag; we just detect a click
+  // on mouseup, after Drawflow has already ended its own drag.
+  let wfDownNodeEl = null, wfDownX = 0, wfDownY = 0, wfNodeMoved = false;
+  if (cont) {
+    cont.addEventListener('mousedown', (e) => {
+      const nodeEl = e.target.closest ? e.target.closest('.drawflow-node') : null;
+      // Ignore the connector dots so starting a connection never opens the modal.
+      if (!nodeEl || (e.target.closest && e.target.closest('.input, .output'))) { wfDownNodeEl = null; return; }
+      wfDownNodeEl = nodeEl; wfDownX = e.clientX; wfDownY = e.clientY; wfNodeMoved = false;
+    });
+    cont.addEventListener('mousemove', (e) => {
+      if (wfDownNodeEl && (Math.abs(e.clientX - wfDownX) > 4 || Math.abs(e.clientY - wfDownY) > 4)) wfNodeMoved = true;
+    });
+    cont.addEventListener('mouseup', () => {
+      const el = wfDownNodeEl; wfDownNodeEl = null;
+      if (el && !wfNodeMoved && el.id) showNodePanel(el.id.slice(5));
+    });
+  }
+  wfEditor.on('nodeSelected', () => { hideEdgePanel(); });
   wfEditor.on('nodeUnselected', () => hideNodePanel());
   wfEditor.on('nodeRemoved', () => hideNodePanel());
   wfEditor.on('connectionSelected', (c) => { hideNodePanel(); showEdgePanel(c); });
@@ -2466,6 +2743,8 @@ function showNodePanel(id) {
   $('#wf-np-agent').innerHTML = buildAgentOptions(d.agentCommand || '');
   $('#wf-np-context').value = d.passContext || 'full';
   $('#wf-np-prompt').value = d.prompt || '';
+  wfClearGenState();
+  wfUpdateGutter();
   const branchSel = $('#wf-np-branch');
   if (branchSel) branchSel.value = d.branchMode === 'ai' ? 'ai' : 'parallel';
   const outCount = wfEditor.export ? wfCountOutgoing(id) : 0;
@@ -2551,6 +2830,8 @@ function hideNodePanel() {
   wfSelectedNodeId = null;
   const panel = $('#wf-node-panel');
   if (panel) panel.hidden = true;
+  wfClearGenState();
+  wfDeselectNode();
 }
 
 function showEdgePanel(conn) {
@@ -2938,6 +3219,7 @@ function wfEnsureTerm() {
     disableStdin: true,
     scrollback: 5000,
     theme: themeForXterm(),
+    minimumContrastRatio: contrastForXterm(),
     allowTransparency: true,
   });
   try {
@@ -3394,6 +3676,111 @@ $('#wf-np-model-refresh') && $('#wf-np-model-refresh').addEventListener('click',
   wfLoadNodeModels(wfAgentCommandForPanel(), pinned, { refresh: true });
 });
 $('#wf-node-panel-close') && $('#wf-node-panel-close').addEventListener('click', hideNodePanel);
+$('#wf-node-panel-done') && $('#wf-node-panel-done').addEventListener('click', hideNodePanel);
+// Escape: dismiss a pending AI suggestion first, otherwise close the modal.
+// No backdrop-close: a stray click must not discard a half-written prompt.
+window.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+  const rev = $('#wf-gen-review');
+  if (rev && !rev.hidden) { $('#wf-gen-discard') && $('#wf-gen-discard').click(); return; }
+  if (!$('#wf-node-panel').hidden) hideNodePanel();
+});
+
+// ── Node config: drawflow release, mini-IDE gutter, AI generate with review ──
+const WF_PROMPT_MIN = 12;
+// Opening the modal on Drawflow's mousedown-select leaves the node mid-drag (its
+// mouseup lands on the modal overlay, not the canvas). Clear the drag flags so
+// the node stops following the cursor once the modal closes.
+// Closing the modal must also drop Drawflow's selection so the node is not left
+// highlighted (which otherwise needs an extra canvas click to clear).
+function wfDeselectNode() {
+  if (!wfEditor) return;
+  try { const el = wfEditor.node_selected; if (el && el.classList) el.classList.remove('selected'); wfEditor.node_selected = null; } catch (_) {}
+  document.querySelectorAll('#wf-canvas .drawflow-node.selected').forEach((n) => n.classList.remove('selected'));
+}
+function wfUpdateGutter() {
+  const ta = $('#wf-np-prompt');
+  const gut = $('#wf-np-gutter');
+  if (!ta || !gut) return;
+  const lines = (ta.value.match(/\n/g) || []).length + 1;
+  let s = '1';
+  for (let i = 2; i <= lines; i++) s += '\n' + i;
+  gut.textContent = s;
+  gut.scrollTop = ta.scrollTop;
+}
+function wfClearGenState() {
+  const ide = $('#wf-ide'); if (ide) ide.classList.remove('field-invalid');
+  const st = $('#wf-np-gen-status'); if (st) { st.hidden = true; st.textContent = ''; st.classList.remove('is-error'); }
+  const rev = $('#wf-gen-review'); if (rev) rev.hidden = true;
+  wfPendingSuggestion = '';
+}
+function wfGenError(msg) {
+  const ide = $('#wf-ide'); if (ide) ide.classList.add('field-invalid');
+  const st = $('#wf-np-gen-status'); if (st) { st.hidden = false; st.textContent = msg; st.classList.add('is-error'); }
+  toast(msg, 'error');
+  const ta = $('#wf-np-prompt'); if (ta) ta.focus();
+}
+let wfPendingSuggestion = '';
+function wfShowGenReview(text) {
+  wfPendingSuggestion = text;
+  const body = $('#wf-gen-review-text'); if (body) body.textContent = text;
+  const rev = $('#wf-gen-review'); if (rev) rev.hidden = false;
+}
+{
+  const ta = $('#wf-np-prompt');
+  if (ta) {
+    ta.addEventListener('input', () => {
+      wfUpdateGutter();
+      const ide = $('#wf-ide'); if (ide) ide.classList.remove('field-invalid');
+      const st = $('#wf-np-gen-status'); if (st && st.classList.contains('is-error')) { st.hidden = true; st.classList.remove('is-error'); }
+    });
+    ta.addEventListener('scroll', () => { const g = $('#wf-np-gutter'); if (g) g.scrollTop = ta.scrollTop; });
+  }
+}
+$('#wf-np-generate') && $('#wf-np-generate').addEventListener('click', async () => {
+  const btn = $('#wf-np-generate');
+  const promptEl = $('#wf-np-prompt');
+  const statusEl = $('#wf-np-gen-status');
+  if (!promptEl) return;
+  const seed = (promptEl.value || '').trim();
+  // Refuse to generate from nothing: the AI improves what you have, it cannot
+  // invent the step's goal. Mark the field and say exactly what's needed.
+  if (seed.length < WF_PROMPT_MIN) {
+    wfGenError(`Write at least ${WF_PROMPT_MIN} characters describing this step first. The AI improves your draft, it can't invent the goal.`);
+    return;
+  }
+  wfClearGenState();
+  btn.disabled = true;
+  if (statusEl) { statusEl.hidden = false; statusEl.classList.remove('is-error'); statusEl.textContent = 'Generating…'; }
+  try {
+    const res = await window.husk.workflows.generateStepPrompt(seed);
+    if (res && res.ok && res.prompt) {
+      if (statusEl) statusEl.hidden = true;
+      wfShowGenReview(res.prompt);
+    } else {
+      wfGenError((res && res.error) || 'Generation failed. Check that the agent CLI is installed and authenticated.');
+    }
+  } catch (_) {
+    wfGenError('Generation failed. Check that the agent CLI is installed and authenticated.');
+  } finally {
+    btn.disabled = false;
+  }
+});
+$('#wf-gen-discard') && $('#wf-gen-discard').addEventListener('click', () => {
+  wfPendingSuggestion = '';
+  const rev = $('#wf-gen-review'); if (rev) rev.hidden = true;
+  const ta = $('#wf-np-prompt'); if (ta) ta.focus();
+});
+$('#wf-gen-use') && $('#wf-gen-use').addEventListener('click', () => {
+  const ta = $('#wf-np-prompt');
+  if (ta && wfPendingSuggestion) {
+    ta.value = wfPendingSuggestion;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+    wfUpdateGutter();
+  }
+  wfPendingSuggestion = '';
+  const rev = $('#wf-gen-review'); if (rev) rev.hidden = true;
+});
 $('#wf-edge-panel-close') && $('#wf-edge-panel-close').addEventListener('click', hideEdgePanel);
 $('#wf-ec-type') && $('#wf-ec-type').addEventListener('change', wfSyncEdgePanel);
 $('#wf-ec-value') && $('#wf-ec-value').addEventListener('input', wfSyncEdgePanel);
@@ -3620,7 +4007,12 @@ async function saveAgentModal() {
   const description = (($('#agent-description') || {}).value || '').trim();
   const systemPrompt = (($('#agent-system-prompt') || {}).value || '').trim();
   const autoSelect = !!(($('#agent-autoselect') || {}).checked);
-  if (!name) { toast('Name is required', 'error'); return; }
+  if ($('#agent-name')) $('#agent-name').classList.remove('field-invalid');
+  if (!name) {
+    toast('Name is required', 'error');
+    if ($('#agent-name')) { $('#agent-name').classList.add('field-invalid'); $('#agent-name').focus(); }
+    return;
+  }
   let res;
   if (editingProfileId) {
     res = await window.husk.profiles.update({ id: editingProfileId, name, description, systemPrompt, autoSelect });
@@ -4203,6 +4595,7 @@ $('#repo-mcp-modal') && $('#repo-mcp-modal').addEventListener('click', (e) => { 
 $('#agent-modal-close') && $('#agent-modal-close').addEventListener('click', closeAgentModal);
 $('#agent-modal-cancel') && $('#agent-modal-cancel').addEventListener('click', closeAgentModal);
 $('#agent-modal-save') && $('#agent-modal-save').addEventListener('click', saveAgentModal);
+$('#agent-name') && $('#agent-name').addEventListener('input', () => $('#agent-name').classList.remove('field-invalid'));
 $('#btn-deactivate-all') && $('#btn-deactivate-all').addEventListener('click', () => deactivateAllProfiles());
 $('#btn-select-all-agents') && $('#btn-select-all-agents').addEventListener('click', () => activateAllProfiles());
 $('#btn-deselect-all-agents') && $('#btn-deselect-all-agents').addEventListener('click', () => deactivateAllProfiles());
@@ -4342,11 +4735,13 @@ async function previewPrompt(mdPath) {
   const bodyEl = document.getElementById('np-content');
   const cancelBtn = document.getElementById('np-cancel');
   const createBtn = document.getElementById('np-create');
+  function clearInvalid() { [nameEl, descEl].forEach((el) => el && el.classList.remove('field-invalid')); }
   function openNewPrompt() {
     if (!modal) return;
     if (nameEl) nameEl.value = '';
     if (descEl) descEl.value = '';
     if (bodyEl) bodyEl.value = '';
+    clearInvalid();
     modal.hidden = false;
     setTimeout(() => { try { nameEl && nameEl.focus(); } catch (_) {} }, 30);
   }
@@ -4355,10 +4750,27 @@ async function previewPrompt(mdPath) {
     const name = (nameEl && nameEl.value || '').trim();
     const description = (descEl && descEl.value || '').trim();
     const content = bodyEl && bodyEl.value || '';
+    // Both fields are required by the backend; validate here so the user sees
+    // exactly which field is missing instead of a generic save failure.
+    clearInvalid();
+    if (!name) {
+      if (nameEl) { nameEl.classList.add('field-invalid'); nameEl.focus(); }
+      toast('Name is required', 'error');
+      return;
+    }
+    if (!/^[a-z][a-z0-9-]*$/.test(name)) {
+      if (nameEl) { nameEl.classList.add('field-invalid'); nameEl.focus(); }
+      toast('Name must be lowercase letters, digits, dashes; start with a letter.', 'error');
+      return;
+    }
+    if (!description) {
+      if (descEl) { descEl.classList.add('field-invalid'); descEl.focus(); }
+      toast('Description is required', 'error');
+      return;
+    }
     const res = await window.husk.prompts.create({ name, description, content });
     if (!res || !res.ok) {
-      const t = document.getElementById('toast');
-      if (t) { t.textContent = (res && res.error) || 'Could not create prompt'; t.hidden = false; setTimeout(() => { t.hidden = true; }, 3500); }
+      toast((res && res.error) || 'Could not create prompt', 'error');
       return;
     }
     closeNewPrompt();
@@ -4367,7 +4779,13 @@ async function previewPrompt(mdPath) {
   if (newBtn) newBtn.addEventListener('click', openNewPrompt);
   if (cancelBtn) cancelBtn.addEventListener('click', closeNewPrompt);
   if (createBtn) createBtn.addEventListener('click', submitNewPrompt);
-  if (modal) modal.addEventListener('click', (e) => { if (e.target === modal) closeNewPrompt(); });
+  // Drop the invalid-field highlight the moment the user starts fixing it.
+  [nameEl, descEl].forEach((el) => el && el.addEventListener('input', () => el.classList.remove('field-invalid')));
+  // Close only via Cancel or Escape. A backdrop click must not dismiss the
+  // modal, so half-written prompts survive an accidental outside click.
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal && !modal.hidden) closeNewPrompt();
+  });
 }
 
 // ─── Skills page ──────────────────────────────────────────────────────────────
@@ -4513,26 +4931,31 @@ function openCreateSkillModal() {
   $('#ns-name').value = '';
   $('#ns-desc').value = '';
   $('#ns-content').value = '';
+  $('#ns-name').classList.remove('field-invalid');
+  $('#ns-desc').classList.remove('field-invalid');
   $('#new-skill-modal').hidden = false;
   setTimeout(() => $('#ns-name').focus(), 50);
 }
 function closeCreateSkillModal() { $('#new-skill-modal').hidden = true; }
 $('#ns-cancel').addEventListener('click', closeCreateSkillModal);
-$('#new-skill-modal').addEventListener('click', (e) => { if (e.target.id === 'new-skill-modal') closeCreateSkillModal(); });
+// Close only via Cancel or Escape; a backdrop click must not discard the form.
 window.addEventListener('keydown', (e) => {
   if (e.key === 'Escape' && !$('#new-skill-modal').hidden) closeCreateSkillModal();
 });
+[$('#ns-name'), $('#ns-desc')].forEach((el) => el && el.addEventListener('input', () => el.classList.remove('field-invalid')));
 
 async function submitCreateSkill() {
   const name = $('#ns-name').value.trim().toLowerCase();
   const description = $('#ns-desc').value.trim();
   const content = $('#ns-content').value;
-  if (!name) { toast('Name is required', 'error'); $('#ns-name').focus(); return; }
+  $('#ns-name').classList.remove('field-invalid');
+  $('#ns-desc').classList.remove('field-invalid');
+  if (!name) { toast('Name is required', 'error'); $('#ns-name').classList.add('field-invalid'); $('#ns-name').focus(); return; }
   if (!/^[a-z][a-z0-9-]*$/.test(name)) {
     toast('Name must be lowercase letters, digits, dashes; start with a letter.', 'error');
-    $('#ns-name').focus(); return;
+    $('#ns-name').classList.add('field-invalid'); $('#ns-name').focus(); return;
   }
-  if (!description) { toast('Description is required', 'error'); $('#ns-desc').focus(); return; }
+  if (!description) { toast('Description is required', 'error'); $('#ns-desc').classList.add('field-invalid'); $('#ns-desc').focus(); return; }
   const r = await window.husk.skills.create({ name, description, content });
   if (r.ok) {
     toast(`Skill created: ${name} · restart agent to load it`, 'success');
@@ -7481,7 +7904,9 @@ $('#btn-new-session').addEventListener('click', () => openNewChatTab());
 const settleZoom = debounce((lvl) => {
   const base = (window.husk.ui && typeof window.husk.ui.zoomBase === 'number') ? window.husk.ui.zoomBase : 0;
   const pct = Math.round(Math.pow(1.2, lvl - base) * 100);
-  toast(`Zoom: ${pct}%`, 'success');
+  // Keyed, so stepping the zoom rewrites one readout instead of stacking a
+  // card per step.
+  notify(`Zoom: ${pct}%`, { kind: 'success', key: 'zoom' });
   fitNow();
 }, 120);
 function reportZoom(lvl) { settleZoom(lvl); }
@@ -8243,6 +8668,7 @@ function openAutopilotStart() {
   if (noProj) noProj.hidden = hasProject;
   if (body) body.hidden = !hasProject;
   if (foot) foot.hidden = !hasProject;
+  $('#aut-goal').classList.remove('field-invalid');
   $('#autopilot-start-modal').hidden = false;
   if (hasProject) setTimeout(() => { try { $('#aut-goal').focus(); } catch (_) {} }, 0);
 }
@@ -8264,7 +8690,14 @@ function readCapField(id, def) {
   return { value: n };
 }
 async function startAutopilot() {
-  const goal = ($('#aut-goal').value || '').trim();
+  const goalEl = $('#aut-goal');
+  const goal = (goalEl && goalEl.value || '').trim();
+  // A run with no goal just burns tokens; require one before launching.
+  if (!goal) {
+    toast('Goal is required', 'error');
+    if (goalEl) { goalEl.classList.add('field-invalid'); goalEl.focus(); }
+    return;
+  }
   const cMin = readCapField('#aut-cap-min', 60);
   const cTok = readCapField('#aut-cap-tok', 200000);
   const cUsd = readCapField('#aut-cap-usd', 5);
@@ -8503,6 +8936,9 @@ const AUTOPILOT_PRESETS = [
 ];
 
 function renderAutopilotPage() {
+  // Mount the real Kernel into the hero art once (the slot lives in the hero).
+  const kSlot = document.querySelector('.aut-kernel-slot');
+  if (kSlot && !kSlot.querySelector('svg')) mountEmptyKernel(kSlot);
   // The dollar figure means different things on an API key vs a plan; learn
   // which so the label is honest before any numbers paint.
   refreshAutBilling();
@@ -10866,6 +11302,7 @@ $('#btn-autopilot') && $('#btn-autopilot').addEventListener('click', () => {
 $('#aut-start-close') && $('#aut-start-close').addEventListener('click', closeAutopilotStart);
 $('#aut-start-cancel') && $('#aut-start-cancel').addEventListener('click', closeAutopilotStart);
 $('#aut-start-go') && $('#aut-start-go').addEventListener('click', startAutopilot);
+$('#aut-goal') && $('#aut-goal').addEventListener('input', () => $('#aut-goal').classList.remove('field-invalid'));
 // Segmented mode control: Solo (one agent) or Team (orchestrated collab).
 // Team shows its explainer; the orchestrator decides the team size, so there
 // is no count to pick.

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -322,7 +322,7 @@
       </button>
       <div class="topbar-spacer"></div>
       <button class="iconbtn" id="btn-palette" title="Command palette (Ctrl+K)">⌘K</button>
-      <button class="iconbtn iconbtn-primary" id="btn-new-session" title="New chat session (restarts the agent)">+ New Chat</button>
+      <button class="iconbtn iconbtn-primary" id="btn-new-session" title="New chat session (restarts the agent)"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> New Chat</button>
       <button class="iconbtn iconbtn-square" id="btn-status-toggle" title="Toggle status panel" aria-label="Toggle status panel">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <rect x="3" y="4" width="18" height="16" rx="2"/><path d="M15 4v16"/>
@@ -507,7 +507,7 @@
                 <span class="wf-stats" id="wf-stats"></span>
               </div>
               <div class="page-head-right">
-                <button class="btn-primary" id="btn-new-workflow">+ New Workflow</button>
+                <button class="btn-primary" id="btn-new-workflow"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> New Workflow</button>
               </div>
             </div>
             <div class="page-body">
@@ -563,51 +563,83 @@
               <div class="wf-canvas-wrap">
                 <div id="wf-canvas" class="wf-canvas"></div>
                 <div class="wf-canvas-hint" id="wf-canvas-hint">Drag from a node's right dot to another node's left dot to connect them. Click a node to edit it.</div>
-                <aside class="wf-node-panel" id="wf-node-panel" hidden>
-                  <div class="wf-node-panel-head">
-                    <span class="wf-node-panel-title">Step</span>
-                    <button class="wf-node-panel-close" id="wf-node-panel-close" aria-label="Close">&times;</button>
+                <div class="wf-drawer" id="wf-node-panel" hidden>
+                  <div class="wf-drawer-scrim" aria-hidden="true"></div>
+                  <div class="wf-drawer-panel" role="dialog" aria-label="Configure step">
+                    <div class="wf-nm-head">
+                      <div class="wf-nm-head-title">
+                        <span class="wf-nm-head-badge"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 4v10l-7 4-7-4V7z"/></svg></span>
+                        <span class="wf-node-panel-title">Configure step</span>
+                      </div>
+                      <button class="wf-node-panel-close" id="wf-node-panel-close" aria-label="Close">&times;</button>
+                    </div>
+                    <div class="wf-drawer-body">
+                      <div class="form-row">
+                        <label class="form-label">Name</label>
+                        <input class="form-input" id="wf-np-name" type="text" maxlength="64" />
+                      </div>
+                      <div class="form-row">
+                        <label class="form-label">Agent</label>
+                        <select class="wf-step-select" id="wf-np-agent"></select>
+                      </div>
+                      <div class="form-row">
+                        <label class="form-label">
+                          Model
+                          <button class="wf-np-model-refresh" id="wf-np-model-refresh" type="button" title="Reload this agent's models">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.5 9a9 9 0 0 1 14.9-3.4L23 10M1 14l4.6 4.4A9 9 0 0 0 20.5 15"/></svg>
+                          </button>
+                        </label>
+                        <select class="wf-step-select" id="wf-np-model"></select>
+                        <input class="form-input wf-np-model-custom" id="wf-np-model-custom" type="text" placeholder="model id, e.g. claude-fable-5[1m]" hidden />
+                        <div class="wf-np-model-hint" id="wf-np-model-hint"></div>
+                      </div>
+                      <div class="form-row" id="wf-np-branch-row" hidden>
+                        <label class="form-label">When this step has multiple next steps</label>
+                        <select class="wf-step-select" id="wf-np-branch">
+                          <option value="parallel">Run all of them (parallel)</option>
+                          <option value="ai">Let this agent pick one (AI routing)</option>
+                        </select>
+                      </div>
+                      <div class="form-row">
+                        <label class="form-label">Context from previous</label>
+                        <select class="wf-step-select" id="wf-np-context">
+                          <option value="full">Full output</option>
+                          <option value="last50">Last 50 lines</option>
+                          <option value="none">None</option>
+                        </select>
+                      </div>
+                      <div class="wf-nm-editor">
+                        <div class="wf-nm-editor-head">
+                          <label class="form-label" for="wf-np-prompt">Prompt</label>
+                          <button class="ghost-btn wf-nm-generate" id="wf-np-generate" type="button" title="Improve this prompt with AI">
+                            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.4 7.2L22 12l-7.6 2.4L12 22l-2.4-7.6L2 12l7.6-2.4z"/></svg>
+                            Generate with AI
+                          </button>
+                        </div>
+                        <div class="wf-ide" id="wf-ide">
+                          <div class="wf-ide-gutter" id="wf-np-gutter" aria-hidden="true">1</div>
+                          <textarea class="wf-ide-input" id="wf-np-prompt" wrap="off" maxlength="8192" spellcheck="false" placeholder="What should this step do? Write a rough idea, then Generate with AI to polish it."></textarea>
+                          <div class="wf-gen-review" id="wf-gen-review" hidden>
+                            <div class="wf-gen-review-head">
+                              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.4 7.2L22 12l-7.6 2.4L12 22l-2.4-7.6L2 12l7.6-2.4z"/></svg>
+                              AI suggestion
+                            </div>
+                            <div class="wf-gen-review-text" id="wf-gen-review-text"></div>
+                            <div class="wf-gen-review-foot">
+                              <button class="ghost-btn" id="wf-gen-discard" type="button">Discard</button>
+                              <button class="btn-primary" id="wf-gen-use" type="button">Use this prompt</button>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="wf-nm-gen-status" id="wf-np-gen-status" hidden></div>
+                      </div>
+                    </div>
+                    <div class="wf-nm-foot">
+                      <button class="ghost-btn ghost-btn-danger" id="wf-np-delete">Delete node</button>
+                      <button class="btn-primary" id="wf-node-panel-done">Done</button>
+                    </div>
                   </div>
-                  <div class="form-row">
-                    <label class="form-label">Name</label>
-                    <input class="form-input" id="wf-np-name" type="text" maxlength="64" />
-                  </div>
-                  <div class="form-row">
-                    <label class="form-label">Agent</label>
-                    <select class="wf-step-select" id="wf-np-agent"></select>
-                  </div>
-                  <div class="form-row">
-                    <label class="form-label">
-                      Model
-                      <button class="wf-np-model-refresh" id="wf-np-model-refresh" type="button" title="Reload this agent's models">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="12" height="12"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.5 9a9 9 0 0 1 14.9-3.4L23 10M1 14l4.6 4.4A9 9 0 0 0 20.5 15"/></svg>
-                      </button>
-                    </label>
-                    <select class="wf-step-select" id="wf-np-model"></select>
-                    <input class="form-input wf-np-model-custom" id="wf-np-model-custom" type="text" placeholder="model id, e.g. claude-fable-5[1m]" hidden />
-                    <div class="wf-np-model-hint" id="wf-np-model-hint"></div>
-                  </div>
-                  <div class="form-row" id="wf-np-branch-row" hidden>
-                    <label class="form-label">When this step has multiple next steps</label>
-                    <select class="wf-step-select" id="wf-np-branch">
-                      <option value="parallel">Run all of them (parallel)</option>
-                      <option value="ai">Let this agent pick one (AI routing)</option>
-                    </select>
-                  </div>
-                  <div class="form-row">
-                    <label class="form-label">Context from previous</label>
-                    <select class="wf-step-select" id="wf-np-context">
-                      <option value="full">Full output</option>
-                      <option value="last50">Last 50 lines</option>
-                      <option value="none">None</option>
-                    </select>
-                  </div>
-                  <div class="form-row">
-                    <label class="form-label">Prompt</label>
-                    <textarea class="form-input form-textarea" id="wf-np-prompt" rows="7" maxlength="8192" placeholder="What should this step do?"></textarea>
-                  </div>
-                  <button class="ghost-btn ghost-btn-danger" id="wf-np-delete">Delete node</button>
-                </aside>
+                </div>
                 <aside class="wf-node-panel" id="wf-edge-panel" hidden>
                   <div class="wf-node-panel-head">
                     <span class="wf-node-panel-title">Connection</span>
@@ -728,6 +760,35 @@
 
           <div class="aut-page-empty" id="aut-page-empty">
             <section class="aut-hero">
+              <div class="aut-hero-art" aria-hidden="true">
+                <svg class="aut-plane" viewBox="0 0 340 230">
+                  <defs><linearGradient id="aut-fuse" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#fbeecb"/><stop offset="1" stop-color="#e4cc95"/></linearGradient><g id="aut-cloud"><ellipse cx="0" cy="7" rx="30" ry="9"/><circle cx="-17" cy="3" r="10"/><circle cx="-3" cy="-5" r="13"/><circle cx="13" cy="-1" r="11"/><circle cx="24" cy="4" r="8"/></g></defs>
+                  <g class="aut-speed" stroke="var(--accent)" stroke-width="3.5" stroke-linecap="round" opacity="0.5"><line x1="14" y1="122" x2="48" y2="122"/><line x1="4" y1="144" x2="42" y2="144"/><line x1="22" y1="166" x2="50" y2="166"/></g>
+                  <g class="aut-clouds"><use href="#aut-cloud" transform="translate(56,188)" opacity="0.55"/><use href="#aut-cloud" transform="translate(300,70) scale(1)" opacity="0.4"/><use href="#aut-cloud" transform="translate(152,206) scale(0.66)" opacity="0.34"/></g>
+                  <path class="aut-p-accent" d="M92,152 L70,114 L90,126 L104,150 Z"/>
+                  <path class="aut-p-accent" d="M150,168 L124,198 L182,180 Z"/>
+                  <path class="aut-p-body" d="M78,152 Q88,128 134,125 L236,125 Q274,127 292,152 Q274,180 236,182 L134,180 Q86,178 78,152 Z"/>
+                  <circle cx="150" cy="152" r="6.5" fill="#7fb7c9"/><circle cx="150" cy="152" r="6.5" fill="none" stroke="#d8c290" stroke-width="1.5"/>
+                  <circle cx="172" cy="154" r="5.5" fill="#7fb7c9"/><circle cx="172" cy="154" r="5.5" fill="none" stroke="#d8c290" stroke-width="1.5"/>
+                  <ellipse class="aut-p-accent" cx="298" cy="152" rx="4" ry="26" opacity="0.32"/>
+                  <circle cx="292" cy="152" r="6" fill="#c9762f"/>
+                  <path class="aut-scarf" d="M188,120 Q158,131 133,124 Q121,120 129,137 Q153,143 184,133 Z" fill="#f3f0e6"/>
+                  <ellipse cx="200" cy="130" rx="33" ry="9" fill="#d7bd86"/>
+                </svg>
+                <div class="aut-kernel-slot"></div>
+                <svg class="aut-hat" viewBox="150 44 100 94">
+                  <path d="M177,86 C 177,100 177,112 176,124 C 174,131 168,131 165,126 C 160,116 160,100 161,86 C 160,66 182,52 200,52 C 218,52 240,66 239,86 C 240,100 240,116 235,126 C 232,131 226,131 224,124 C 223,112 223,100 223,86 C 214,80 186,80 177,86 Z" fill="#7c4a26"/>
+                  <path d="M176,64 Q200,55 224,64" stroke="#4a2c14" stroke-width="5" fill="none" stroke-linecap="round"/>
+                  <circle cx="185" cy="64" r="8.5" fill="#2b3340"/><circle cx="185" cy="64" r="8.5" fill="none" stroke="#cfa66a" stroke-width="2.5"/>
+                  <circle cx="215" cy="64" r="8.5" fill="#2b3340"/><circle cx="215" cy="64" r="8.5" fill="none" stroke="#cfa66a" stroke-width="2.5"/>
+                  <circle cx="182" cy="61" r="2.2" fill="#8fb3c9" opacity="0.85"/><circle cx="212" cy="61" r="2.2" fill="#8fb3c9" opacity="0.85"/>
+                </svg>
+                <svg class="aut-plane-front" viewBox="0 0 340 230">
+                  <path class="aut-p-body" d="M118,146 Q188,137 258,146 Q266,160 258,176 Q188,186 122,180 Q112,162 118,146 Z"/>
+                  <circle cx="150" cy="156" r="6" fill="#7fb7c9"/><circle cx="150" cy="156" r="6" fill="none" stroke="#d8c290" stroke-width="1.5"/>
+                  <circle cx="172" cy="158" r="5" fill="#7fb7c9"/><circle cx="172" cy="158" r="5" fill="none" stroke="#d8c290" stroke-width="1.5"/>
+                </svg>
+              </div>
               <div class="aut-hero-eyebrow">AUTOPILOT</div>
               <h2 class="aut-hero-title">Hand off entire tasks.<br/>Reach further while you focus.</h2>
               <p class="aut-hero-body">Husk snapshots your workspace, audits every agent step in a hash-chained log, and caps the run on time, tokens, or dollars. Stop anytime. Revert anything.</p>
@@ -890,7 +951,7 @@
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M5 19h14"/></svg>
                 Import
               </button>
-              <button class="btn-primary" id="btn-new-agent">+ New Agent</button>
+              <button class="btn-primary" id="btn-new-agent"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> New Agent</button>
             </div>
           </div>
           <div class="page-body">
@@ -1086,8 +1147,8 @@
             <!-- Step 2: review / edit -->
             <div id="agent-edit-step" class="modal-body" hidden>
               <div class="form-row">
-                <label class="form-label">Name</label>
-                <input class="form-input" id="agent-name" type="text" maxlength="64" placeholder="Code Reviewer" />
+                <label class="form-label">Name <span class="req" aria-hidden="true">*</span></label>
+                <input class="form-input" id="agent-name" type="text" maxlength="64" placeholder="Code Reviewer" required aria-required="true" />
               </div>
               <div class="form-row">
                 <label class="form-label">Description</label>
@@ -1136,9 +1197,9 @@
               <div class="modal-hint">Short, human-readable. Appears in the Projects grid and the topbar.</div>
             </div>
             <div class="modal-section">
-              <div class="modal-label">Folder</div>
+              <div class="modal-label">Folder <span class="req" aria-hidden="true">*</span></div>
               <span style="display:inline-flex; gap:6px; width:100%;">
-                <input type="text" id="npj-path" placeholder="/path/to/project" autocomplete="off" spellcheck="false" style="flex:1; min-width:0;" />
+                <input type="text" id="npj-path" placeholder="/path/to/project" autocomplete="off" spellcheck="false" required aria-required="true" style="flex:1; min-width:0;" />
                 <button class="ghost-btn" id="npj-pick" type="button">Pick&hellip;</button>
               </span>
               <div class="modal-hint">Must exist. The agent will <code>cd</code> here when this project is active.</div>
@@ -1174,15 +1235,15 @@
             <div class="modal-sub">Saved as <code>~/.config/husk/prompts/&lt;name&gt;.md</code> and shown on the Prompts page.</div>
 
             <div class="modal-section">
-              <div class="modal-label">Name</div>
-              <input type="text" id="np-name" placeholder="my-new-prompt" autocomplete="off" spellcheck="false" />
-              <div class="modal-hint">Lowercase, dashes ok. Becomes the filename and the frontmatter <code>name</code>.</div>
+              <div class="modal-label">Name <span class="req" aria-hidden="true">*</span></div>
+              <input type="text" id="np-name" placeholder="my-new-prompt" autocomplete="off" spellcheck="false" required aria-required="true" />
+              <div class="modal-hint">Lowercase letters, numbers, and dashes; must start with a letter. Used as the prompt's file name.</div>
             </div>
 
             <div class="modal-section">
-              <div class="modal-label">Description</div>
-              <input type="text" id="np-desc" placeholder="One-line summary of what this prompt does" autocomplete="off" />
-              <div class="modal-hint">Shown on the Prompts card. Required.</div>
+              <div class="modal-label">Description <span class="req" aria-hidden="true">*</span></div>
+              <input type="text" id="np-desc" placeholder="One-line summary of what this prompt does" autocomplete="off" required aria-required="true" />
+              <div class="modal-hint">Shown on the Prompts card.</div>
             </div>
 
             <div class="modal-section">
@@ -1456,18 +1517,18 @@
       <div class="modal-card modal-wide">
         <div class="modal-icon">⌬</div>
         <div class="modal-title">Create a skill</div>
-        <div class="modal-sub">Skills live in the shared library (<code>skills/&lt;name&gt;/SKILL.md</code>). Use one via <strong>Use</strong> on the Skills page; Claude also loads them automatically.</div>
+        <div class="modal-sub">Skills live in the shared library (<code>skills/&lt;name&gt;/SKILL.md</code>). Use one via <strong>Use</strong> on the Skills page; agents that support skills also load them automatically.</div>
 
         <div class="modal-section">
-          <div class="modal-label">Name</div>
-          <input type="text" id="ns-name" placeholder="my-new-skill" autocomplete="off" spellcheck="false" />
-          <div class="modal-hint">Lowercase, dashes ok. Becomes the folder and frontmatter <code>name</code>.</div>
+          <div class="modal-label">Name <span class="req" aria-hidden="true">*</span></div>
+          <input type="text" id="ns-name" placeholder="my-new-skill" autocomplete="off" spellcheck="false" required aria-required="true" />
+          <div class="modal-hint">Lowercase letters, numbers, and dashes; must start with a letter. Used as the skill's folder name.</div>
         </div>
 
         <div class="modal-section">
-          <div class="modal-label">Description</div>
-          <input type="text" id="ns-desc" placeholder="Short one-line summary of when to use this skill" autocomplete="off" />
-          <div class="modal-hint">Shown to the agent as the skill's purpose. Required.</div>
+          <div class="modal-label">Description <span class="req" aria-hidden="true">*</span></div>
+          <input type="text" id="ns-desc" placeholder="Short one-line summary of when to use this skill" autocomplete="off" required aria-required="true" />
+          <div class="modal-hint">Shown to the agent as the skill's purpose.</div>
         </div>
 
         <div class="modal-section">
@@ -1555,7 +1616,7 @@
           <div id="aut-start-body">
           <p class="ra-hint">Hand the agent a goal and walk away. Husk snapshots the workspace, audits every event in a hash-chained log, and caps the run. When it stops, you can review the diff and revert with one click.</p>
           <div class="mcp-input-group">
-            <label for="aut-goal">Goal</label>
+            <label for="aut-goal">Goal <span class="req" aria-hidden="true">*</span></label>
             <textarea id="aut-goal" class="aut-goal-input" rows="4" placeholder="e.g. find every TODO that mentions security, draft a fix per occurrence, do not push" spellcheck="false"></textarea>
             <div class="mig-hint">Plain text. The model sees this as the first message.</div>
           </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -250,35 +250,45 @@
   --accent-2: #ff5a3c;
   --accent-3: #d4471c;
   --accent-glow: rgba(255, 120, 71, 0.32);
+  --focus-ring: 0 0 0 3px var(--accent-glow);
   --grad: linear-gradient(135deg, #ff7847 0%, #ff5a3c 100%);
+  --on-accent: #ffffff;
 }
 [data-accent="cyan"] {
   --accent: #67e8f9;
   --accent-2: #5eead4;
   --accent-3: #06b6d4;
   --accent-glow: rgba(103, 232, 249, 0.35);
+  --focus-ring: 0 0 0 3px var(--accent-glow);
   --grad: linear-gradient(135deg, #67e8f9, #5eead4);
+  --on-accent: #06343d;
 }
 [data-accent="indigo"] {
   --accent: #818cf8;
   --accent-2: #a78bfa;
   --accent-3: #4f46e5;
   --accent-glow: rgba(129, 140, 248, 0.32);
+  --focus-ring: 0 0 0 3px var(--accent-glow);
   --grad: linear-gradient(135deg, #818cf8, #a78bfa);
+  --on-accent: #ffffff;
 }
 [data-accent="emerald"] {
   --accent: #34d399;
   --accent-2: #6ee7b7;
   --accent-3: #059669;
   --accent-glow: rgba(52, 211, 153, 0.32);
+  --focus-ring: 0 0 0 3px var(--accent-glow);
   --grad: linear-gradient(135deg, #34d399, #6ee7b7);
+  --on-accent: #043a2b;
 }
 [data-accent="rose"] {
   --accent: #fb7185;
   --accent-2: #f9a8d4;
   --accent-3: #e11d48;
   --accent-glow: rgba(251, 113, 133, 0.32);
+  --focus-ring: 0 0 0 3px var(--accent-glow);
   --grad: linear-gradient(135deg, #fb7185, #f9a8d4);
+  --on-accent: #ffffff;
 }
 
 /* Cross-theme control, radius and motion tokens. Linear/Vercel-style
@@ -297,7 +307,7 @@
   --motion-fast: 0.12s;
   --motion-base: 0.18s;
   --motion-slow: 0.28s;
-  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+  --focus-ring: 0 0 0 3px var(--accent-glow);
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -310,9 +320,9 @@
   --fs-display: 28px;
   --fs-h1: 22px;
   --fs-h2: 16px;
-  --fs-body: 13px;
-  --fs-small: 12px;
-  --fs-micro: 11px;
+  --fs-body: 14px;
+  --fs-small: 13px;
+  --fs-micro: 12px;
   --lh-tight: 1.15;
   --lh-snug: 1.3;
   --lh-base: 1.5;
@@ -366,7 +376,7 @@ body {
   background-attachment: fixed;
   color: var(--text);
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: 14px;
   font-feature-settings: 'cv11', 'ss03';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -481,13 +491,16 @@ body:not([data-page="chat"]) #btn-new-session { display: none; }
   color: var(--text-2);
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  /* Top-heavy padding drops the label 1px; with line-height 1 the
-     centered text box reads optically high in this font. */
-  padding: 2px 12px 0;
+  padding: 0 12px;
   height: var(--control-h);
   display: inline-flex; align-items: center; justify-content: center;
   gap: 6px;
-  font-size: 13px; line-height: 1;
+  /* Not line-height: 1. That clamps the line box below the font's own content
+     area, and the overflow lands asymmetrically, so flex centring puts the
+     label about 1px above the icon and the leading icon reads as sitting low.
+     `normal` lets the line box match the font and the two share a centreline.
+     The button height is fixed above, so this changes alignment only. */
+  font-size: 13px; line-height: normal;
   cursor: pointer;
   font-family: inherit;
   font-weight: 500;
@@ -496,18 +509,25 @@ body:not([data-page="chat"]) #btn-new-session { display: none; }
 }
 .iconbtn:hover { color: var(--text); border-color: var(--line-3); background: var(--bg-2); box-shadow: none; }
 .iconbtn svg { width: 16px; height: 16px; display: block; }
-.btn-primary .btn-icon { width: 14px; height: 14px; flex: 0 0 auto; display: block; }
+/* Every labelled action button uses the same 14px leading icon, whatever the
+   button variant, so the primary actions across pages stay one size. The
+   .iconbtn override is needed because `.iconbtn svg` sizes bare icons at 16px. */
+.btn-icon { width: 14px; height: 14px; flex: 0 0 auto; display: block; }
+.iconbtn .btn-icon { width: 14px; height: 14px; }
 body[data-theme="dark"] #btn-theme .theme-sun { display: none; }
 body[data-theme="light"] #btn-theme .theme-moon { display: none; }
 .iconbtn-primary {
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent, #ffffff);
   border-color: var(--accent);
   font-weight: 500;
+  /* Match .btn-primary so the topbar primary and the page-header primaries
+     read as the same button. */
+  padding: 0 14px;
 }
 .iconbtn-primary:hover {
   background: color-mix(in srgb, var(--accent) 90%, white);
-  color: #ffffff;
+  color: var(--on-accent, #ffffff);
   border-color: color-mix(in srgb, var(--accent) 90%, white);
   box-shadow: none;
 }
@@ -1035,7 +1055,8 @@ body[data-page="boot"] .page { display: none !important; }
   padding: 0 14px;
   height: var(--control-h);
   font-size: 13px;
-  line-height: 1;
+  /* See .iconbtn: line-height 1 misaligns the leading icon against the label. */
+  line-height: normal;
   font-family: inherit;
   font-weight: 500;
   cursor: pointer;
@@ -1047,7 +1068,6 @@ body[data-page="boot"] .page { display: none !important; }
   transition: background 0.14s var(--ease), color 0.14s var(--ease), border-color 0.14s var(--ease), box-shadow 0.14s var(--ease);
 }
 .ghost-btn:hover { color: var(--text); border-color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, var(--bg-3)); }
-.ghost-btn .btn-icon { width: 14px; height: 14px; flex: 0 0 auto; display: block; }
 .ghost-btn-danger { color: var(--rose); border-color: color-mix(in srgb, var(--rose) 30%, var(--line)); }
 .ghost-btn-danger:hover { color: #fff; background: var(--rose); border-color: var(--rose); }
 
@@ -1522,6 +1542,30 @@ body[data-mode="light"] .aut-diff-added-count { color: #12703f; }
   pointer-events: none;
   filter: blur(8px);
 }
+/* Autopilot hero: the real Kernel flying a little plane. Funny, on-brand,
+   and it uses the actual mascot art instead of a hand-drawn face. */
+.aut-hero-art {
+  position: absolute; right: 3%; top: 50%; z-index: 0;
+  width: 340px; height: 230px; pointer-events: none;
+  transform: translateY(-50%);
+  animation: apk-float 6s ease-in-out infinite;
+}
+@media (max-width: 1080px) { .aut-hero-art { display: none; } }
+.aut-plane { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; filter: drop-shadow(0 14px 22px rgba(0, 0, 0, 0.42)); }
+/* The fuselage front lip sits ABOVE Kernel so his lower body tucks inside. */
+.aut-plane-front { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; z-index: 3; pointer-events: none; }
+.aut-p-body { fill: url(#aut-fuse); }
+.aut-p-accent { fill: var(--accent); }
+/* Clouds must read on both skies: white on the dark hero, soft slate on light. */
+.aut-clouds { fill: #ffffff; }
+[data-mode="light"] .aut-clouds { fill: #9db4d4; }
+/* Kernel sits DOWN in the cockpit; the front lip hides his lower half. */
+.aut-kernel-slot { position: absolute; left: 55%; top: 26px; transform: translateX(-50%); z-index: 2; line-height: 0; }
+.aut-kernel-slot .hk { width: 96px; height: auto; cursor: default; }
+/* Pilot cap overlaid on the real Kernel's head. */
+.aut-hat { position: absolute; left: 55%; top: 44px; transform: translateX(-50%); width: 108px; height: auto; z-index: 4; overflow: visible; }
+@keyframes apk-float { 0%, 100% { transform: translateY(-50%) rotate(0deg); } 50% { transform: translateY(-56%) rotate(1.2deg); } }
+@media (prefers-reduced-motion: reduce) { .aut-hero-art { animation: none; } }
 .aut-hero-eyebrow {
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
@@ -3455,6 +3499,7 @@ body[data-page="chat"] #chats-panel { display: flex; }
 .term-pane.show { display: block; }
 .xterm-viewport { background-color: transparent !important; }
 
+
 /* ─── Workflows page ──────────────────────────────────────────────────── */
 
 /* List */
@@ -3769,6 +3814,101 @@ body[data-page="chat"] #chats-panel { display: flex; }
 }
 .wf-node-panel-close:hover { color: var(--text); background: var(--bg-3); }
 .wf-node-panel #wf-np-delete { margin-top: 4px; align-self: flex-start; }
+
+/* Node config: right-side drawer with a rich single-column form + mini-IDE. */
+.wf-drawer { position: fixed; inset: 0; z-index: 200; display: flex; justify-content: flex-end; }
+.wf-drawer[hidden] { display: none; }
+.wf-drawer-scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.42); backdrop-filter: blur(2px); animation: wf-scrim-in 0.2s ease; }
+.wf-drawer-panel {
+  position: relative; width: min(560px, 94vw); height: 100%;
+  display: flex; flex-direction: column;
+  background-color: var(--bg); background-image: linear-gradient(var(--bg-1), var(--bg-1));
+  border-left: 1px solid var(--line); box-shadow: -26px 0 60px -24px rgba(0,0,0,0.6);
+  animation: wf-drawer-in 0.24s cubic-bezier(.16,1,.3,1);
+}
+@keyframes wf-drawer-in { from { transform: translateX(26px); opacity: 0; } to { transform: none; opacity: 1; } }
+@keyframes wf-scrim-in { from { opacity: 0; } to { opacity: 1; } }
+.wf-drawer-body { flex: 1; min-height: 0; overflow-y: auto; padding: 18px 20px; display: flex; flex-direction: column; gap: 16px; }
+.wf-nm-head { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--line); }
+.wf-nm-head-title { display: flex; align-items: center; gap: 11px; min-width: 0; }
+.wf-nm-head-badge {
+  display: grid; place-items: center; width: 28px; height: 28px; flex: none; border-radius: 9px;
+  background: color-mix(in srgb, var(--accent) 15%, transparent); color: var(--accent);
+}
+.wf-nm-head-badge svg { width: 15px; height: 15px; }
+.wf-nm-head .wf-node-panel-title { font-size: 15px; font-weight: 650; letter-spacing: -0.01em; text-transform: none; color: var(--text); }
+.wf-nm-editor { display: flex; flex-direction: column; gap: 10px; min-width: 0; flex: 1; min-height: 0; }
+.wf-nm-editor-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.wf-nm-editor-head .form-label { margin: 0; }
+.wf-nm-generate { display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 12px; font-size: var(--fs-small); white-space: nowrap; border-radius: 8px; }
+.wf-nm-generate svg { color: var(--accent); }
+.wf-nm-generate:disabled { opacity: 0.55; cursor: default; }
+/* Mini IDE: line-number gutter + a monospace editor, styled as a code surface. */
+.wf-ide {
+  position: relative; flex: 1; display: flex; min-height: 220px;
+  background: var(--bg-2); border: 1px solid var(--line); border-radius: 12px;
+  overflow: hidden;
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 13px; line-height: 1.7;
+}
+/* Single accent outline on focus. --focus-ring layers a --bg gap ring under the
+   accent, which read as two lines in two colors; use one accent border + a soft
+   same-hue glow instead. */
+.wf-ide:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
+.wf-ide.field-invalid { border-color: var(--rose); box-shadow: 0 0 0 3px color-mix(in srgb, var(--rose) 26%, transparent); }
+/* The inner textarea must stay flat: the .wf-ide wrapper owns the focus ring
+   via :focus-within. Global textarea:focus rules otherwise paint their own
+   border + box-shadow + dark background on it, which the wrapper's
+   overflow:hidden clips into a stray highlighted line down the left edge. */
+.wf-ide-input:focus,
+.wf-ide-input:focus-visible,
+[data-mode="dark"] .wf-ide-input:focus,
+[data-mode="light"] .wf-ide-input:focus {
+  background: transparent !important;
+  box-shadow: none !important;
+  border-color: transparent !important;
+}
+.wf-ide-gutter {
+  flex: none; width: 42px; padding: 14px 8px 14px 0; text-align: right;
+  color: var(--text-3); background: color-mix(in srgb, var(--text) 3%, transparent);
+  user-select: none; overflow: hidden;
+  white-space: pre; font-variant-numeric: tabular-nums;
+}
+.wf-ide-input {
+  flex: 1; min-width: 0; border: 0; outline: none; resize: none;
+  background: transparent; color: var(--text); padding: 14px 16px;
+  font: inherit; line-height: inherit; white-space: pre;
+}
+.wf-ide-input::placeholder { color: var(--text-3); white-space: pre-wrap; }
+/* AI suggestion review overlay: approve or discard before it touches the editor. */
+.wf-gen-review {
+  position: absolute; inset: 0; z-index: 2; display: flex; flex-direction: column;
+  border-radius: 12px;
+  /* Opaque: the --bg-N tokens are translucent white overlays, so paint a solid
+     base first or the editor bleeds through the suggestion. */
+  background-color: var(--bg);
+  background-image: linear-gradient(var(--bg-2), var(--bg-2));
+}
+.wf-gen-review-head {
+  display: flex; align-items: center; gap: 7px; padding: 12px 14px;
+  font-size: var(--fs-small); font-weight: 600; color: var(--text-2);
+  border-bottom: 1px solid var(--line);
+}
+.wf-gen-review-head svg { color: var(--accent); }
+.wf-gen-review-text {
+  flex: 1; overflow: auto; padding: 14px 16px; margin: 0; white-space: pre-wrap;
+  color: var(--text);
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 13px; line-height: 1.7;
+}
+.wf-gen-review-foot { display: flex; justify-content: flex-end; gap: 10px; padding: 12px 14px; border-top: 1px solid var(--line); }
+.wf-nm-gen-status { font-size: var(--fs-small); color: var(--text-3); min-height: 1em; }
+.wf-nm-gen-status.is-error { color: var(--rose); }
+.wf-nm-foot { display: flex; align-items: center; justify-content: space-between; padding: 13px 20px; border-top: 1px solid var(--line); }
+.wf-nm-foot #wf-np-delete { border: 0; background: transparent; color: var(--text-3); padding: 7px 10px; font-size: var(--fs-small); }
+.wf-nm-foot #wf-np-delete:hover { background: color-mix(in srgb, var(--rose) 14%, transparent); color: var(--rose); }
+/* Beat the .modal-card .btn-primary { width:100% } rule so Done stays compact. */
+.wf-drawer .btn-primary { width: auto; min-width: 96px; height: var(--control-h); padding: 0 18px; font-size: var(--fs-small); }
 .wf-edge-panel-hint {
   font-size: 11.5px; line-height: 1.6; color: var(--text-3);
   margin: 0; padding: 8px 10px;
@@ -4339,7 +4479,7 @@ body[data-page="chat"] #chats-panel { display: flex; }
   flex: 0 0 auto;
 }
 .agent-card-desc {
-  font-size: 12.5px; color: var(--text-2); line-height: 1.5;
+  font-size: 13.5px; color: var(--text-2); line-height: 1.5;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
   overflow: hidden;
   margin: 0;
@@ -4360,7 +4500,7 @@ body[data-page="chat"] #chats-panel { display: flex; }
 }
 /* Prompt preview: muted italic, 2-line clamp. */
 .agent-card-prompt {
-  font-size: 11.5px; color: var(--text-3); line-height: 1.55;
+  font-size: 12.5px; color: var(--text-3); line-height: 1.55;
   font-style: italic;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
   overflow: hidden;
@@ -4589,7 +4729,7 @@ body[data-page="chat"] #chats-panel { display: flex; }
   padding: 2px 8px;
 }
 .prompt-card-body {
-  font-size: 12px; color: var(--text-2);
+  font-size: 13px; color: var(--text-2);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 3; line-clamp: 3;
@@ -4731,7 +4871,7 @@ body[data-page="chat"] #chats-panel { display: flex; }
   font-size: 16px;
 }
 .skill-card .sk-desc {
-  font-size: 13px; color: var(--text-2); line-height: 1.55;
+  font-size: 14px; color: var(--text-2); line-height: 1.55;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -5825,14 +5965,15 @@ input[type="checkbox"]:disabled {
 
 .btn-primary {
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent, #ffffff);
   border: 0;
   border-radius: var(--radius-md);
   padding: 0 14px;
   height: var(--control-h);
   font-size: 13px;
   font-weight: 500;
-  line-height: 1;
+  /* See .iconbtn: line-height 1 misaligns the leading icon against the label. */
+  line-height: normal;
   cursor: pointer; font-family: inherit;
   display: inline-flex;
   align-items: center;
@@ -5893,8 +6034,13 @@ input[type="checkbox"]:disabled {
   letter-spacing: -0.02em;
   text-transform: uppercase;
   font-weight: 850;
-  color: var(--accent);
-  background: linear-gradient(90deg, var(--accent-2) 0%, var(--accent) 58%, #ffb08f 100%);
+  /* Fixed identity. Accent is a separate axis from theme, so painting this in
+     accent made the title a different colour for every accent and clash on most
+     of them. It reads only from the theme text ramp now: same wordmark under
+     every accent, still legible on the light-family themes. The vertical fade
+     to --text-2 keeps the weight from going flat. */
+  color: var(--text);
+  background: linear-gradient(180deg, var(--text) 0%, var(--text-2) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -6129,6 +6275,9 @@ input[type="checkbox"]:disabled {
 }
 .modal-section { text-align: left; margin-bottom: 16px; }
 .modal-label { font-size: 11px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-3); margin-bottom: 8px; font-weight: 700; }
+.req { color: var(--danger, #ef4444); margin-left: 3px; font-weight: 700; font-size: 16px; line-height: 0; vertical-align: -2px; }
+input.field-invalid,
+textarea.field-invalid { border-color: var(--danger, #ef4444); box-shadow: 0 0 0 1px var(--danger, #ef4444); }
 .modal-card input[type="text"] {
   width: 100%; padding: 10px 12px; font-size: 13px;
   background: var(--bg); color: var(--text);
@@ -6137,7 +6286,7 @@ input[type="checkbox"]:disabled {
   transition: border-color 0.12s var(--ease), box-shadow 0.12s var(--ease);
 }
 .modal-card input[type="text"]:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
-.modal-hint { color: var(--text-3); font-size: 12px; margin: 12px 0 18px; }
+.modal-hint { color: var(--text-3); font-size: 13px; margin: 12px 0 18px; }
 .modal-hint code { background: var(--bg-3); padding: 1px 6px; border-radius: 4px; color: var(--accent); font-family: 'JetBrains Mono', monospace; }
 .modal-card .btn-primary { width: 100%; height: var(--control-h-lg); padding: 0 16px; font-size: 14px; }
 /* Footer buttons use standard sizing, overriding the stacked default above. */
@@ -6343,6 +6492,54 @@ body[data-mode="light"] .ob-aurora i { opacity: 0.32; }
   width: 196px; height: 210px; display: block;
   overflow: visible;
   cursor: pointer;
+}
+/* ── Kernel in empty states ──────────────────────────────────────────────
+   A standalone, static Kernel wired to workflow node cards, with a signal
+   flowing along each wire toward its node. */
+.empty-state.es-kernel { gap: 4px; }
+.es-kernel .ek-stage {
+  position: relative; width: 480px; height: 280px; max-width: 100%;
+  display: grid; place-items: center;
+  margin-bottom: 4px;
+}
+/* Bare Kernel: hide the pod/husk shell, hands, glow and sparks and show only
+   the seed character, at rest, with every animation and transition off. */
+.hk.is-bare .hk-petal, .hk.is-bare .hk-pit, .hk.is-bare .hk-shadow,
+.hk.is-bare .hk-glow, .hk.is-bare .hk-hands, .hk.is-bare .hk-sparks { display: none; }
+.hk.is-bare .hk-seed { transform: none; opacity: 1; }
+.hk.is-bare, .hk.is-bare * { animation: none !important; transition: none !important; }
+.es-kernel .ek-slot { position: relative; z-index: 1; line-height: 0; }
+.es-kernel .ek-slot .hk { width: 104px; height: auto; cursor: default; }
+/* Workflow graph: curved wires from Kernel to faint node cards, each carrying a
+   bright signal dot that flows out toward its node. */
+.es-kernel .ek-graph { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
+.es-kernel .ek-wire {
+  fill: none; stroke-width: 2; stroke-linecap: round;
+  stroke: color-mix(in srgb, var(--accent) 32%, var(--line));
+}
+.es-kernel .ek-wire-2 { stroke-width: 1.5; stroke: color-mix(in srgb, var(--accent) 20%, var(--line)); }
+.es-kernel .ek-flow {
+  fill: none; stroke-width: 3; stroke-linecap: round; stroke: var(--accent);
+  stroke-dasharray: 6 100; stroke-dashoffset: 106;
+  filter: drop-shadow(0 0 3px var(--accent-glow));
+  animation: ek-flow 2.4s linear infinite;
+}
+.es-kernel .ek-flow:nth-of-type(10) { animation-delay: 0.6s; }
+.es-kernel .ek-flow:nth-of-type(11) { animation-delay: 1.2s; }
+.es-kernel .ek-flow:nth-of-type(12) { animation-delay: 1.8s; }
+/* Mini workflow-node cards: gradient icon badge, title + meta lines, floating. */
+.es-kernel .ek-node { filter: drop-shadow(0 4px 7px rgba(0, 0, 0, 0.38)); }
+.es-kernel .ek-card { fill: var(--bg-4); stroke: var(--line-2); stroke-width: 1; }
+.es-kernel .ek-node-icon { fill: url(#ek-ic); }
+.es-kernel .ek-node-l1 { fill: color-mix(in srgb, var(--text) 52%, transparent); }
+.es-kernel .ek-node-l2 { fill: color-mix(in srgb, var(--text) 22%, transparent); }
+.ek-ic0 { stop-color: var(--accent); }
+.ek-ic1 { stop-color: var(--accent-2); }
+.es-kernel .ek-dot { fill: var(--accent); }
+.es-kernel .ek-dot-2 { fill: color-mix(in srgb, var(--accent) 70%, transparent); }
+@keyframes ek-flow { to { stroke-dashoffset: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .es-kernel .ek-flow { animation: none; stroke-dasharray: none; stroke-dashoffset: 0; opacity: 0; }
 }
 /* Every animated part is positioned in viewBox units, so transform-origin is
    read against the viewBox rather than each element's own tight bounding box. */
@@ -7089,6 +7286,14 @@ kbd {
    keeps the resting state visible even if the compositor is not animating. */
 .toast.is-enter { opacity: 0; transform: translateX(16px); }
 .toast.is-out { opacity: 0; transform: translateX(16px); }
+/* A keyed card that was rewritten in place. The card does not move or re-enter,
+   so a short pulse is what tells the eye the value changed. */
+.toast.is-bump { animation: toast-bump 220ms var(--ease-out); }
+@keyframes toast-bump {
+  0% { transform: scale(1); }
+  38% { transform: scale(1.035); }
+  100% { transform: scale(1); }
+}
 .toast-icon { display: flex; align-items: center; justify-content: center; width: 18px; height: 18px; margin-top: 1px; color: var(--text-3); flex: none; }
 .toast-icon svg { width: 18px; height: 18px; }
 .toast-body { min-width: 0; }
@@ -7361,21 +7566,27 @@ kbd {
 [data-mode="dark"] .btn-primary,
 [data-mode="dark"] .iconbtn-primary {
   background: var(--grad);
-  color: white;
+  color: var(--on-accent, white);
   border: 1px solid transparent;
   border-radius: 10px;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.28),
-    0 10px 30px -10px rgba(255, 120, 71, 0.55);
+    inset 0 1px 0 rgba(255, 255, 255, 0.16),
+    0 6px 16px -8px rgba(0, 0, 0, 0.45);
   font-weight: 600;
   letter-spacing: -0.005em;
   transition: box-shadow 180ms ease, transform 180ms ease;
 }
 [data-mode="dark"] .btn-primary:hover,
 [data-mode="dark"] .iconbtn-primary:hover {
+  /* Keep the gradient + on-accent text on hover. Without this, the shared
+     [data-mode="dark"] .iconbtn:hover rule (higher specificity) repaints the
+     background translucent-white while the text stays near-black on-accent,
+     which reads as invisible text. */
+  background: var(--grad);
+  color: var(--on-accent, white);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.34),
-    0 14px 36px -12px rgba(255, 120, 71, 0.75);
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 10px 24px -10px rgba(0, 0, 0, 0.55);
   transform: translateY(-1px);
 }
 
@@ -7972,12 +8183,14 @@ kbd {
   border-color: var(--accent);
   box-shadow: var(--elev-3), 0 0 0 3px var(--accent-glow);
 }
-.wf-cv-node { position: relative; padding: 12px 13px 11px; cursor: grab; }
+/* border-radius + overflow clip the top accent bar to the card's rounded top so
+   its straight ends can't poke past the corners. The connector dots live on the
+   node, not this content box, so clipping here never hides them. */
+.wf-cv-node { position: relative; padding: 12px 13px 11px; cursor: grab; border-radius: 13px; overflow: hidden; }
 /* The same bar the run view uses for state; here it just says "step". */
 .wf-cv-node::before {
   content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
   background: var(--line-2);
-  border-radius: 14px 14px 0 0;
 }
 .wf-canvas .drawflow .drawflow-node.selected .wf-cv-node::before {
   background: linear-gradient(90deg, var(--accent), var(--accent-2));


### PR DESCRIPTION
Brings development up to main. No version bump; this is not a release.

- Workflows: step config in a right-side drawer, line-numbered prompt editor, AI draft-improve with approve or discard, drag no longer opens the config.
- Terminal: readable text on light themes, drag-select auto-scrolls at the edges.
- Sessions: resume only offered when the transcript exists; helper runs no longer rename a tab.
- Forms: required fields marked and highlighted, backdrop click no longer discards a form.
- Empty states: workflows page and autopilot hero illustrations, leading icons on primary actions.