### PR TITLE
test(e2e): wait for the recap read instead of a fixed budget

### DIFF
--- a/test/e2e/fixtures/recap-echo.js
+++ b/test/e2e/fixtures/recap-echo.js
@@ -16,6 +16,9 @@ function paint() {
 }
 
 paint();
-// Redraw later (a TUI repaint): must NOT cause a second read.
+// Redraw twice (TUI repaints): neither may cause a second read. The first lands
+// while the recap is still being settled, the second lands after it has been
+// spoken, so both sides of the once-per-turn rule are exercised.
 setTimeout(paint, 3000);
-setTimeout(() => process.exit(0), 10000);
+setTimeout(paint, 6000);
+setTimeout(() => process.exit(0), 14000);

--- a/test/e2e/recap-voice.spec.js
+++ b/test/e2e/recap-voice.spec.js
@@ -63,8 +63,15 @@ test('recap is read from the grid, cleanly (no chrome), exactly once', async () 
   });
   await win.evaluate(() => window.husk.pty.start({ cols: 100, rows: 30 }));
 
-  // Wait past the settle window and the fixture's redraw interval.
-  await win.waitForTimeout(5000);
+  // A repaint re-arms the settle window, so the earliest a recap can be read is
+  // agent-spawn plus the fixture's redraw plus the settle. That total is close
+  // enough to any fixed budget that a slow machine loses the race, so wait for
+  // the read itself instead of guessing how long it takes.
+  await win.waitForFunction(() => window.__spoken.length > 0, null, { timeout: 30_000 });
+  // Then hold past the fixture's LATER repaint, which lands after the recap has
+  // been read. That is what proves the once-per-turn rule: a redraw of a recap
+  // already spoken must not speak it again.
+  await win.waitForTimeout(3500);
 
   const spoken = await win.evaluate(() => window.__spoken);
   await app.close();


### PR DESCRIPTION
The recap test gave the read a fixed 5 second budget. The measured path to a read is agent spawn plus the fixture repaint plus the settle window, which lands around 4.5 seconds on a fast machine, so the margin was roughly 400ms and CI lost it repeatedly today.

The test now waits for the read itself, then holds past a second fixture repaint that lands after the recap was spoken, so the once-per-turn rule is actually exercised on both sides of the read.

No version bump; this is not a release.