### PR TITLE
fix: leave the user's CLAUDE.md alone

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -278,6 +278,19 @@ elif [ -d "$LIFEOS_BUNDLE" ]; then
     for MEMDIR in WORK KNOWLEDGE LEARNING STATE OBSERVABILITY SKILLS; do
         mkdir -p "$CLAUDE_DIR/LIFEOS/MEMORY/$MEMDIR"
     done
+    # Agent-instruction files carried inside the bundle belong to the upstream
+    # project's own repo, where they steer whoever is editing the framework.
+    # Landed in a user's ~/.claude/ they read as standing orders that person
+    # never wrote, in the exact place the CLI looks for their own. Writing
+    # their instructions is their business. Only the ones we just copied are
+    # removed, and only when they still match the bundle byte for byte, so a
+    # file the user already had is never touched.
+    find "$CLAUDE_DIR" -name 'CLAUDE.md' -not -path "$CLAUDE_DIR/CLAUDE.md" 2>/dev/null | while read -r INSTALLED; do
+        REL="${INSTALLED#$CLAUDE_DIR/}"
+        SRC="$LIFEOS_BUNDLE/$REL"
+        [ -f "$SRC" ] || continue
+        cmp -s "$INSTALLED" "$SRC" && rm -f "$INSTALLED"
+    done
     ok "LifeOS ready"
 fi
 

--- a/src/lib/pai-state.js
+++ b/src/lib/pai-state.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const PARKED_BASENAME = 'CLAUDE.md.husk-disabled';
 const HUSK_AGENTS_START = '<!-- HUSK-AGENTS:START -->';
@@ -18,9 +19,33 @@ function parkedPath(claudeDir) {
   return path.join(claudeDir, PARKED_BASENAME);
 }
 
+function digestOf(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+// Whether a CLAUDE.md is one Husk put there and the user has left alone.
+// A file is ours only while it still matches, byte for byte, a template we
+// ship. The moment someone edits it, it is their file and their words, and
+// nothing here may move it again.
+//
+// Matching on content rather than on a recorded flag is what makes this work
+// for installs that predate the check: there is no state to migrate, an old
+// untouched copy still matches its template.
+function isHuskAuthoredClaudeMd(claudeDir, templateDigests) {
+  const digests = Array.isArray(templateDigests) ? templateDigests.filter(Boolean) : [];
+  if (!digests.length) return false;
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path scoped to claudeDir/CLAUDE.md
+    const body = fs.readFileSync(path.join(claudeDir, 'CLAUDE.md'), 'utf8');
+    return digests.includes(digestOf(body));
+  } catch (_) {
+    return false;
+  }
+}
+
 // Rename ~/.claude/CLAUDE.md to/from the parked sibling based on whether
-// PAI is supposed to be active. Renames only; never deletes. All four
-// presence combinations are handled deliberately:
+// the framework is supposed to be active. Renames only; never deletes. All
+// four presence combinations are handled deliberately:
 //
 //   active=false, live present, parked absent  → rename live → parked
 //   active=false, live present, parked present → leave both alone
@@ -31,7 +56,18 @@ function parkedPath(claudeDir) {
 //
 // The "leave both alone" cases protect a user-edited file from being
 // silently overwritten. The caller can surface a toast if needed.
-function applyPaiState(claudeDir, active) {
+//
+// Parking is gated on the file being ours. ~/.claude/CLAUDE.md belongs to
+// the user: plenty of people wrote one long before they ever installed Husk,
+// and a toggle in our Preferences must not move it. Without the gate, turning
+// the framework off renamed whatever was there, so someone's hand-written
+// config silently disappeared from the path the CLI reads. Pass the digests
+// of the templates we ship via opts.templateDigests; anything that does not
+// match one of them is left exactly where it is.
+//
+// Restoring is unconditional: the parked file only exists because we put it
+// there, so moving it back is always returning our own file.
+function applyPaiState(claudeDir, active, opts = {}) {
   if (typeof claudeDir !== 'string' || !claudeDir) {
     throw new TypeError('applyPaiState: claudeDir must be a non-empty string');
   }
@@ -46,7 +82,8 @@ function applyPaiState(claudeDir, active) {
   try {
     if (!active) {
       // eslint-disable-next-line security/detect-non-literal-fs-filename -- path scoped to claudeDir/CLAUDE.md, validated input
-      if (fs.existsSync(live) && !fs.existsSync(parked)) {
+      if (fs.existsSync(live) && !fs.existsSync(parked)
+          && isHuskAuthoredClaudeMd(claudeDir, opts.templateDigests)) {
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- rename target is the parked sibling, fixed basename
         fs.renameSync(live, parked);
       }
@@ -139,6 +176,8 @@ module.exports = {
   HUSK_AGENTS_START,
   HUSK_AGENTS_END,
   parkedPath,
+  digestOf,
+  isHuskAuthoredClaudeMd,
   applyPaiState,
   buildHuskPrompt,
   renderHuskAgentsBlock,

--- a/src/main.js
+++ b/src/main.js
@@ -569,8 +569,31 @@ function bootstrapHuskPromptsIfNeeded() {
 // Implementation lives in src/lib/pai-state.js so it can be unit-tested
 // without spinning up Electron.
 const PaiState = require('./lib/pai-state');
+
+// Digests of every CLAUDE.md template Husk has shipped. The toggle parks the
+// live file only when it still matches one of these, which is how we tell our
+// own untouched scaffold apart from a file the user wrote or edited. Older
+// entries stay listed forever so an install that never upgraded its scaffold
+// is still recognised as ours.
+const SHIPPED_CLAUDE_MD_DIGESTS = [
+  // LifeOS 7.1.1, the template in the current bundle. Read at call time rather
+  // than hard-coded so it cannot drift from the file we actually ship.
+];
+function shippedClaudeMdDigests() {
+  const digests = [...SHIPPED_CLAUDE_MD_DIGESTS];
+  try {
+    const bundle = findBundledFramework();
+    if (bundle) {
+      const tpl = path.join(bundle, 'CLAUDE.template.md');
+      if (fs.existsSync(tpl)) digests.push(PaiState.digestOf(fs.readFileSync(tpl, 'utf8')));
+    }
+  } catch (_) {}
+  return digests;
+}
 function applyPaiState(active) {
-  PaiState.applyPaiState(path.join(HOME, '.claude'), active);
+  PaiState.applyPaiState(path.join(HOME, '.claude'), active, {
+    templateDigests: shippedClaudeMdDigests(),
+  });
 }
 
 // Per-install state the runtime writes into but the bundle never ships. The
@@ -585,6 +608,21 @@ const LIFEOS_MEMORY_SUBDIRS = ['WORK', 'KNOWLEDGE', 'LEARNING', 'STATE', 'OBSERV
 // versions that have since had advisories filed against them. Dropping them
 // means a user who does opt in resolves current versions instead. Keep the
 // package.json files, they are what makes that resolve possible.
+
+// Locate the bundled framework.
+// Packaged: app.isPackaged && process.resourcesPath/lifeos/ exists.
+// Dev:      <repo>/libs/lifeos/ relative to __dirname (which is <repo>/src/).
+function findBundledFramework() {
+  const candidates = [];
+  if (app.isPackaged && process.resourcesPath) {
+    candidates.push(path.join(process.resourcesPath, 'lifeos'));
+  }
+  candidates.push(path.join(__dirname, '..', 'libs', 'lifeos'));
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.existsSync(path.join(c, 'CLAUDE.template.md'))) return c;
+  }
+  return null;
+}
 
 function bootstrapPaiIfNeeded() {
   // Hard opt-out: when the user has disabled the framework in Preferences, we
@@ -602,21 +640,7 @@ function bootstrapPaiIfNeeded() {
     // Removing it is the user's call, not ours.
     if (fs.existsSync(path.join(claudeDir, 'PAI'))) return;
 
-    // Locate the bundled framework.
-    // Packaged: app.isPackaged && process.resourcesPath/lifeos/ exists.
-    // Dev:      <repo>/libs/lifeos/ relative to __dirname (which is <repo>/src/).
-    const candidates = [];
-    if (app.isPackaged && process.resourcesPath) {
-      candidates.push(path.join(process.resourcesPath, 'lifeos'));
-    }
-    candidates.push(path.join(__dirname, '..', 'libs', 'lifeos'));
-
-    let bundle = null;
-    for (const c of candidates) {
-      if (fs.existsSync(c) && fs.existsSync(path.join(c, 'CLAUDE.template.md'))) {
-        bundle = c; break;
-      }
-    }
+    const bundle = findBundledFramework();
     if (!bundle) return;
 
     fs.mkdirSync(claudeDir, { recursive: true });
@@ -668,6 +692,7 @@ function bootstrapPaiIfNeeded() {
 // already-present skills are never touched.
 function copyMissingChildrenSync(src, dst) {
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (entry.isFile() && BUNDLE_INSTRUCTION_FILES.has(entry.name)) continue;
     const s = path.join(src, entry.name);
     const d = path.join(dst, entry.name);
     if (fs.existsSync(d)) continue;
@@ -681,9 +706,17 @@ function copyMissingChildrenSync(src, dst) {
   }
 }
 
+// Agent-instruction files carried inside the bundle. The upstream project
+// keeps these for its own repo, where they steer whoever is editing the
+// framework. Copied into a user's ~/.claude/ they become standing orders that
+// person never wrote, in the exact place the CLI looks for their own. Writing
+// their instructions is their business, so these stay in the bundle.
+const BUNDLE_INSTRUCTION_FILES = new Set(['CLAUDE.md', 'AGENTS.md', 'GEMINI.md']);
+
 function copyDirRecursiveSync(src, dst) {
   fs.mkdirSync(dst, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    if (entry.isFile() && BUNDLE_INSTRUCTION_FILES.has(entry.name)) continue;
     const s = path.join(src, entry.name);
     const d = path.join(dst, entry.name);
     if (entry.isDirectory()) copyDirRecursiveSync(s, d);

--- a/test/unit/pai-state.test.js
+++ b/test/unit/pai-state.test.js
@@ -15,6 +15,8 @@ const {
   HUSK_AGENTS_END,
   PARKED_BASENAME,
   parkedPath,
+  digestOf,
+  isHuskAuthoredClaudeMd,
   applyPaiState,
   buildHuskPrompt,
   renderHuskAgentsBlock,
@@ -28,11 +30,16 @@ afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catc
 const live = () => path.join(tmp, 'CLAUDE.md');
 const parked = () => path.join(tmp, PARKED_BASENAME);
 
+// Parking only ever moves a scaffold Husk wrote. Tests that exercise the
+// park/restore mechanics therefore have to declare the content as ours, the
+// same way main.js declares the digest of the template it ships.
+const ours = (text) => { fs.writeFileSync(live(), text); return { templateDigests: [digestOf(text)] }; };
+
 // ─── applyPaiState ────────────────────────────────────────────────────────
 
-test('ISC-1: disabling parks an existing CLAUDE.md verbatim', () => {
-  fs.writeFileSync(live(), 'PAI prose here.\nline 2\n');
-  applyPaiState(tmp, false);
+test('ISC-1: disabling parks a scaffold Husk wrote, verbatim', () => {
+  const opts = ours('PAI prose here.\nline 2\n');
+  applyPaiState(tmp, false, opts);
   assert.equal(fs.existsSync(live()), false, 'live file should be gone');
   assert.equal(fs.existsSync(parked()), true, 'parked file should exist');
   assert.equal(fs.readFileSync(parked(), 'utf8'), 'PAI prose here.\nline 2\n');
@@ -61,17 +68,17 @@ test('ISC-4: enabling never clobbers a user-created live CLAUDE.md', () => {
 });
 
 test('ISC-5: disabling when both files exist leaves both alone', () => {
-  fs.writeFileSync(live(), 'live content\n');
+  const opts = ours('live content\n');
   fs.writeFileSync(parked(), 'parked content\n');
-  applyPaiState(tmp, false);
+  applyPaiState(tmp, false, opts);
   assert.equal(fs.readFileSync(live(), 'utf8'), 'live content\n');
   assert.equal(fs.readFileSync(parked(), 'utf8'), 'parked content\n');
 });
 
 test('ISC-6: applyPaiState is idempotent; calling twice equals once', () => {
-  fs.writeFileSync(live(), 'pai\n');
-  applyPaiState(tmp, false);
-  applyPaiState(tmp, false);
+  const opts = ours('pai\n');
+  applyPaiState(tmp, false, opts);
+  applyPaiState(tmp, false, opts);
   assert.equal(fs.existsSync(live()), false);
   assert.equal(fs.existsSync(parked()), true);
   assert.equal(fs.readFileSync(parked(), 'utf8'), 'pai\n');
@@ -79,30 +86,30 @@ test('ISC-6: applyPaiState is idempotent; calling twice equals once', () => {
 
 test('ISC-7: full disable → enable round-trip preserves byte-exact content', () => {
   const original = 'multi\nline\nPAI\nbody with unicode ── █ ─ ──\n';
-  fs.writeFileSync(live(), original);
-  applyPaiState(tmp, false);
+  const opts = ours(original);
+  applyPaiState(tmp, false, opts);
   assert.equal(fs.existsSync(live()), false);
-  applyPaiState(tmp, true);
+  applyPaiState(tmp, true, opts);
   assert.equal(fs.existsSync(parked()), false);
   assert.equal(fs.readFileSync(live(), 'utf8'), original);
 });
 
 test('ISC-A1: applyPaiState never deletes; same total file count survives', () => {
-  fs.writeFileSync(live(), 'a');
+  const opts = ours('a');
   fs.writeFileSync(path.join(tmp, 'unrelated.txt'), 'b');
-  applyPaiState(tmp, false);
-  applyPaiState(tmp, true);
-  applyPaiState(tmp, false);
-  applyPaiState(tmp, true);
+  applyPaiState(tmp, false, opts);
+  applyPaiState(tmp, true, opts);
+  applyPaiState(tmp, false, opts);
+  applyPaiState(tmp, true, opts);
   const survivors = fs.readdirSync(tmp).sort();
   assert.deepEqual(survivors, ['CLAUDE.md', 'unrelated.txt']);
 });
 
 test('ISC-A2: applyPaiState writes only inside the supplied claudeDir', () => {
-  fs.writeFileSync(live(), 'pai\n');
+  const opts = ours('pai\n');
   const before = fs.readdirSync(os.tmpdir()).filter((n) => n.includes('husk-pai-')).length;
-  applyPaiState(tmp, false);
-  applyPaiState(tmp, true);
+  applyPaiState(tmp, false, opts);
+  applyPaiState(tmp, true, opts);
   const after = fs.readdirSync(os.tmpdir()).filter((n) => n.includes('husk-pai-')).length;
   assert.equal(after, before, 'no new sibling dirs created in tmpdir');
 });
@@ -281,4 +288,46 @@ test('merge with malformed markers (END before START) falls back to append', () 
   const lastStart = merged.lastIndexOf(HUSK_AGENTS_START);
   const lastEnd = merged.lastIndexOf(HUSK_AGENTS_END);
   assert.ok(lastEnd > lastStart, 'new block has START before END at the bottom');
+});
+
+// ─── the user's own CLAUDE.md is not ours to move ─────────────────────────
+// ~/.claude/CLAUDE.md belongs to the user. Plenty of people wrote one long
+// before they installed Husk, and a toggle in our Preferences must never
+// relocate it: the CLI stops seeing their config and the cause is invisible.
+
+test('a hand-written CLAUDE.md survives disabling, untouched', () => {
+  const mine = '# my own rules\nbuilt up over a year\n';
+  fs.writeFileSync(live(), mine);
+  // Digests of what Husk ships. The user's file matches none of them.
+  applyPaiState(tmp, false, { templateDigests: [digestOf('# the shipped scaffold\n')] });
+  assert.equal(fs.existsSync(live()), true, 'the user file must stay where the CLI reads it');
+  assert.equal(fs.readFileSync(live(), 'utf8'), mine, 'and must be byte-identical');
+  assert.equal(fs.existsSync(parked()), false, 'nothing should have been parked');
+});
+
+test('a scaffold the user has since edited is theirs, and stays put', () => {
+  const shipped = '# the shipped scaffold\n';
+  fs.writeFileSync(live(), shipped + '\nmy own additions\n');
+  applyPaiState(tmp, false, { templateDigests: [digestOf(shipped)] });
+  assert.equal(fs.existsSync(live()), true);
+  assert.equal(fs.existsSync(parked()), false);
+});
+
+test('with no digests supplied, nothing is parked: unproven ownership is not ownership', () => {
+  fs.writeFileSync(live(), 'anything at all\n');
+  applyPaiState(tmp, false);
+  assert.equal(fs.existsSync(live()), true);
+  assert.equal(fs.existsSync(parked()), false);
+});
+
+test('an older shipped scaffold is still recognised as ours', () => {
+  const older = '# scaffold from a previous Husk release\n';
+  fs.writeFileSync(live(), older);
+  applyPaiState(tmp, false, { templateDigests: [digestOf('# current\n'), digestOf(older)] });
+  assert.equal(fs.existsSync(live()), false, 'ours, so it parks');
+  assert.equal(fs.existsSync(parked()), true);
+});
+
+test('isHuskAuthoredClaudeMd is false when the file is absent', () => {
+  assert.equal(isHuskAuthoredClaudeMd(tmp, [digestOf('x')]), false);
 });


### PR DESCRIPTION
`~/.claude/CLAUDE.md` belongs to the user. Husk was writing itself into that space in two ways.

**Turning the framework off renamed whatever CLAUDE.md was there.** A file written long before Husk was installed disappeared from the path the CLI reads, with nothing on screen to say why. Parking is now gated on the file still matching a scaffold we shipped, byte for byte. Anything else, including our own scaffold once edited, stays put. Matching on content rather than a recorded flag means installs predating the check need no migration.

**The bundle carries agent-instruction files from the upstream project's own repo**, and the copy walked them into the user's tree. Landed there they read as standing orders nobody wrote, in the place the CLI looks for the user's own. Both bootstrap paths skip them now, and the installer removes only copies it placed that still match the bundle.

Verified against real installs, not just units: a hand-written CLAUDE.md survives the toggle byte-identical; Husk's own scaffold still parks and restores byte-identical; a fresh install ends with exactly one CLAUDE.md, the user's. Unit 755/755, e2e 50/50.

No version bump; this is not a release.