### PR TITLE
feat(agents): find and continue the agents a chat starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ a cleanup path such as `~/.local/share/husk`, the uninstaller skips that path.
 3. Press the Launch button and start chatting. The agent runs in a real PTY, so everything you would normally do in the terminal works: tool calls, slash commands, stdin, ctrl-c, scrollback, keyboard interrupts, the lot.
 4. Drag files onto the window to share them with the agent. Use the topbar `+` button as a fallback file picker.
 5. Switch pages with the rail or `Alt+1..6`. Open the command palette with `Cmd/Ctrl+K`.
+6. If a chat starts agents that keep working on their own, the topbar says how many are running and how many are waiting on you. Click it or press `Alt+A` to pick one and continue its conversation.
 
 ### Pages
 
@@ -196,7 +197,7 @@ a cleanup path such as `~/.local/share/husk`, the uninstaller skips that path.
 - **MCP**: install / toggle / health-check Model Context Protocol servers.
 - **Plugins**: browse and manage Husk plugins.
 - **Files**: drag-drop file context, with a tree view of your working directory.
-- **Sessions**: resume any prior agent session from its JSONL log.
+- **Sessions**: resume any prior agent session from its JSONL log. Agents a chat started are grouped under that chat rather than listed beside it.
 
 Preferences (agent command, name, theme, accent, voice, recap, sidebar defaults) open as a modal from the rail or `Alt+6`, not as a page.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "husk",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "husk",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",

--- a/src/lib/model-catalog.js
+++ b/src/lib/model-catalog.js
@@ -18,7 +18,8 @@ const PROVIDER_LABELS = Object.freeze({
 
 const FALLBACK_MODEL_CATALOGS = Object.freeze({
   claude: [
-    ['opus', 'Opus 4.8'],
+    ['opus', 'Opus 5'],
+    ['opus[1m]', 'Opus 5 With 1M Context'],
     ['fable', 'Fable 5'],
     ['sonnet', 'Sonnet 5'],
     ['haiku', 'Haiku 4.5'],
@@ -119,6 +120,22 @@ function titleFromId(id) {
     .join(' ')
     .replace(/\bGpt\b/g, 'GPT')
     .replace(/\bAi\b/g, 'AI');
+}
+
+// Every picker row reads "<Name> · <what it is for>". The long-context row
+// breaks that shape: it repeats its tier inside the name, in the picker's own
+// lowercase wording. Normalize the name half and keep the description after the
+// separator so the row sits in the dropdown looking like its siblings.
+function longContextLabel(description, family) {
+  const parts = String(description || '').split('·');
+  const name = parts[0]
+    .replace(/\(1m context\)/ig, '')
+    .replace(/\bwith\s+1m\s+context\b/ig, '')
+    .replace(/\s+/g, ' ')
+    .trim() || titleFromId(family);
+  const rest = parts.slice(1).join('·').replace(/\s+/g, ' ').trim();
+  const named = `${name} With 1M Context`;
+  return rest ? `${named} · ${rest}` : named;
 }
 
 function cleanLabel(label) {
@@ -257,8 +274,17 @@ function modelCandidateFromLine(line, vendor) {
       if (tag) rest = rest.slice(tag[0].length).trim();
       const fam = rest.match(/^(opus|fable|sonnet|haiku)\b/i);
       if (fam) {
-        const label = rest.slice(fam[0].length).trim().replace(/^[-\u2014\u2013]/, '').trim().slice(0, 160);
-        const value = fam[1].toLowerCase();
+        let value = fam[1].toLowerCase();
+        rest = rest.slice(fam[0].length).trim();
+        // The long-context row qualifies the family name rather than naming a
+        // separate one: "Opus (1M context)". The tier belongs to the id the CLI
+        // accepts, so it moves into the value. Left in the label it both reads
+        // as a description and collapses onto the base family, which drops one
+        // of the two rows on the way to the picker.
+        const tier = rest.match(/^\(1m context\)/i);
+        if (tier) { value += '[1m]'; rest = rest.slice(tier[0].length).trim(); }
+        let label = rest.replace(/^[-\u2014\u2013]/, '').trim().slice(0, 160);
+        if (tier) label = longContextLabel(label, fam[1]);
         return { value, label: cleanLabel(label || titleFromId(value)) };
       }
     }
@@ -328,7 +354,7 @@ function isModelValueUsable(value, vendor) {
   const normalized = normalizeModelId(raw);
   if (!normalized || normalized !== raw.replace(/[),.;:]+$/g, '')) return false;
   if (looksLikeModelId(normalized, vendor)
-    || /^(opus|fable|sonnet|haiku|opusplan)$/i.test(normalized)
+    || /^(opus|fable|sonnet|haiku|opusplan)(\[1m\])?$/i.test(normalized)
     || /^(kimi|mai)-/i.test(normalized)) return true;
   // aider routes to arbitrary providers (openrouter/x/y, bare aliases like
   // flash or r1), so a saved aider value that passed the garbage checks
@@ -349,9 +375,10 @@ function looksLikeModelId(id, vendor) {
   if (/(^|[-./_])(api|sdk|cli|docs?|settings|config|readme|help)$/.test(x)) return false;
   if (v === 'claude') {
     // The claude CLI accepts tier aliases and claude-* ids only; anything
-    // else scraped from its TUI is narration, not a selectable model.
-    if (/^(haiku|sonnet|opus|fable|opusplan)$/.test(x)) return true;
-    return /^claude-[a-z0-9][a-z0-9.-]*$/.test(x);
+    // else scraped from its TUI is narration, not a selectable model. Either
+    // form may carry the long-context suffix, as in opus[1m].
+    if (/^(haiku|sonnet|opus|fable|opusplan)(\[1m\])?$/.test(x)) return true;
+    return /^claude-[a-z0-9][a-z0-9.-]*(\[1m\])?$/.test(x);
   }
   // One optional "provider/" prefix, stripped before the vendor-word check so
   // the regex stays flat.

--- a/src/lib/model-routing.js
+++ b/src/lib/model-routing.js
@@ -48,7 +48,9 @@ function isExplicitModelValueUsable(value) {
   // older catalog parsing) must never reach the CLI as --model.
   if (/\.(json|jsonc|ya?ml|md|txt|log|lock|toml|ini|cfg|conf|sh|mjs|cjs|js|ts)$/i.test(raw)) return false;
   if (/(^|[-./_])(api|sdk|cli|docs?|settings|config|readme|help)$/i.test(raw)) return false;
-  return /^[A-Za-z0-9][A-Za-z0-9._:+/-]*$/.test(raw);
+  // A trailing [1m] selects the long-context tier and is part of the id the
+  // CLI accepts, so it survives the character check rather than failing it.
+  return /^[A-Za-z0-9][A-Za-z0-9._:+/-]*(\[1m\])?$/i.test(raw);
 }
 
 // Classify a goal into a model tier. Conservative by design: only route DOWN

--- a/src/main.js
+++ b/src/main.js
@@ -891,6 +891,14 @@ function killPtyTree() {
 
 // ─── PTY ─────────────────────────────────────────────────────────────────────────
 
+// Transcript file names present in a project dir right now. Used to tell a
+// resumed tab's successor transcript apart from the one it was resumed from.
+function listTranscriptNames(projDir) {
+  try {
+    return fs.readdirSync(projDir).filter((f) => f.endsWith('.jsonl'));
+  } catch (_) { return []; }
+}
+
 // The last claude session id Husk bound for a given project dir, so a fresh
 // app boot can resume the ongoing discussion instead of starting a new one.
 function lastClaudeSessionForCwd(encodedCwd, projDir) {
@@ -1093,10 +1101,18 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   }
   if (s.claudeSessionId) {
     try {
-      const pinned = path.join(CLAUDE_DIR, 'projects', encodedCwd, `${s.claudeSessionId}.jsonl`);
+      const projDir = path.join(CLAUDE_DIR, 'projects', encodedCwd);
+      const pinned = path.join(projDir, `${s.claudeSessionId}.jsonl`);
       // Resume: the file exists already. New chat: it appears once claude starts
       // writing, so until then the session has no transcript and reads 0 context.
-      s.transcript = fs.existsSync(pinned) ? pinned : null;
+      const resumed = fs.existsSync(pinned);
+      s.transcript = resumed ? pinned : null;
+      // --resume names the conversation to continue, not the file that will be
+      // written: the CLI opens a fresh transcript under a new id and leaves the
+      // one it was handed frozen. Snapshot the directory so the successor is
+      // identifiable later as the file that was not here when this tab spawned.
+      s.resumedTranscript = resumed;
+      s.priorTranscripts = resumed ? new Set(listTranscriptNames(projDir)) : null;
     } catch (_) { s.transcript = null; }
   }
 
@@ -1380,7 +1396,7 @@ function readActiveSessionStats() {
       .filter((f) => f.endsWith('.jsonl'))
       .map((f) => {
         const p = path.join(dir, f);
-        try { const st = fs.statSync(p); return { p, mtime: st.mtimeMs, size: st.size }; } catch (_) { return null; }
+        try { const st = fs.statSync(p); return { p, mtime: st.mtimeMs, btime: st.birthtimeMs, size: st.size }; } catch (_) { return null; }
       })
       .filter(Boolean)
       .sort((a, b) => b.mtime - a.mtime);
@@ -1392,7 +1408,33 @@ function readActiveSessionStats() {
     // with the conversation; it re-resolves only when that file disappears.
     const sess = activeSessionId ? sessions.get(activeSessionId) : null;
     let latest = null;
-    if (sess && sess.claudeSessionId) {
+    if (sess && sess.resumedTranscript) {
+      // A resumed tab was handed the id of the conversation to continue, and the
+      // CLI writes the continuation to a new file. Reading the id it was handed
+      // reports the source conversation forever: its model, its turn count, its
+      // occupancy, none of them moving. The live file is the one that was not in
+      // the directory when this tab spawned. Take the earliest such file rather
+      // than the newest, because background agents write here too and the tab's
+      // own transcript is the first to appear after launch.
+      const claimed = new Set();
+      for (const o of sessions.values()) if (o !== sess && o.transcript) claimed.add(o.transcript);
+      const prior = sess.priorTranscripts || new Set();
+      const fresh = files
+        .filter((f) => !prior.has(path.basename(f.p)) && !claimed.has(f.p))
+        .sort((a, b) => (a.btime || a.mtime) - (b.btime || b.mtime))[0];
+      if (fresh) {
+        latest = fresh.p;
+        sess.transcript = fresh.p;
+        sess.claudeSessionId = path.basename(fresh.p, '.jsonl');
+        sess.resumedTranscript = false;
+        sess.priorTranscripts = null;
+        rememberClaudeSession(encoded, sess.claudeSessionId);
+      } else if (sess.transcript && fs.existsSync(sess.transcript)) {
+        // Nothing new yet: keep showing the resumed conversation rather than a
+        // blank panel, since that is what the pane is displaying too.
+        latest = sess.transcript;
+      }
+    } else if (sess && sess.claudeSessionId) {
       // This tab owns exactly <claudeSessionId>.jsonl in its cwd, so tabs that
       // share a cwd stay distinct. The file appears on the chat's first turn;
       // until then there is nothing to read and the context reads 0.

--- a/src/main.js
+++ b/src/main.js
@@ -1563,7 +1563,7 @@ function readActiveSessionStats() {
     // record in the file's tail, so it stays correct even for huge transcripts.
     const ctxWindow = resolveContextWindow(activePtyCwd, effModel, ctxTokens);
     const ctxPct = ctxWindow ? Math.round((ctxTokens / ctxWindow) * 1000) / 10 : 0;
-    return { turns, chars, tokens: Math.round(chars / 4), file: latest, model: effModel, ctxTokens, ctxWindow, ctxPct };
+    return { turns, chars, tokens: Math.round(chars / 4), file: latest, model: effModel, modelLabel: catalogModelLabel(effModel), ctxTokens, ctxWindow, ctxPct };
   } catch (_) { return null; }
 }
 
@@ -4134,6 +4134,37 @@ function runAiderModelProbe(agentCommand) {
     child.on('error', (err) => done({ ok: false, output, error: (err && err.message) || String(err) }));
     child.on('close', () => done({ ok: output.trim().length > 0, output, error: output.trim() ? '' : 'model list exited with no output' }));
   });
+}
+
+// What the CLI itself calls a model, taken from the catalog its own /model
+// picker produced. Deriving a name from the id can only ever print what the id
+// already spells out: the alias "opus[1m]" carries no version, so it reads as a
+// bare "Opus" until a transcript turn happens to name the full id. The catalog
+// is the provider's own wording, so a model Husk has never heard of arrives
+// correctly named the day it ships.
+//
+// Returns '' for a full versioned id such as claude-opus-5, on purpose: the
+// name derived from it is already right, and resolving it through an alias row
+// would report whatever the alias points at today, relabelling an older session
+// as the current model. '' is also the answer before the catalog has been read.
+// Both cases leave the id-derived name in place.
+function catalogModelLabel(id, command = null) {
+  const raw = String(id || '').trim();
+  if (!raw) return '';
+  const head = safeAgentCommandHead(command || config.agentCommand || 'claude');
+  if (!head) return '';
+  const cached = modelCatalogCache.get(`${head.base}:${head.exe}`);
+  const models = cached && cached.value && Array.isArray(cached.value.models) ? cached.value.models : null;
+  if (!models || !models.length) return '';
+  // Compare with the context tier and vendor prefix removed, so "opus[1m]",
+  // "opus" and "claude-opus-5" all reach the same catalog row.
+  const key = (s) => String(s || '').toLowerCase().replace(/\[[^\]]*\]/g, '').replace(/^claude-/, '');
+  const want = key(raw);
+  const hit = models.find((m) => key(m.value) === want);
+  if (!hit) return '';
+  // Catalog labels read "Opus 5 · Best for everyday use". The status panel has
+  // room for the name, not the blurb.
+  return String(hit.label || '').split('·')[0].trim();
 }
 
 async function discoverModelCatalog({ refresh = false, command = null, fast = false } = {}) {
@@ -8694,6 +8725,12 @@ if (!gotLock) {
     try { reconcileOrphanWorktrees(); } catch (_) {}
     createWindow();
     setupAutoUpdater();
+    // Read the active CLI's model catalog once in the background so the status
+    // panel can name the running model in the provider's own words from the
+    // first poll. The probe drives the CLI's picker in a PTY and takes seconds,
+    // so it must never sit in front of the window opening; until it lands the
+    // panel falls back to the name derived from the model id.
+    setTimeout(() => { discoverModelCatalog().catch(() => {}); }, 4000);
   });
   app.on('window-all-closed', () => {
     killPtyTree(); stopNullVoiceServer(); stopStatuslineRefresh(); stopUsageRefresh(); stopAutoUpdater();

--- a/src/main.js
+++ b/src/main.js
@@ -4202,7 +4202,12 @@ function catalogModelLabel(id, command = null) {
   const head = safeAgentCommandHead(command || config.agentCommand || 'claude');
   if (!head) return '';
   const cached = modelCatalogCache.get(`${head.base}:${head.exe}`);
-  const models = cached && cached.value && Array.isArray(cached.value.models) ? cached.value.models : null;
+  const live = cached && cached.value && Array.isArray(cached.value.models) ? cached.value.models : null;
+  // The live catalog is only there once something has asked the CLI for it, and
+  // asking means driving its picker in a terminal. Not worth spawning the user's
+  // agent binary unprompted just to title a row, so fall back to the names we
+  // already know for this vendor.
+  const models = (live && live.length) ? live : fallbackModelsFor(head.base);
   if (!models || !models.length) return '';
   // Compare with the context tier and vendor prefix removed, so "opus[1m]",
   // "opus" and "claude-opus-5" all reach the same catalog row.
@@ -8918,12 +8923,6 @@ if (!gotLock) {
     try { reconcileOrphanWorktrees(); } catch (_) {}
     createWindow();
     setupAutoUpdater();
-    // Read the active CLI's model catalog once in the background so the status
-    // panel can name the running model in the provider's own words from the
-    // first poll. The probe drives the CLI's picker in a PTY and takes seconds,
-    // so it must never sit in front of the window opening; until it lands the
-    // panel falls back to the name derived from the model id.
-    setTimeout(() => { discoverModelCatalog().catch(() => {}); }, 4000);
   });
   app.on('window-all-closed', () => {
     killPtyTree(); stopNullVoiceServer(); stopStatuslineRefresh(); stopUsageRefresh(); stopAutoUpdater();

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const http = require('http');
 const crypto = require('crypto');
-const { spawn } = require('child_process');
+const { spawn, execFile } = require('child_process');
 const pty = require('node-pty');
 
 const { shJoin } = require('./lib/shell-quote');
@@ -935,7 +935,28 @@ function rememberClaudeSession(encodedCwd, sessionId) {
   saveConfig(config);
 }
 
-function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null, sessionId = null, resumeLast = false) {
+// Environment variables the renderer is allowed to set on a spawned agent.
+// An allowlist rather than a passthrough: the renderer hands this straight to a
+// child process, and names like PATH, LD_PRELOAD or NODE_OPTIONS decide which
+// code runs, not merely how it behaves. Values are single-line and bounded so a
+// crafted string cannot carry a newline into the environment block.
+const SPAWN_ENV_ALLOW = new Set(['CLAUDE_AGENTS_SELECT']);
+function sanitizeSpawnEnv(env) {
+  if (!env || typeof env !== 'object') return null;
+  const out = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (!SPAWN_ENV_ALLOW.has(k)) continue;
+    const value = String(v == null ? '' : v);
+    if (!value || value.length > 200 || /[\r\n\0]/.test(value)) continue;
+    out[k] = value;
+  }
+  return Object.keys(out).length ? out : null;
+}
+
+// extraEnv reaches the child process and nothing else. Attaching to a running
+// background agent is selected by an environment variable the CLI reads at
+// startup, so there is no command-line form to express it.
+function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null, sessionId = null, resumeLast = false, extraEnv = null) {
   // Target an existing session (Restart replaces just that tab's child) or
   // create a new one (New Chat passes a fresh id so the running agents keep
   // going). Falls back to the active session, then a generated id.
@@ -977,7 +998,7 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
     // right panel already surfaces. PAI side checks $HUSK_HOST and
     // early-exits.
     HUSK_HOST: '1',
-  });
+  }, extraEnv && typeof extraEnv === 'object' ? extraEnv : {});
   const bunBin = path.join(HOME, '.bun', 'bin');
   if (env.PATH && !env.PATH.includes(bunBin)) env.PATH = `${bunBin}:${env.PATH}`;
   // ~/.local/bin is where the native claude installer (and other user CLIs)
@@ -1594,7 +1615,7 @@ function readActiveSessionStats() {
 function targetSession(sessionId) {
   return (sessionId && sessions.get(sessionId)) || activeSession();
 }
-ipcMain.handle('pty:start', (_e, { cols, rows, command, cwd, sessionId, resumeLast } = {}) => spawnPty(cols, rows, command || null, cwd || null, sessionId || null, !!resumeLast));
+ipcMain.handle('pty:start', (_e, { cols, rows, command, cwd, sessionId, resumeLast, env } = {}) => spawnPty(cols, rows, command || null, cwd || null, sessionId || null, !!resumeLast, sanitizeSpawnEnv(env)));
 // List the chat PTYs that are still alive, so a reloaded renderer can rebuild
 // its tabs and reattach instead of orphaning them and minting a fresh chat.
 ipcMain.handle('pty:list', () => {
@@ -7860,6 +7881,144 @@ ipcMain.handle('sessions:resumeCommand', (_e, payload = {}) => {
     return { ok: true, command: `gemini --resume ${index}` };
   }
   return { ok: false, error: `resume is not supported for ${agent} sessions` };
+});
+
+// ─── Background agents ───────────────────────────────────────────────────────
+// A chat can start agents that keep working on their own. They are separate
+// top-level sessions, not turns inside the chat, which is why they surface as
+// peers in a naive session listing and why resuming one the ordinary way fails:
+// the CLI refuses while the agent is still running and points at its own picker.
+
+// The parent a background agent was forked from. Two records carry it and
+// neither is sufficient alone. The transcript's snake_case `session_id` is the
+// id of the process that wrote the line, so on a forked file it keeps naming
+// the parent while `sessionId` names the child; it is exact, but only once the
+// agent has written a turn. The daemon roster is exact from the moment of
+// spawn, and is dropped the moment the worker exits. Together they cover the
+// whole lifetime.
+function bgAgentParent(sessionId, projDir) {
+  try {
+    const roster = JSON.parse(fs.readFileSync(path.join(CLAUDE_DIR, 'daemon', 'roster.json'), 'utf8'));
+    const workers = (roster && roster.workers) || {};
+    for (const w of Object.values(workers)) {
+      if (!w || w.sessionId !== sessionId) continue;
+      const launch = w.dispatch && w.dispatch.launch;
+      if (launch && launch.fork && typeof launch.sessionId === 'string') {
+        return path.basename(launch.sessionId).replace(/\.jsonl$/, '');
+      }
+    }
+  } catch (_) {}
+  try {
+    // Bounded: the first line carrying session_id sits within a couple of MB
+    // even when early turns drag large attachments with them.
+    const head = readHead(path.join(projDir, `${sessionId}.jsonl`), 2 * 1024 * 1024);
+    for (const line of head.split('\n')) {
+      const m = line.match(/"session_id":"([0-9a-f-]{16,})"/);
+      if (m && m[1] !== sessionId) return m[1];
+    }
+  } catch (_) {}
+  return '';
+}
+
+// Durable per-agent state. Survives the worker, unlike the roster, and is where
+// the one-line "what it is doing" comes from.
+function bgAgentJobState(shortId) {
+  if (!shortId) return {};
+  try {
+    const j = JSON.parse(fs.readFileSync(path.join(CLAUDE_DIR, 'jobs', shortId, 'state.json'), 'utf8'));
+    return {
+      state: j.state || '',
+      detail: typeof j.detail === 'string' ? j.detail.replace(/\s+/g, ' ').trim().slice(0, 160) : '',
+      intent: typeof j.intent === 'string' ? j.intent.replace(/\s+/g, ' ').trim().slice(0, 400) : '',
+      needs: typeof j.needs === 'string' ? j.needs.slice(0, 160) : '',
+      tokens: Number(j.tokens) || 0,
+      updatedAt: Number(j.updatedAt) || 0,
+    };
+  } catch (_) { return {}; }
+}
+
+ipcMain.handle('bgAgents:list', async (_e, payload = {}) => {
+  const agent = activeAgentName();
+  // Tool-agnostic by construction: a CLI with no agent concept reports that it
+  // has none, rather than the UI naming a vendor it happens to know about.
+  if (agent !== 'claude') return { ok: true, supported: false, agents: [] };
+  const cwd = String((payload && payload.cwd) || activePtyCwd || '').trim();
+  const args = ['agents', '--json'];
+  if (cwd) args.push('--cwd', cwd);
+  if (payload && payload.all) args.push('--all');
+  const env = buildAgentEnv();
+  const exe = resolveAgentExe('claude', env.PATH);
+  let raw = '';
+  try {
+    raw = await new Promise((resolve, reject) => {
+      execFile(exe, args, { env, timeout: 8000, maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+        if (err) reject(err); else resolve(String(stdout || ''));
+      });
+    });
+  } catch (err) {
+    return { ok: false, supported: true, agents: [], error: (err && err.message) || 'could not list agents' };
+  }
+  let rows = [];
+  try { rows = JSON.parse(raw); } catch (_) {
+    return { ok: false, supported: true, agents: [], error: 'agent list was not readable' };
+  }
+  if (!Array.isArray(rows)) return { ok: true, supported: true, agents: [] };
+  const projDir = cwd ? path.join(CLAUDE_DIR, 'projects', cwd.replace(/[^a-zA-Z0-9]/g, '-')) : '';
+  const agents = rows
+    .filter((r) => r && r.kind === 'background' && r.sessionId)
+    .map((r) => {
+      const shortId = String(r.id || String(r.sessionId).slice(0, 8));
+      const job = bgAgentJobState(shortId);
+      const transcript = projDir ? path.join(projDir, `${r.sessionId}.jsonl`) : '';
+      return {
+        id: shortId,
+        sessionId: String(r.sessionId),
+        name: String(r.name || '').slice(0, 120),
+        cwd: String(r.cwd || ''),
+        // A pid means a live worker. Attaching is only valid then; once it is
+        // gone the session resumes like any other chat.
+        running: r.pid != null,
+        status: String(r.status || ''),
+        state: String(r.state || job.state || ''),
+        detail: job.detail || '',
+        intent: job.intent || '',
+        needs: job.needs || '',
+        tokens: job.tokens || 0,
+        startedAt: Number(r.startedAt) || 0,
+        updatedAt: job.updatedAt || 0,
+        parentSessionId: projDir ? bgAgentParent(String(r.sessionId), projDir) : '',
+        // An agent can be listed and running with nothing on disk yet, so the
+        // caller must not treat a missing transcript as a missing agent.
+        hasTranscript: !!(transcript && fs.existsSync(transcript)),
+        transcript,
+      };
+    });
+  return { ok: true, supported: true, agents };
+});
+
+// How to reach one agent. Validated before it is handed back, the way copilot
+// and gemini already are: returning a command blind is what produces a tab that
+// opens onto nothing.
+ipcMain.handle('bgAgents:openCommand', (_e, payload = {}) => {
+  const agent = activeAgentName();
+  if (agent !== 'claude') return { ok: false, error: `background agents are not available for ${agent}` };
+  const id = String((payload && payload.id) || '').trim();
+  const sessionId = String((payload && payload.sessionId) || '').trim();
+  if (!id && !sessionId) return { ok: false, error: 'no agent selected' };
+  if (payload && payload.running) {
+    // A running agent is owned by its worker; the CLI refuses --resume against
+    // one and says so. Its own fleet view is the supported way in, and it opens
+    // straight onto this agent when told which one.
+    if (!/^[A-Za-z0-9][A-Za-z0-9-]{2,}$/.test(id)) return { ok: false, error: 'that agent has no id to attach to' };
+    return { ok: true, mode: 'attach', command: 'claude agents', env: { CLAUDE_AGENTS_SELECT: id } };
+  }
+  if (!/^[0-9a-fA-F-]{16,}$/.test(sessionId)) return { ok: false, error: 'that agent has no session to resume' };
+  const cwd = String((payload && payload.cwd) || activePtyCwd || '');
+  const projDir = path.join(CLAUDE_DIR, 'projects', cwd.replace(/[^a-zA-Z0-9]/g, '-'));
+  if (!fs.existsSync(path.join(projDir, `${sessionId}.jsonl`))) {
+    return { ok: false, error: 'that agent finished without leaving a transcript' };
+  }
+  return { ok: true, mode: 'resume', command: `claude --resume ${sessionId}` };
 });
 
 ipcMain.handle('sessions:rename', (_e, payload = {}) => {

--- a/src/main.js
+++ b/src/main.js
@@ -899,6 +899,24 @@ function listTranscriptNames(projDir) {
   } catch (_) { return []; }
 }
 
+// Whether a transcript belongs to a person typing in a terminal. Hooks, title
+// generators and agent SDK calls all write into the same project directory and
+// often land there before the chat's own first turn, so creation order cannot
+// identify a tab's transcript. The CLI records how the session was entered:
+// an interactive one is "cli", everything programmatic is "sdk-cli"/"sdk-py".
+function isInteractiveTranscript(file) {
+  try {
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(64 * 1024);
+      const n = fs.readSync(fd, buf, 0, buf.length, 0);
+      const head = buf.toString('utf8', 0, n);
+      if (/"entrypoint"\s*:\s*"sdk/.test(head)) return false;
+      return /"entrypoint"\s*:\s*"cli"/.test(head);
+    } finally { fs.closeSync(fd); }
+  } catch (_) { return false; }
+}
+
 // The last claude session id Husk bound for a given project dir, so a fresh
 // app boot can resume the ongoing discussion instead of starting a new one.
 function lastClaudeSessionForCwd(encodedCwd, projDir) {
@@ -1413,15 +1431,19 @@ function readActiveSessionStats() {
       // CLI writes the continuation to a new file. Reading the id it was handed
       // reports the source conversation forever: its model, its turn count, its
       // occupancy, none of them moving. The live file is the one that was not in
-      // the directory when this tab spawned. Take the earliest such file rather
-      // than the newest, because background agents write here too and the tab's
-      // own transcript is the first to appear after launch.
+      // the directory when this tab spawned, written by an interactive session.
+      // The interactive test is what makes this reliable: hooks and title
+      // generators spawn their own sessions into the same directory, and one of
+      // them routinely appears before the chat's own first turn, so arrival
+      // order alone picks a two-turn helper. Earliest-first among the survivors,
+      // since the tab's transcript precedes any agent it goes on to spawn.
       const claimed = new Set();
       for (const o of sessions.values()) if (o !== sess && o.transcript) claimed.add(o.transcript);
       const prior = sess.priorTranscripts || new Set();
       const fresh = files
         .filter((f) => !prior.has(path.basename(f.p)) && !claimed.has(f.p))
-        .sort((a, b) => (a.btime || a.mtime) - (b.btime || b.mtime))[0];
+        .sort((a, b) => (a.btime || a.mtime) - (b.btime || b.mtime))
+        .find((f) => isInteractiveTranscript(f.p));
       if (fresh) {
         latest = fresh.p;
         sess.transcript = fresh.p;

--- a/src/main.js
+++ b/src/main.js
@@ -1017,6 +1017,12 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   const userTokens = rawCmd.split(/\s+/).filter(Boolean);
   let agentExe = userTokens.shift() || 'claude';
   let agentArgs = userTokens;
+  // A subcommand runs a different program under the same binary: `claude agents`
+  // manages background agents and takes none of the chat flags. Decided from the
+  // command as typed, because injected flags are prepended below and would
+  // otherwise hide the subcommand behind them. Only the first token counts, so a
+  // flag's bare value ("--permission-mode default") is not mistaken for one.
+  const isSubcommand = agentArgs.length > 0 && !String(agentArgs[0]).startsWith('-');
 
   // Resolve a bare program name to an absolute path up front (which/where via a
   // login shell if needed) so the spawn does not depend on the child PATH being
@@ -1040,7 +1046,7 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   // folder trust remains in ~/.claude.json.
   const isWin32 = process.platform === 'win32';
   let injectionPlan = { method: 'none' };
-  if (!isWin32 && !agentArgs.includes('--settings')) {
+  if (!isWin32 && !isSubcommand && !agentArgs.includes('--settings')) {
     injectionPlan = AgentInject.planInjection({
       agentCommand: rawCmd,
       agentName: config.agentName,
@@ -1115,12 +1121,6 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   const encodedCwd = cwd.replace(/[^a-zA-Z0-9]/g, '-');
   const resumeMatch = (rawCmd || '').match(/--resume[=\s]+([A-Za-z0-9][A-Za-z0-9-]{6,})/);
   const isClaudeAgent = agentExe === 'claude' || agentExe.endsWith('/claude') || agentExe.endsWith('\\claude');
-  // A subcommand runs a different program with its own flags: `claude agents`
-  // manages background agents and rejects the session flags the chat form takes.
-  // Only the bare chat invocation gets bound to a transcript.
-  // Only the first token decides: a flag's value is also a bare word, so
-  // `--permission-mode default` must not read as a subcommand.
-  const isSubcommand = agentArgs.length > 0 && !String(agentArgs[0]).startsWith('-');
   if (resumeMatch) {
     s.claudeSessionId = resumeMatch[1];
   } else if (isClaudeAgent && !isWin32 && !isSubcommand && !agentArgs.includes('--session-id') && !agentArgs.includes('--resume')) {

--- a/src/main.js
+++ b/src/main.js
@@ -4162,9 +4162,16 @@ function catalogModelLabel(id, command = null) {
   const want = key(raw);
   const hit = models.find((m) => key(m.value) === want);
   if (!hit) return '';
-  // Catalog labels read "Opus 5 · Best for everyday use". The status panel has
-  // room for the name, not the blurb.
-  return String(hit.label || '').split('·')[0].trim();
+  // Catalog labels read "Opus 5 With 1M Context · Best for everyday use". The
+  // panel wants the model's name: not the blurb, and not the context tier,
+  // which it already reports on its own row and which is a property of the
+  // session rather than part of what the model is called. The dropdown keeps
+  // the full wording, since choosing a tier is the point there.
+  return String(hit.label || '').split('·')[0]
+    .replace(/\bwith\s+1m\s+context\b/ig, '')
+    .replace(/\(1m context\)/ig, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 async function discoverModelCatalog({ refresh = false, command = null, fast = false } = {}) {

--- a/src/main.js
+++ b/src/main.js
@@ -1115,9 +1115,15 @@ function spawnPty(cols = 100, rows = 30, overrideCmd = null, overrideCwd = null,
   const encodedCwd = cwd.replace(/[^a-zA-Z0-9]/g, '-');
   const resumeMatch = (rawCmd || '').match(/--resume[=\s]+([A-Za-z0-9][A-Za-z0-9-]{6,})/);
   const isClaudeAgent = agentExe === 'claude' || agentExe.endsWith('/claude') || agentExe.endsWith('\\claude');
+  // A subcommand runs a different program with its own flags: `claude agents`
+  // manages background agents and rejects the session flags the chat form takes.
+  // Only the bare chat invocation gets bound to a transcript.
+  // Only the first token decides: a flag's value is also a bare word, so
+  // `--permission-mode default` must not read as a subcommand.
+  const isSubcommand = agentArgs.length > 0 && !String(agentArgs[0]).startsWith('-');
   if (resumeMatch) {
     s.claudeSessionId = resumeMatch[1];
-  } else if (isClaudeAgent && !isWin32 && !agentArgs.includes('--session-id') && !agentArgs.includes('--resume')) {
+  } else if (isClaudeAgent && !isWin32 && !isSubcommand && !agentArgs.includes('--session-id') && !agentArgs.includes('--resume')) {
     // Keep one discussion in one transcript across restarts (project switch, MCP
     // reload, manual restart). Within a process the tab reuses its own
     // claudeSessionId. Across a full app restart that in-memory id is gone, so

--- a/src/main.js
+++ b/src/main.js
@@ -1538,17 +1538,16 @@ function readActiveSessionStats() {
         }
       } catch (_) {}
     }
-    // Model preference. The transcript records the model on every assistant
-    // turn, so when this tab owns its transcript it is the live truth for the
-    // session: it reflects mid-session switches that happen server-side
-    // without settings.json ever changing (settings only knows what was
-    // configured, not what the session is actually running). settings.json
-    // still fills the gap before the first assistant turn. When the tab has
-    // NO resolved transcript of its own (bare files[0] fallback below), keep
-    // settings first so a stale newest-by-mtime file cannot mislabel it.
+    // Model preference. settings.json is the model the user selected and the
+    // same value the CLI's own picker reports, so it answers "what is this
+    // running" directly and cannot name some other session. A transcript can
+    // only answer it by first being the right transcript, and this directory
+    // holds hundreds written by hooks, title generators and agent runs; picking
+    // the wrong one reports a model the user never chose. Transcripts are used
+    // for turn counts and occupancy, which are per-file by nature, and for the
+    // model only when settings names none.
     const settingsModel = ((readClaudeSettings() || {}).model || '').trim();
-    const ownTranscript = Boolean(sess && latest);
-    let effModel = ownTranscript ? (model || settingsModel) : (settingsModel || model);
+    let effModel = settingsModel || model;
     // Model label fallback, DISPLAY ONLY. If neither settings.json nor this
     // tab's own transcript yielded a model (a brand-new tab before its first
     // turn, or a non-claude tab), borrow the model from the newest transcript

--- a/src/preload.js
+++ b/src/preload.js
@@ -94,6 +94,13 @@ contextBridge.exposeInMainWorld('husk', {
     resumeCommand: (payload) => ipcRenderer.invoke('sessions:resumeCommand', payload),
     delete: (paths) => ipcRenderer.invoke('sessions:delete', { paths }),
   },
+  // Agents a chat started that keep working on their own. Distinct from
+  // `agents` below, which detects which agent CLIs are installed, and from the
+  // Agents page, which edits reusable agent definitions.
+  bgAgents: {
+    list: (payload) => ipcRenderer.invoke('bgAgents:list', payload || {}),
+    openCommand: (payload) => ipcRenderer.invoke('bgAgents:openCommand', payload || {}),
+  },
   prds: { list: () => ipcRenderer.invoke('prds:list') },
   plugins: {
     list: () => ipcRenderer.invoke('plugins:list'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1915,8 +1915,14 @@ async function refreshStatusline() {
   // (claude from ~/.claude, copilot from ~/.copilot), so it always names
   // the agent's real model, never a different CLI's session. The ctx
   // fallback is claude-only (context window is a claude-transcript figure).
-  const modelLabel = prettyModelLabel((u.session && u.session.model)
-    || (agentKindCache === 'claude' && ctx && ctx.model) || '');
+  // The CLI's own name for the model wins when the catalog has been read: an
+  // id-derived name can only print what the id spells out, so a bare alias
+  // renders without its version. Falls back to the derived name until then.
+  const modelId = (u.session && u.session.model)
+    || (agentKindCache === 'claude' && ctx && ctx.model) || '';
+  const modelLabel = (u.session && u.session.modelLabel)
+    || (agentKindCache === 'claude' && ctx && ctx.modelLabel)
+    || prettyModelLabel(modelId);
   // The active agent CLI (claude, codex, copilot, ...) and its version, so the
   // Build section reflects whichever agent is selected, not a fixed one.
   const agentLabel = (s.agent || 'claude').replace(/^\w/, (c) => c.toUpperCase());
@@ -1957,7 +1963,7 @@ async function refreshStatusline() {
       <div class="sp-section-head"><span class="sp-h-icon">▣</span><span>Build</span></div>
       <div class="sp-section-body">
         <div class="sp-row"><span class="sp-muted">${escapeHtml(agentLabel)} ${spInfo('Installed CLI version of the active agent.')}</span><span class="sp-mono">${escapeHtml(s.agentVersion || 'unknown')}</span></div>
-        ${modelLabel ? `<div class="sp-row"><span class="sp-muted">Model ${spInfo('The AI model the active session is running.')}</span><span class="sp-mono sp-accent" title="${escapeHtml((u.session && u.session.model) || (ctx && ctx.model) || '')}">${escapeHtml(modelLabel)}</span></div>` : ''}
+        ${modelLabel ? `<div class="sp-row"><span class="sp-muted">Model ${spInfo('The AI model the active session is running.')}</span><span class="sp-mono sp-accent" title="${escapeHtml(modelId)}">${escapeHtml(modelLabel)}</span></div>` : ''}
         <div class="sp-row"><span class="sp-muted">Husk ${spInfo('Installed Husk app version.')}</span><span class="sp-mono">${escapeHtml(s.huskVer || '0.2')}</span></div>
       </div>
     </div>

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -675,6 +675,26 @@ const MANUAL_UPDATE_CMD = {
 // update, and at the end of the first-run flow). Bullets are trusted static
 // strings; the <strong> lead-ins are intentional markup.
 const WHATS_NEW = {
+  '2.10.1': {
+    items: [
+      {
+        title: 'Agents a chat starts are visible',
+        body: 'A chat can send agents off to work on their own. The topbar now says how many are running and how many are waiting on you, so you find them without knowing they exist.',
+      },
+      {
+        title: 'Open an agent and keep talking',
+        body: 'Press Alt+A, pick an agent, and land in its conversation. Running agents attach, finished ones resume, and the switcher tells them apart by what each is doing right now.',
+      },
+      {
+        title: 'Agents sit under the chat that started them',
+        body: 'The Sessions list groups them under their chat instead of listing them beside it, so one conversation is one row again.',
+      },
+      {
+        title: 'The status panel names the right model',
+        body: 'It reads the model you selected rather than guessing from whichever transcript was newest, so a resumed chat no longer reports a model it is not running.',
+      },
+    ],
+  },
   '2.10.0': {
     items: [
       {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1240,7 +1240,7 @@ async function openNewChatTab(opts = {}) {
   chatHasInput = false;
   resetSpeechState();
   clearSessionContext();
-  await window.husk.pty.start({ cols, rows, command: opts.command || null, cwd: opts.cwd || null, sessionId: tab.id });
+  await window.husk.pty.start({ cols, rows, command: opts.command || null, cwd: opts.cwd || null, sessionId: tab.id, env: opts.env || null });
   tab.term.focus();
   maybeShowTrustBanner();
   // skipWelcome: the caller is about to write into this chat, so painting the
@@ -9859,6 +9859,160 @@ const PALETTE_ACTIONS = [
 ];
 
 let paletteSel = 0;
+// ─── Agent switcher ──────────────────────────────────────────────────────────
+// A chat can start agents that keep working after it moves on. They are their
+// own sessions, so the only way to reach one has been to leave Husk and drive
+// the CLI's picker by hand. This is that picker, owned by Husk.
+let agentSwitch = { rows: [], sel: 0, loading: false, error: '', supported: true, parent: null };
+
+function agentAgeLabel(ms) {
+  if (!ms) return '';
+  const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86400) return `${(s / 3600).toFixed(s < 36000 ? 1 : 0)}h`;
+  return `${Math.round(s / 86400)}d`;
+}
+
+// Rows are titled from the parent chat, so the title alone cannot tell two
+// agents apart. What the agent is doing right now can.
+function agentSubtitle(a) {
+  if (a.detail) return a.detail;
+  if (a.needs) return a.needs;
+  if (a.intent) return a.intent;
+  return a.running ? 'starting' : 'no activity recorded';
+}
+
+async function openAgentSwitch() {
+  const el = $('#agent-switch');
+  if (!el) return;
+  el.hidden = false;
+  $('#agent-switch-input').value = '';
+  agentSwitch = { rows: [], sel: 0, loading: true, error: '', supported: true };
+  renderAgentSwitch('');
+  $('#agent-switch-input').focus();
+  let res = null;
+  // No cwd: main scopes to the active chat's directory, which is the one whose
+  // agents the user is asking about.
+  try { res = await window.husk.bgAgents.list({}); } catch (err) { res = { ok: false, error: (err && err.message) || 'could not reach the agent list' }; }
+  if (el.hidden) return;                       // closed while we were loading
+  agentSwitch.loading = false;
+  agentSwitch.supported = !res || res.supported !== false;
+  agentSwitch.error = res && res.ok === false ? (res.error || 'could not list agents') : '';
+  agentSwitch.rows = (res && Array.isArray(res.agents) ? res.agents : [])
+    .slice()
+    .sort((a, b) => (a.startedAt || 0) - (b.startedAt || 0));
+  renderAgentSwitch($('#agent-switch-input').value);
+}
+
+function closeAgentSwitch() {
+  const el = $('#agent-switch');
+  if (el) el.hidden = true;
+  if (term) term.focus();
+}
+
+function agentSwitchMatches(query) {
+  const q = String(query || '').toLowerCase().trim();
+  if (!q) return agentSwitch.rows;
+  return agentSwitch.rows.filter((a) =>
+    (a.name || '').toLowerCase().includes(q)
+    || (a.detail || '').toLowerCase().includes(q)
+    || (a.intent || '').toLowerCase().includes(q));
+}
+
+function renderAgentSwitch(query) {
+  const list = $('#agent-switch-list');
+  if (!list) return;
+  const esc = escapeHtml;
+  if (agentSwitch.loading) {
+    // Shape-preserving placeholders: the list has known geometry, so a spinner
+    // would say less than the rows it is about to be replaced by.
+    // eslint-disable-next-line no-unsanitized/property -- Static markup, no interpolation.
+    list.innerHTML = '<li class="as-skel"></li><li class="as-skel"></li><li class="as-skel"></li>';
+    return;
+  }
+  if (!agentSwitch.supported) {
+    // eslint-disable-next-line no-unsanitized/property -- Static markup, no interpolation.
+    list.innerHTML = '<li class="as-empty"><strong>This tool has no background agents</strong><span>Husk shows them for tools that start them.</span></li>';
+    return;
+  }
+  if (agentSwitch.error) {
+    // eslint-disable-next-line no-unsanitized/property -- Only the escaped error text is interpolated.
+    list.innerHTML = `<li class="as-empty"><strong>Could not list agents</strong><span>${esc(agentSwitch.error)}</span></li>`;
+    return;
+  }
+  const rows = agentSwitchMatches(query);
+  if (!rows.length) {
+    const msg = agentSwitch.rows.length
+      ? '<strong>No agent matches</strong><span>Clear the filter to see them all.</span>'
+      : '<strong>No agents yet</strong><span>Agents this chat starts in the background show up here.</span>';
+    // eslint-disable-next-line no-unsanitized/property -- Both branches are literals.
+    list.innerHTML = `<li class="as-empty">${msg}</li>`;
+    return;
+  }
+  if (agentSwitch.sel >= rows.length) agentSwitch.sel = rows.length - 1;
+  if (agentSwitch.sel < 0) agentSwitch.sel = 0;
+  // eslint-disable-next-line no-unsanitized/property -- Every interpolated value is escaped above.
+  list.innerHTML = rows.map((a, i) => {
+    const state = a.running ? (a.state === 'blocked' ? 'is-blocked' : 'is-running') : 'is-done';
+    const stateWord = a.running ? (a.state === 'blocked' ? 'needs input' : 'working') : 'done';
+    return `
+    <li class="as-row ${state} ${i === agentSwitch.sel ? 'active' : ''}" data-idx="${i}">
+      <span class="as-idx">${i < 9 ? i + 1 : ''}</span>
+      <span class="as-dot" aria-hidden="true"></span>
+      <span class="as-text">
+        <strong>${esc(a.name || a.id)}</strong>
+        <span class="as-sub">${esc(agentSubtitle(a))}</span>
+      </span>
+      <span class="as-state">${esc(stateWord)}</span>
+      <span class="as-age">${esc(agentAgeLabel(a.startedAt))}</span>
+    </li>`;
+  }).join('');
+  list.querySelectorAll('li.as-row').forEach((li, i) => {
+    li.addEventListener('mouseenter', () => { agentSwitch.sel = i; renderAgentSwitch($('#agent-switch-input').value); });
+    li.addEventListener('click', () => openAgentFromSwitch(i));
+  });
+}
+
+async function openAgentFromSwitch(idx) {
+  const rows = agentSwitchMatches($('#agent-switch-input').value);
+  const a = rows[idx];
+  if (!a) return;
+  closeAgentSwitch();
+  await openBgAgent(a);
+}
+
+// A running agent belongs to its worker and cannot be resumed like a chat; the
+// tool refuses and says so. Its own agent view is the supported way in, and it
+// opens straight onto this agent when told which one. A finished agent has no
+// worker left, so it resumes normally.
+async function openBgAgent(a) {
+  let res = null;
+  try {
+    res = await window.husk.bgAgents.openCommand({
+      id: a.id, sessionId: a.sessionId, running: !!a.running, cwd: a.cwd || '',
+    });
+  } catch (err) { res = { ok: false, error: (err && err.message) || 'could not open that agent' }; }
+  if (!res || !res.ok) {
+    toast((res && res.error) || 'could not open that agent', 'error');
+    return;
+  }
+  setPage('chat');
+  const tab = await openNewChatTab({
+    command: res.command,
+    env: res.env || null,
+    cwd: a.cwd || null,
+    skipContext: true,
+    skipWelcome: true,
+  });
+  if (tab) {
+    tab.customTitle = a.name || a.id;
+    tab.agentId = a.sessionId || '';
+    renderTabStrip();
+  }
+  toast(`Opened ${a.name || a.id}`, 'success');
+}
+
 function openPalette() {
   $('#palette').hidden = false;
   $('#palette-input').value = '';
@@ -9907,6 +10061,23 @@ $('#palette-input').addEventListener('keydown', (e) => {
   }
 });
 $('#palette').addEventListener('click', (e) => { if (e.target.id === 'palette') closePalette(); });
+
+$('#agent-switch-input').addEventListener('input', (e) => { agentSwitch.sel = 0; renderAgentSwitch(e.target.value); });
+$('#agent-switch-input').addEventListener('keydown', (e) => {
+  const value = $('#agent-switch-input').value;
+  const rows = agentSwitchMatches(value);
+  if (e.key === 'Escape') { e.preventDefault(); closeAgentSwitch(); return; }
+  if (e.key === 'ArrowDown') { e.preventDefault(); agentSwitch.sel = Math.min(rows.length - 1, agentSwitch.sel + 1); renderAgentSwitch(value); return; }
+  if (e.key === 'ArrowUp') { e.preventDefault(); agentSwitch.sel = Math.max(0, agentSwitch.sel - 1); renderAgentSwitch(value); return; }
+  if (e.key === 'Enter') { e.preventDefault(); openAgentFromSwitch(agentSwitch.sel); return; }
+  // Number keys jump, but only while the filter is empty: once the user is
+  // typing, a digit belongs to the search text.
+  if (!value && /^[1-9]$/.test(e.key)) {
+    const idx = Number(e.key) - 1;
+    if (idx < rows.length) { e.preventDefault(); openAgentFromSwitch(idx); }
+  }
+});
+$('#agent-switch').addEventListener('click', (e) => { if (e.target.id === 'agent-switch') closeAgentSwitch(); });
 $('#btn-palette').addEventListener('click', openPalette);
 // On the chat page, if focus is on the page body (nothing focused) and a
 // printable/edit key is pressed, focus the active terminal first so the
@@ -9937,6 +10108,11 @@ window.addEventListener('keydown', (e) => {
     const map = { '1': 'chat', '2': 'skills', '3': 'sessions', '4': 'files', '5': 'mcp' };
     if (map[e.key]) { e.preventDefault(); setPage(map[e.key]); }
     if (e.key === '6') { e.preventDefault(); openPrefsModal(); }
+    // Alt-keyed like the rest of the chrome so it never eats terminal input.
+    if (String(e.key || '').toLowerCase() === 'a') {
+      e.preventDefault();
+      if ($('#agent-switch') && $('#agent-switch').hidden) openAgentSwitch(); else closeAgentSwitch();
+    }
   }
   // Ctrl/Cmd +/-/0 for renderer zoom
   if (e.ctrlKey || e.metaKey) {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -415,6 +415,8 @@ function createTab(idOverride) {
 // Show one tab, hide the rest, and re-point the active-tab pointers so the
 // shared handlers operate on it.
 function activateTab(id) {
+  // One cover for the whole terminal area, so it must not outlive its tab.
+  agentBootHide();
   const tab = TABS.get(id);
   if (!tab) return;
   // Drop the cached context reading so the next poll shows the newly-focused
@@ -10205,25 +10207,61 @@ async function openAgentFromSwitch(idx) {
 // a key sent into a half-drawn picker is dropped. Bounded, and sent once: if the
 // list never appears the user is simply left on whatever did.
 const AGENT_PICKER_READY = /awaiting input|to collapse|for shortcut/i;
+
+function agentBootShow(name) {
+  const el = $('#agent-boot');
+  if (!el) return;
+  $('#agent-boot-name').textContent = name || '';
+  el.classList.remove('is-leaving');
+  el.hidden = false;
+}
+function agentBootHide() {
+  const el = $('#agent-boot');
+  if (!el || el.hidden) return;
+  el.classList.add('is-leaving');
+  setTimeout(() => { el.hidden = true; el.classList.remove('is-leaving'); }, 140);
+}
+
+function agentTailText(tab) {
+  try {
+    const b = tab.term.buffer.active;
+    let text = '';
+    for (let i = Math.max(0, b.length - 60); i < b.length; i++) {
+      const line = b.getLine(i);
+      if (line) text += line.translateToString(true) + '\n';
+    }
+    return text;
+  } catch (_) { return ''; }
+}
+
 function confirmAgentSelection(tab) {
   const deadline = Date.now() + 12000;
+  // Poll tightly. The picker is only up for a few frames before the key lands,
+  // and every extra millisecond here is machinery the user would otherwise see.
   const tick = () => {
-    if (!tab || !tab.term || !TABS.has(tab.id)) return;
-    let text = '';
-    try {
-      const b = tab.term.buffer.active;
-      for (let i = Math.max(0, b.length - 60); i < b.length; i++) {
-        const line = b.getLine(i);
-        if (line) text += line.translateToString(true) + '\n';
-      }
-    } catch (_) { return; }
-    if (AGENT_PICKER_READY.test(text)) {
+    if (!tab || !tab.term || !TABS.has(tab.id)) { agentBootHide(); return; }
+    if (AGENT_PICKER_READY.test(agentTailText(tab))) {
       try { window.husk.pty.write('\r', tab.id); } catch (_) {}
+      waitForAgentConversation(tab, deadline);
       return;
     }
-    if (Date.now() < deadline) setTimeout(tick, 250);
+    if (Date.now() < deadline) setTimeout(tick, 40);
+    else agentBootHide();
   };
-  setTimeout(tick, 600);
+  setTimeout(tick, 40);
+}
+
+// Uncover only once the picker is off screen, so the cover never lifts onto a
+// half-drawn list. Failing open on the deadline: a stuck cover would hide a
+// working conversation, which is worse than a brief glimpse of the picker.
+function waitForAgentConversation(tab, deadline) {
+  const tick = () => {
+    if (!tab || !tab.term || !TABS.has(tab.id)) { agentBootHide(); return; }
+    if (!AGENT_PICKER_READY.test(agentTailText(tab))) { agentBootHide(); return; }
+    if (Date.now() < deadline) setTimeout(tick, 40);
+    else agentBootHide();
+  };
+  setTimeout(tick, 40);
 }
 
 async function openBgAgent(a) {
@@ -10252,7 +10290,7 @@ async function openBgAgent(a) {
       tab.customTitle = a.name || a.id;
       tab.agentId = a.sessionId || '';
       renderTabStrip();
-      if (res.mode === 'attach') confirmAgentSelection(tab);
+      if (res.mode === 'attach') { agentBootShow(a.name || a.id); confirmAgentSelection(tab); }
     }
     toast(`Opened ${a.name || a.id}`, 'success');
   } finally { agentOpening = false; }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -6288,6 +6288,7 @@ async function renderSessions() {
   sessionsCache = res.sessions;
   sessionsAgent = res.agent || 'claude';
   sessionsDir = res.sessionsDir || '';
+  await loadSessionAgents();
   // Reflect which agent's sessions are shown, and where they live.
   const subEl = $('#sessions-sub');
   if (subEl) {
@@ -6341,12 +6342,76 @@ function fmtSize(bytes) {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
+// Which listed sessions are actually agents a chat started, keyed by session id,
+// plus the parent each one belongs to. The list of sessions on disk cannot tell
+// them apart: an agent is a fork of its chat, so it inherits that chat's title
+// and looks like a peer conversation. The tool's own agent listing is
+// authoritative, so ask it rather than inferring from transcripts.
+let sessionAgents = { bySession: new Map(), byParent: new Map() };
+let sessionAgentsExpanded = new Set();
+
+async function loadSessionAgents() {
+  sessionAgents = { bySession: new Map(), byParent: new Map() };
+  let res = null;
+  try { res = await window.husk.bgAgents.list({ all: true }); } catch (_) { return; }
+  if (!res || !res.ok || !Array.isArray(res.agents)) return;
+  for (const a of res.agents) {
+    if (!a || !a.sessionId) continue;
+    sessionAgents.bySession.set(a.sessionId, a);
+    if (!a.parentSessionId) continue;
+    if (!sessionAgents.byParent.has(a.parentSessionId)) sessionAgents.byParent.set(a.parentSessionId, []);
+    sessionAgents.byParent.get(a.parentSessionId).push(a);
+  }
+  for (const arr of sessionAgents.byParent.values()) arr.sort((x, y) => (x.startedAt || 0) - (y.startedAt || 0));
+}
+
+function agentChildRowsHTML(parentId) {
+  const kids = sessionAgents.byParent.get(parentId) || [];
+  if (!kids.length || !sessionAgentsExpanded.has(parentId)) return '';
+  const rows = kids.map((a, i) => {
+    const state = a.running ? (a.state === 'blocked' ? 'is-blocked' : 'is-running') : 'is-done';
+    const word = a.running ? (a.state === 'blocked' ? 'needs input' : 'working') : 'done';
+    return `
+      <button class="agent-row ${state}" type="button" data-agent="${escapeAttr(a.sessionId)}">
+        <span class="agent-idx">${i + 1}</span>
+        <span class="agent-dot" aria-hidden="true"></span>
+        <span class="agent-desc">
+          <strong>${escapeHtml(a.name || a.id)}</strong>
+          <span class="agent-live">${escapeHtml(agentSubtitle(a))}</span>
+        </span>
+        <span class="agent-stat">${escapeHtml(word)}</span>
+        <span class="agent-stat">${escapeHtml(agentAgeLabel(a.startedAt))}</span>
+      </button>`;
+  }).join('');
+  return `<div class="agent-group">${rows}</div>`;
+}
+
+function agentChipHTML(parentId) {
+  const kids = sessionAgents.byParent.get(parentId) || [];
+  if (!kids.length) return '';
+  const live = kids.filter((a) => a.running).length;
+  const open = sessionAgentsExpanded.has(parentId);
+  return `<span class="session-agents" role="button" tabindex="0" data-agents-for="${escapeAttr(parentId)}" aria-expanded="${open ? 'true' : 'false'}">
+      <svg class="sa-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+      ${kids.length} agent${kids.length === 1 ? '' : 's'}${live ? `<span class="sa-live">${live} running</span>` : ''}
+    </span>`;
+}
+
 function paintSessions(list, query) {
   const ul = $('#sessions-list');
   const q = (query || '').toLowerCase().trim();
-  const filtered = q ? list.filter((s) =>
+  const matched = q ? list.filter((s) =>
     (s.title + ' ' + s.id + ' ' + s.projectPath + ' ' + (s.prdPhase || '')).toLowerCase().includes(q)
   ) : list;
+  // An agent is a fork of its chat, so it carries that chat's title and sits in
+  // the list as a peer conversation with the same name. Show it under the chat
+  // that started it instead. Only when that chat is actually in view: reparenting
+  // a row onto something not on screen would remove it with nowhere to go.
+  const present = new Set(matched.map((s) => s.id));
+  const filtered = matched.filter((s) => {
+    const a = sessionAgents.bySession.get(s.id);
+    return !(a && a.parentSessionId && present.has(a.parentSessionId));
+  });
   if (!filtered.length) {
     const card = list.length
       ? sessionsEmptyCard({
@@ -6391,6 +6456,8 @@ function paintSessions(list, query) {
         ${progressHTML || `<span class="session-progress">${escapeHtml(fmtSize(s.sizeBytes))}</span>`}
         ${phaseHTML}
       </button>
+      ${agentChipHTML(s.id)}
+      ${agentChildRowsHTML(s.id)}
     `;
   }).join('');
   ul.querySelectorAll('.session-row').forEach((r) =>
@@ -6401,6 +6468,23 @@ function paintSessions(list, query) {
       } else {
         openSessionDetail(r.dataset);
       }
+    })
+  );
+  const toggleAgents = (parentId) => {
+    if (sessionAgentsExpanded.has(parentId)) sessionAgentsExpanded.delete(parentId);
+    else sessionAgentsExpanded.add(parentId);
+    paintSessions(list, query);
+  };
+  ul.querySelectorAll('.session-agents').forEach((chip) => {
+    chip.addEventListener('click', () => toggleAgents(chip.dataset.agentsFor));
+    chip.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleAgents(chip.dataset.agentsFor); }
+    });
+  });
+  ul.querySelectorAll('.agent-row').forEach((row) =>
+    row.addEventListener('click', () => {
+      const a = sessionAgents.bySession.get(row.dataset.agent);
+      if (a) openBgAgent(a);
     })
   );
 }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -9940,7 +9940,7 @@ const PALETTE_ACTIONS = [
   // Ahead of the pages, because three entries answer "agent" and the palette
   // preselects the first: someone hunting a running agent was landing on the
   // page of agent definitions instead. The rail order below is untouched.
-  { icon: ICONS.agents,      label: 'Find a running agent',           run: () => openAgentSwitch(), shortcut: 'Alt A' },
+  { icon: ICONS.agents,      label: 'Find a running agent',           run: () => openAgentSwitch(), shortcut: 'Alt+A' },
   { icon: ICONS.agents,      label: 'Switch to Agents',               run: () => setPage('agents') },
   { icon: ICONS.workflows,   label: 'Switch to Workflows',            run: () => setPage('workflows') },
   { icon: ICONS.autopilot,    label: 'Switch to Autopilot',             run: () => setPage('autopilot') },

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -10199,6 +10199,33 @@ async function openAgentFromSwitch(idx) {
 // tool refuses and says so. Its own agent view is the supported way in, and it
 // opens straight onto this agent when told which one. A finished agent has no
 // worker left, so it resumes normally.
+// Opening an agent lands on the tool's own agent list with that agent selected,
+// not inside its conversation: the environment variable chooses the row, and a
+// return key opens it. Waiting for the list to paint before sending it, because
+// a key sent into a half-drawn picker is dropped. Bounded, and sent once: if the
+// list never appears the user is simply left on whatever did.
+const AGENT_PICKER_READY = /awaiting input|to collapse|for shortcut/i;
+function confirmAgentSelection(tab) {
+  const deadline = Date.now() + 12000;
+  const tick = () => {
+    if (!tab || !tab.term || !TABS.has(tab.id)) return;
+    let text = '';
+    try {
+      const b = tab.term.buffer.active;
+      for (let i = Math.max(0, b.length - 60); i < b.length; i++) {
+        const line = b.getLine(i);
+        if (line) text += line.translateToString(true) + '\n';
+      }
+    } catch (_) { return; }
+    if (AGENT_PICKER_READY.test(text)) {
+      try { window.husk.pty.write('\r', tab.id); } catch (_) {}
+      return;
+    }
+    if (Date.now() < deadline) setTimeout(tick, 250);
+  };
+  setTimeout(tick, 600);
+}
+
 async function openBgAgent(a) {
   if (agentOpening) return;                    // the tab takes a round trip to appear, so one press is one tab
   agentOpening = true;
@@ -10225,6 +10252,7 @@ async function openBgAgent(a) {
       tab.customTitle = a.name || a.id;
       tab.agentId = a.sessionId || '';
       renderTabStrip();
+      if (res.mode === 'attach') confirmAgentSelection(tab);
     }
     toast(`Opened ${a.name || a.id}`, 'success');
   } finally { agentOpening = false; }

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -8025,7 +8025,11 @@ function fillOrchSelect(sel, customInput, vendor, current) {
     for (const m of models) {
       const o = document.createElement('option');
       o.value = m.value;
-      o.textContent = m.label === m.value ? m.value : `${m.label}: ${m.value}`;
+      // The label already names the model. Appending the raw id repeated it in
+      // a second vocabulary and pushed the useful half of longer rows out of
+      // the control's width, so the id moves to the tooltip.
+      o.textContent = m.label || m.value;
+      if (m.label !== m.value) o.title = m.value;
       group.appendChild(o);
     }
     sel.appendChild(group);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -436,6 +436,9 @@ function activateTab(id) {
   Promise.resolve(window.husk.pty.setActive(id))
     .then(() => refreshStats())
     .then(() => refreshStatusline())
+    // The agent count is scoped to the active chat's directory, so it is only
+    // right once the main process knows which chat that is.
+    .then(() => refreshTopbarAgents())
     .catch(() => {});
 }
 
@@ -6368,21 +6371,17 @@ async function loadSessionAgents() {
 function agentChildRowsHTML(parentId) {
   const kids = sessionAgents.byParent.get(parentId) || [];
   if (!kids.length || !sessionAgentsExpanded.has(parentId)) return '';
-  const rows = kids.map((a, i) => {
-    const state = a.running ? (a.state === 'blocked' ? 'is-blocked' : 'is-running') : 'is-done';
-    const word = a.running ? (a.state === 'blocked' ? 'needs input' : 'working') : 'done';
-    return `
-      <button class="agent-row ${state}" type="button" data-agent="${escapeAttr(a.sessionId)}">
-        <span class="agent-idx">${i + 1}</span>
+  // The chat these belong to is the row directly above, so a child carries only
+  // what its siblings do not: its id, what it is doing, how it stands, how old.
+  // Fields run state then age here and in the switcher, in one age format.
+  const rows = kids.map((a) => `
+      <button class="agent-row ${agentStateClass(a)}" type="button" data-agent="${escapeAttr(a.sessionId)}">
         <span class="agent-dot" aria-hidden="true"></span>
-        <span class="agent-desc">
-          <strong>${escapeHtml(a.name || a.id)}</strong>
-          <span class="agent-live">${escapeHtml(agentSubtitle(a))}</span>
-        </span>
-        <span class="agent-stat">${escapeHtml(word)}</span>
-        <span class="agent-stat">${escapeHtml(agentAgeLabel(a.startedAt))}</span>
-      </button>`;
-  }).join('');
+        <code class="agent-id">${escapeHtml(agentShortId(a))}</code>
+        <span class="agent-live">${escapeHtml(agentSubtitle(a))}</span>
+        <span class="agent-state">${escapeHtml(agentStateWord(a))}</span>
+        <span class="agent-age">${escapeHtml(agentAgeLabel(a.startedAt))}</span>
+      </button>`).join('');
   return `<div class="agent-group">${rows}</div>`;
 }
 
@@ -6390,10 +6389,16 @@ function agentChipHTML(parentId) {
   const kids = sessionAgents.byParent.get(parentId) || [];
   if (!kids.length) return '';
   const live = kids.filter((a) => a.running).length;
+  const blocked = kids.filter((a) => a.running && a.state === 'blocked').length;
   const open = sessionAgentsExpanded.has(parentId);
-  return `<span class="session-agents" role="button" tabindex="0" data-agents-for="${escapeAttr(parentId)}" aria-expanded="${open ? 'true' : 'false'}">
+  // One tail note, and the waiting count outranks the running one: a chat with
+  // an agent stuck on a question needs the collapsed row to say so.
+  const tail = blocked
+    ? `<span class="sa-live">${blocked} needs you</span>`
+    : (live ? `<span class="sa-live">${live} running</span>` : '');
+  return `<span class="session-agents${blocked ? ' has-blocked' : ''}" role="button" tabindex="0" data-agents-for="${escapeAttr(parentId)}" aria-expanded="${open ? 'true' : 'false'}">
       <svg class="sa-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
-      ${kids.length} agent${kids.length === 1 ? '' : 's'}${live ? `<span class="sa-live">${live} running</span>` : ''}
+      <span class="sa-count">${kids.length} agent${kids.length === 1 ? '' : 's'}</span>${tail}
     </span>`;
 }
 
@@ -6437,16 +6442,18 @@ function paintSessions(list, query) {
   ul.classList.toggle('select-mode', sessionsSelectMode);
   // eslint-disable-next-line no-unsanitized/property -- Session fields are escaped via escapeHtml/escapeAttr.
   ul.innerHTML = filtered.map((s) => {
+    // No badge for the default: a filled pill reading "chat" on every chat is
+    // the loudest thing in the card and the only one carrying no information.
     const phaseHTML = s.prdPhase
       ? `<span class="session-phase ${escapeAttr(s.prdPhase)}">${escapeHtml(s.prdPhase)}</span>`
-      : `<span class="session-phase">chat</span>`;
+      : '';
     const progressHTML = s.prdProgress ? `<span class="session-progress">${escapeHtml(s.prdProgress)}</span>` : '';
     const checked = sessionsSelected.has(s.path) ? 'checked' : '';
     const checkboxHTML = sessionsSelectMode
       ? `<label class="session-check"><input class="ai-check" type="checkbox" tabindex="-1" ${checked} data-path="${escapeAttr(s.path)}" /><span class="ai-check-box"></span></label>`
       : '';
-    return `
-      <button class="session-row${sessionsSelected.has(s.path) ? ' selected' : ''}" data-id="${escapeAttr(s.id)}" data-title="${escapeAttr(s.title)}" data-project="${escapeAttr(s.projectPath)}" data-path="${escapeAttr(s.path)}" data-prdpath="${escapeAttr(s.prdPath)}" data-started="${escapeAttr(s.startedISO)}" data-mtime="${s.mtime}" data-size="${s.sizeBytes}" data-phase="${escapeAttr(s.prdPhase || '')}" data-progress="${escapeAttr(s.prdProgress || '')}">
+    const rowHTML = `
+      <button class="session-row${sessionsSelected.has(s.path) ? ' selected' : ''}${phaseHTML ? '' : ' no-phase'}" data-id="${escapeAttr(s.id)}" data-title="${escapeAttr(s.title)}" data-project="${escapeAttr(s.projectPath)}" data-path="${escapeAttr(s.path)}" data-prdpath="${escapeAttr(s.prdPath)}" data-started="${escapeAttr(s.startedISO)}" data-mtime="${s.mtime}" data-size="${s.sizeBytes}" data-phase="${escapeAttr(s.prdPhase || '')}" data-progress="${escapeAttr(s.prdProgress || '')}">
         ${checkboxHTML}
         <div class="session-task">
           <strong>${escapeHtml(s.title)}</strong>
@@ -6455,10 +6462,12 @@ function paintSessions(list, query) {
         <span class="session-effort">${escapeHtml(timeAgo(s.mtime))}</span>
         ${progressHTML || `<span class="session-progress">${escapeHtml(fmtSize(s.sizeBytes))}</span>`}
         ${phaseHTML}
-      </button>
-      ${agentChipHTML(s.id)}
-      ${agentChildRowsHTML(s.id)}
-    `;
+      </button>`;
+    // A chat and its agents are one card: the chat keeps the card's surface and
+    // the agents hang off it, so containment survives both theme families where
+    // a fill of their own would invert between them.
+    if (!(sessionAgents.byParent.get(s.id) || []).length) return rowHTML;
+    return `<div class="session-block">${rowHTML}${agentChipHTML(s.id)}${agentChildRowsHTML(s.id)}</div>`;
   }).join('');
   ul.querySelectorAll('.session-row').forEach((r) =>
     r.addEventListener('click', (e) => {
@@ -6473,7 +6482,14 @@ function paintSessions(list, query) {
   const toggleAgents = (parentId) => {
     if (sessionAgentsExpanded.has(parentId)) sessionAgentsExpanded.delete(parentId);
     else sessionAgentsExpanded.add(parentId);
+    const top = ul.scrollTop;
     paintSessions(list, query);
+    ul.scrollTop = top;
+    // The repaint replaces the chip that was just pressed, so hand focus to its
+    // replacement or the next key lands on the page body.
+    for (const chip of ul.querySelectorAll('.session-agents')) {
+      if (chip.dataset.agentsFor === parentId) { chip.focus(); break; }
+    }
   };
   ul.querySelectorAll('.session-agents').forEach((chip) => {
     chip.addEventListener('click', () => toggleAgents(chip.dataset.agentsFor));
@@ -9921,6 +9937,10 @@ const ICONS = {
 // to the focused terminal as literal input instead of switching pages.
 const PALETTE_ACTIONS = [
   { icon: ICONS.chat,        label: 'Switch to Chat',                 run: () => setPage('chat'),        shortcut: 'Alt 1' },
+  // Ahead of the pages, because three entries answer "agent" and the palette
+  // preselects the first: someone hunting a running agent was landing on the
+  // page of agent definitions instead. The rail order below is untouched.
+  { icon: ICONS.agents,      label: 'Find a running agent',           run: () => openAgentSwitch(), shortcut: 'Alt A' },
   { icon: ICONS.agents,      label: 'Switch to Agents',               run: () => setPage('agents') },
   { icon: ICONS.workflows,   label: 'Switch to Workflows',            run: () => setPage('workflows') },
   { icon: ICONS.autopilot,    label: 'Switch to Autopilot',             run: () => setPage('autopilot') },
@@ -9947,52 +9967,125 @@ let paletteSel = 0;
 // A chat can start agents that keep working after it moves on. They are their
 // own sessions, so the only way to reach one has been to leave Husk and drive
 // the CLI's picker by hand. This is that picker, owned by Husk.
-let agentSwitch = { rows: [], sel: 0, loading: false, error: '', supported: true, parent: null };
+// `view` is the list actually on screen. Every index handed back by a click, an
+// arrow or a digit means a position in that, never in the unfiltered set.
+let agentSwitch = { rows: [], view: [], sel: 0, loading: false, error: '', supported: true };
+let agentSwitchLoad = 0;
+let agentOpening = false;
+let agentSwitchPointer = { x: -1, y: -1 };
 
 function agentAgeLabel(ms) {
   if (!ms) return '';
   const s = Math.max(0, Math.round((Date.now() - ms) / 1000));
-  if (s < 60) return `${s}s`;
+  if (s < 60) return 'now';
   if (s < 3600) return `${Math.round(s / 60)}m`;
-  if (s < 86400) return `${(s / 3600).toFixed(s < 36000 ? 1 : 0)}h`;
+  if (s < 86400) return `${Math.round(s / 3600)}h`;
   return `${Math.round(s / 86400)}d`;
 }
 
-// Rows are titled from the parent chat, so the title alone cannot tell two
-// agents apart. What the agent is doing right now can.
+function agentStateClass(a) {
+  if (!a || !a.running) return 'is-done';
+  return a.state === 'blocked' ? 'is-blocked' : 'is-running';
+}
+
+// Only the waiting state is worded urgently; the other two label themselves
+// quietly so one marker in the list carries the thing that needs a human.
+function agentStateWord(a) {
+  if (!a || !a.running) return 'done';
+  return a.state === 'blocked' ? 'needs you' : 'working';
+}
+
+// What the agent is doing right now.
 function agentSubtitle(a) {
   if (a.detail) return a.detail;
   if (a.needs) return a.needs;
   if (a.intent) return a.intent;
-  return a.running ? 'starting' : 'no activity recorded';
+  return a.running ? 'starting up' : 'no activity recorded';
+}
+
+// The title is what a person recognises, so it leads. It cannot stand alone:
+// every agent a chat starts inherits that chat's title, so the id rides the
+// second line as the field that is guaranteed to differ between siblings.
+function agentHeadline(a) { return a.name || a.id || ''; }
+function agentShortId(a) { return String(a.id || a.sessionId || '').slice(0, 8); }
+
+// Order is the message: what is waiting on a human first, then what is still
+// moving, then what is over. Newest first inside each of the three.
+const AGENT_SECTIONS = [
+  { key: 'blocked', label: 'Needs you', has: (a) => a.running && a.state === 'blocked' },
+  { key: 'running', label: 'Running', has: (a) => a.running && a.state !== 'blocked' },
+  { key: 'done', label: 'Finished', has: (a) => !a.running },
+];
+
+function agentSections(rows) {
+  return AGENT_SECTIONS
+    .map((sec) => ({ label: sec.label, items: rows.filter(sec.has).sort((x, y) => (y.startedAt || 0) - (x.startedAt || 0)) }))
+    .filter((sec) => sec.items.length);
 }
 
 async function openAgentSwitch() {
   const el = $('#agent-switch');
   if (!el) return;
+  if (!$('#palette').hidden) closePalette();   // two stacked overlays would fight over the same keys
   el.hidden = false;
-  $('#agent-switch-input').value = '';
-  agentSwitch = { rows: [], sel: 0, loading: true, error: '', supported: true };
+  const input = $('#agent-switch-input');
+  input.value = '';
+  agentSwitch = { rows: [], view: [], sel: 0, loading: true, error: '', supported: true };
   renderAgentSwitch('');
-  $('#agent-switch-input').focus();
+  input.focus();
+  const token = ++agentSwitchLoad;
   let res = null;
   // No cwd: main scopes to the active chat's directory, which is the one whose
   // agents the user is asking about.
   try { res = await window.husk.bgAgents.list({}); } catch (err) { res = { ok: false, error: (err && err.message) || 'could not reach the agent list' }; }
-  if (el.hidden) return;                       // closed while we were loading
+  // Closed, or reopened while this call was in flight: the later open owns the list.
+  if (el.hidden || token !== agentSwitchLoad) return;
   agentSwitch.loading = false;
   agentSwitch.supported = !res || res.supported !== false;
   agentSwitch.error = res && res.ok === false ? (res.error || 'could not list agents') : '';
-  agentSwitch.rows = (res && Array.isArray(res.agents) ? res.agents : [])
-    .slice()
-    .sort((a, b) => (a.startedAt || 0) - (b.startedAt || 0));
-  renderAgentSwitch($('#agent-switch-input').value);
+  agentSwitch.rows = (res && Array.isArray(res.agents) ? res.agents : []).slice();
+  renderAgentSwitch(input.value);
+  paintTopbarAgents(res);
 }
 
 function closeAgentSwitch() {
   const el = $('#agent-switch');
   if (el) el.hidden = true;
+  agentSwitch.view = [];
   if (term) term.focus();
+}
+
+// The switcher is behind a chord nobody discovers on their own, so the topbar
+// carries a standing count. It stands down only when this project has no agents
+// at all: hiding it once the last one finishes takes the only way in with it,
+// at exactly the moment there is a finished agent worth reading.
+function paintTopbarAgents(res) {
+  const el = $('#topbar-agents');
+  if (!el) return;
+  const agents = res && res.ok !== false && res.supported !== false && Array.isArray(res.agents) ? res.agents : [];
+  const live = agents.filter((a) => a && a.running);
+  const blocked = live.filter((a) => a.state === 'blocked').length;
+  if (!agents.length) { el.hidden = true; return; }
+  el.hidden = false;
+  const n = live.length || agents.length;
+  $('#topbar-agents-count').textContent = String(n);
+  $('#topbar-agents-word').textContent = n === 1 ? 'agent' : 'agents';
+  const needs = $('#topbar-agents-needs');
+  needs.hidden = !blocked;
+  needs.textContent = blocked ? `${blocked} needs you` : '';
+  el.classList.toggle('is-blocked', !!blocked);
+  el.classList.toggle('is-running', !!live.length && !blocked);
+  el.classList.toggle('is-idle', !live.length);
+  if (!live.length) el.title = `${n} finished agent${n === 1 ? '' : 's'} in this project (Alt+A)`;
+  else if (blocked) el.title = `${blocked} of ${n} running agent${n === 1 ? '' : 's'} is waiting on you (Alt+A)`;
+  else el.title = `${n} agent${n === 1 ? '' : 's'} running in this project (Alt+A)`;
+}
+
+async function refreshTopbarAgents() {
+  if (!$('#topbar-agents')) return;
+  let res = null;
+  try { res = await window.husk.bgAgents.list({}); } catch (_) { res = null; }
+  paintTopbarAgents(res);
 }
 
 function agentSwitchMatches(query) {
@@ -10000,67 +10093,103 @@ function agentSwitchMatches(query) {
   if (!q) return agentSwitch.rows;
   return agentSwitch.rows.filter((a) =>
     (a.name || '').toLowerCase().includes(q)
+    || (a.id || '').toLowerCase().includes(q)
     || (a.detail || '').toLowerCase().includes(q)
     || (a.intent || '').toLowerCase().includes(q));
+}
+
+// One drawing for every state the list can be in instead of rows, so an empty
+// card is centred and iconed rather than one orphaned line at the row indent.
+function agentSwitchEmptyHTML(title, hint) {
+  return `<li class="as-empty" role="presentation">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M5 20c0-3.3 3.1-6 7-6s7 2.7 7 6"/></svg>
+      <strong>${escapeHtml(title)}</strong><span>${escapeHtml(hint)}</span>
+    </li>`;
 }
 
 function renderAgentSwitch(query) {
   const list = $('#agent-switch-list');
   if (!list) return;
   const esc = escapeHtml;
+  agentSwitch.view = [];
+  let html = '';
+  let count = 0;
   if (agentSwitch.loading) {
     // Shape-preserving placeholders: the list has known geometry, so a spinner
-    // would say less than the rows it is about to be replaced by.
-    // eslint-disable-next-line no-unsanitized/property -- Static markup, no interpolation.
-    list.innerHTML = '<li class="as-skel"></li><li class="as-skel"></li><li class="as-skel"></li>';
-    return;
-  }
-  if (!agentSwitch.supported) {
-    // eslint-disable-next-line no-unsanitized/property -- Static markup, no interpolation.
-    list.innerHTML = '<li class="as-empty"><strong>This tool has no background agents</strong><span>Husk shows them for tools that start them.</span></li>';
-    return;
-  }
-  if (agentSwitch.error) {
-    // eslint-disable-next-line no-unsanitized/property -- Only the escaped error text is interpolated.
-    list.innerHTML = `<li class="as-empty"><strong>Could not list agents</strong><span>${esc(agentSwitch.error)}</span></li>`;
-    return;
-  }
-  const rows = agentSwitchMatches(query);
-  if (!rows.length) {
-    const msg = agentSwitch.rows.length
-      ? '<strong>No agent matches</strong><span>Clear the filter to see them all.</span>'
-      : '<strong>No agents yet</strong><span>Agents this chat starts in the background show up here.</span>';
-    // eslint-disable-next-line no-unsanitized/property -- Both branches are literals.
-    list.innerHTML = `<li class="as-empty">${msg}</li>`;
-    return;
-  }
-  if (agentSwitch.sel >= rows.length) agentSwitch.sel = rows.length - 1;
-  if (agentSwitch.sel < 0) agentSwitch.sel = 0;
-  // eslint-disable-next-line no-unsanitized/property -- Every interpolated value is escaped above.
-  list.innerHTML = rows.map((a, i) => {
-    const state = a.running ? (a.state === 'blocked' ? 'is-blocked' : 'is-running') : 'is-done';
-    const stateWord = a.running ? (a.state === 'blocked' ? 'needs input' : 'working') : 'done';
-    return `
-    <li class="as-row ${state} ${i === agentSwitch.sel ? 'active' : ''}" data-idx="${i}">
-      <span class="as-idx">${i < 9 ? i + 1 : ''}</span>
+    // would say less than the rows it is about to be replaced by. A label
+    // placeholder rides along because the loaded list is banded.
+    html = '<li class="as-skel-group" role="presentation"><i></i></li>'
+      + '<li class="as-skel" role="presentation"><i class="sk-dot"></i><i class="sk-name"></i><i class="sk-sub"></i><i class="sk-meta"></i></li>'.repeat(4);
+  } else if (!agentSwitch.supported) {
+    html = agentSwitchEmptyHTML('This tool has no background agents', 'Husk shows them for tools that start them.');
+  } else if (agentSwitch.error) {
+    html = agentSwitchEmptyHTML('Could not list agents', agentSwitch.error);
+  } else {
+    const rows = agentSwitchMatches(query);
+    if (!rows.length) {
+      html = agentSwitch.rows.length
+        ? agentSwitchEmptyHTML('No agent matches', 'Clear the filter to see them all.')
+        : agentSwitchEmptyHTML('No agents yet', 'Agents this chat starts in the background show up here.');
+    } else {
+      count = rows.length;
+      // The flat view stays the index space every click, arrow and Enter speaks
+      // in; the section labels are painted around it and own no index.
+      const sections = agentSections(rows);
+      agentSwitch.view = sections.flatMap((sec) => sec.items);
+      agentSwitch.sel = Math.min(Math.max(agentSwitch.sel, 0), agentSwitch.view.length - 1);
+      let i = 0;
+      html = sections.map((sec) => `
+    <li class="as-group" role="presentation">${esc(sec.label)}</li>` + sec.items.map((a) => {
+        const idx = i++;
+        return `
+    <li class="as-row ${agentStateClass(a)}" id="as-row-${idx}" data-idx="${idx}" role="option" aria-selected="false">
       <span class="as-dot" aria-hidden="true"></span>
       <span class="as-text">
-        <strong>${esc(a.name || a.id)}</strong>
-        <span class="as-sub">${esc(agentSubtitle(a))}</span>
+        <strong class="as-name">${esc(agentHeadline(a))}</strong>
+        <span class="as-sub"><code class="as-id">${esc(agentShortId(a))}</code>${esc(agentSubtitle(a))}</span>
       </span>
-      <span class="as-state">${esc(stateWord)}</span>
-      <span class="as-age">${esc(agentAgeLabel(a.startedAt))}</span>
+      <span class="as-meta">
+        <span class="as-state">${esc(agentStateWord(a))}</span>
+        <span class="as-age">${esc(agentAgeLabel(a.startedAt))}</span>
+      </span>
     </li>`;
-  }).join('');
+      }).join('')).join('');
+    }
+  }
+  // eslint-disable-next-line no-unsanitized/property -- Every interpolated value is escaped or a literal.
+  list.innerHTML = html;
+  // A key hint that does nothing is worse than no hint, so the row keys stand
+  // down whenever there is no row for them to reach.
+  const navHints = $('#as-nav-hints');
+  if (navHints) navHints.hidden = !agentSwitch.view.length;
+  const foot = $('#as-foot-count');
+  if (foot) foot.textContent = count ? `${count} agent${count === 1 ? '' : 's'}` : '';
+  // Measured, not guessed: the bottom ramp is only honest while there is
+  // something below the fold, and the list is polled across that threshold.
+  list.classList.toggle('is-scrollable', list.scrollHeight > list.clientHeight + 1);
+  paintAgentSwitchSel(false);
+}
+
+// Moving the selection flips a class and never rebuilds the list: replacing the
+// rows under the pointer destroys the one being pressed, so its click is lost.
+function paintAgentSwitchSel(scroll) {
+  const list = $('#agent-switch-list');
+  const input = $('#agent-switch-input');
+  if (!list || !input) return;
+  let active = null;
   list.querySelectorAll('li.as-row').forEach((li, i) => {
-    li.addEventListener('mouseenter', () => { agentSwitch.sel = i; renderAgentSwitch($('#agent-switch-input').value); });
-    li.addEventListener('click', () => openAgentFromSwitch(i));
+    const on = i === agentSwitch.sel;
+    li.classList.toggle('active', on);
+    li.setAttribute('aria-selected', on ? 'true' : 'false');
+    if (on) active = li;
   });
+  if (active) input.setAttribute('aria-activedescendant', active.id);
+  else input.removeAttribute('aria-activedescendant');
+  if (scroll && active) active.scrollIntoView({ block: 'nearest' });
 }
 
 async function openAgentFromSwitch(idx) {
-  const rows = agentSwitchMatches($('#agent-switch-input').value);
-  const a = rows[idx];
+  const a = agentSwitch.view[idx];
   if (!a) return;
   closeAgentSwitch();
   await openBgAgent(a);
@@ -10071,33 +10200,38 @@ async function openAgentFromSwitch(idx) {
 // opens straight onto this agent when told which one. A finished agent has no
 // worker left, so it resumes normally.
 async function openBgAgent(a) {
-  let res = null;
+  if (agentOpening) return;                    // the tab takes a round trip to appear, so one press is one tab
+  agentOpening = true;
   try {
-    res = await window.husk.bgAgents.openCommand({
-      id: a.id, sessionId: a.sessionId, running: !!a.running, cwd: a.cwd || '',
+    let res = null;
+    try {
+      res = await window.husk.bgAgents.openCommand({
+        id: a.id, sessionId: a.sessionId, running: !!a.running, cwd: a.cwd || '',
+      });
+    } catch (err) { res = { ok: false, error: (err && err.message) || 'could not open that agent' }; }
+    if (!res || !res.ok) {
+      toast((res && res.error) || 'could not open that agent', 'error');
+      return;
+    }
+    setPage('chat');
+    const tab = await openNewChatTab({
+      command: res.command,
+      env: res.env || null,
+      cwd: a.cwd || null,
+      skipContext: true,
+      skipWelcome: true,
     });
-  } catch (err) { res = { ok: false, error: (err && err.message) || 'could not open that agent' }; }
-  if (!res || !res.ok) {
-    toast((res && res.error) || 'could not open that agent', 'error');
-    return;
-  }
-  setPage('chat');
-  const tab = await openNewChatTab({
-    command: res.command,
-    env: res.env || null,
-    cwd: a.cwd || null,
-    skipContext: true,
-    skipWelcome: true,
-  });
-  if (tab) {
-    tab.customTitle = a.name || a.id;
-    tab.agentId = a.sessionId || '';
-    renderTabStrip();
-  }
-  toast(`Opened ${a.name || a.id}`, 'success');
+    if (tab) {
+      tab.customTitle = a.name || a.id;
+      tab.agentId = a.sessionId || '';
+      renderTabStrip();
+    }
+    toast(`Opened ${a.name || a.id}`, 'success');
+  } finally { agentOpening = false; }
 }
 
 function openPalette() {
+  if (!$('#agent-switch').hidden) closeAgentSwitch();
   $('#palette').hidden = false;
   $('#palette-input').value = '';
   paletteSel = 0;
@@ -10148,20 +10282,45 @@ $('#palette').addEventListener('click', (e) => { if (e.target.id === 'palette') 
 
 $('#agent-switch-input').addEventListener('input', (e) => { agentSwitch.sel = 0; renderAgentSwitch(e.target.value); });
 $('#agent-switch-input').addEventListener('keydown', (e) => {
-  const value = $('#agent-switch-input').value;
-  const rows = agentSwitchMatches(value);
-  if (e.key === 'Escape') { e.preventDefault(); closeAgentSwitch(); return; }
-  if (e.key === 'ArrowDown') { e.preventDefault(); agentSwitch.sel = Math.min(rows.length - 1, agentSwitch.sel + 1); renderAgentSwitch(value); return; }
-  if (e.key === 'ArrowUp') { e.preventDefault(); agentSwitch.sel = Math.max(0, agentSwitch.sel - 1); renderAgentSwitch(value); return; }
-  if (e.key === 'Enter') { e.preventDefault(); openAgentFromSwitch(agentSwitch.sel); return; }
-  // Number keys jump, but only while the filter is empty: once the user is
-  // typing, a digit belongs to the search text.
-  if (!value && /^[1-9]$/.test(e.key)) {
-    const idx = Number(e.key) - 1;
-    if (idx < rows.length) { e.preventDefault(); openAgentFromSwitch(idx); }
+  const rows = agentSwitch.view;
+  // Nothing else may act on this Esc: the page underneath has its own, and one
+  // press must close one layer.
+  if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); closeAgentSwitch(); return; }
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (!rows.length) return;
+    const step = e.key === 'ArrowDown' ? 1 : -1;
+    agentSwitch.sel = (agentSwitch.sel + step + rows.length) % rows.length;
+    paintAgentSwitchSel(true);
+    return;
   }
+  if (e.key === 'Enter') { e.preventDefault(); openAgentFromSwitch(agentSwitch.sel); }
+});
+$('#agent-switch-list').addEventListener('mousedown', (e) => {
+  // A row cannot hold focus, so letting the press move it would strand the
+  // arrows and Enter away from the input that handles them.
+  if (e.target.closest('li.as-row')) e.preventDefault();
+});
+$('#agent-switch-list').addEventListener('click', (e) => {
+  const li = e.target.closest('li.as-row');
+  if (li) openAgentFromSwitch(Number(li.dataset.idx));
+});
+$('#agent-switch-list').addEventListener('mousemove', (e) => {
+  // Only a real pointer move re-aims the selection: scrolling a row under a
+  // parked cursor would otherwise undo the arrow key that caused the scroll.
+  if (e.clientX === agentSwitchPointer.x && e.clientY === agentSwitchPointer.y) return;
+  agentSwitchPointer = { x: e.clientX, y: e.clientY };
+  const li = e.target.closest('li.as-row');
+  if (!li) return;
+  const idx = Number(li.dataset.idx);
+  if (!Number.isInteger(idx) || idx === agentSwitch.sel) return;
+  agentSwitch.sel = idx;
+  paintAgentSwitchSel(false);
 });
 $('#agent-switch').addEventListener('click', (e) => { if (e.target.id === 'agent-switch') closeAgentSwitch(); });
+$('#topbar-agents').addEventListener('click', () => {
+  if ($('#agent-switch').hidden) openAgentSwitch(); else closeAgentSwitch();
+});
 $('#btn-palette').addEventListener('click', openPalette);
 // On the chat page, if focus is on the page body (nothing focused) and a
 // printable/edit key is pressed, focus the active terminal first so the
@@ -10686,6 +10845,11 @@ async function boot() {
     if (document.hidden) return;
     refreshRecentList();
   }, 30000);
+  refreshTopbarAgents();
+  setInterval(() => {
+    if (document.hidden) return;
+    refreshTopbarAgents();
+  }, 20000);
 
   // With skipWelcome on, boot goes straight to a chat, so the welcome screen
   // must never paint. Adding it unconditionally here made it flash for the
@@ -12072,9 +12236,10 @@ function autopilotPageVisible() {
   const page = document.querySelector('.page-autopilot');
   return !!(page && !page.hidden);
 }
+// Every overlay that floats on the palette shell, so a key aimed at one of them
+// is not also read as a key for the page underneath.
 function paletteOpen() {
-  const p = $('#palette');
-  return !!(p && !p.hidden);
+  return !!document.querySelector('.palette:not([hidden])');
 }
 // Close the topmost open modal the way the modal itself would: its own
 // close button when it has one (state cleanup runs), else the backdrop

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -317,6 +317,20 @@
       </div>
     </div>
 
+    <!-- Agents this chat started that keep working on their own. -->
+    <div id="agent-switch" class="palette" hidden>
+      <div class="palette-card">
+        <input type="text" id="agent-switch-input" placeholder="Switch agent" autocomplete="off" spellcheck="false" />
+        <ul id="agent-switch-list" class="palette-list"></ul>
+        <div class="palette-foot">
+          <span><kbd>↑↓</kbd> navigate</span>
+          <span><kbd>1-9</kbd> jump</span>
+          <span><kbd>↵</kbd> open</span>
+          <span><kbd>Esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+
     <!-- Topbar -->
     <header id="topbar">
       <button class="topbar-project" id="topbar-project" title="Active project (click to switch)" hidden>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -526,6 +526,12 @@
             <div class="terminal-wrap">
               <div id="tab-strip" class="tab-strip"></div>
               <div id="terminal"></div>
+              <!-- Covers the tool's own agent picker while Husk drives it. -->
+              <div id="agent-boot" class="agent-boot" hidden>
+                <span class="ab-dot" aria-hidden="true"></span>
+                <span class="ab-name" id="agent-boot-name"></span>
+                <span class="ab-sub">Opening</span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -354,7 +354,7 @@
         <span class="ta-count" id="topbar-agents-count"></span>
         <span class="ta-word" id="topbar-agents-word"></span>
         <span class="ta-needs" id="topbar-agents-needs" hidden></span>
-        <span class="ta-key" aria-hidden="true">Alt A</span>
+        <span class="ta-key" aria-hidden="true">Alt+A</span>
       </button>
       <button class="iconbtn" id="btn-palette" title="Command palette (Ctrl+K)">⌘K</button>
       <button class="iconbtn iconbtn-primary" id="btn-new-session" title="New chat session (restarts the agent)"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> New Chat</button>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -320,13 +320,20 @@
     <!-- Agents this chat started that keep working on their own. -->
     <div id="agent-switch" class="palette" hidden>
       <div class="palette-card">
-        <input type="text" id="agent-switch-input" placeholder="Switch agent" autocomplete="off" spellcheck="false" />
-        <ul id="agent-switch-list" class="palette-list"></ul>
+        <!-- The glyph holds the same column the row dots do, so the query text
+             starts on the left edge every result title and section label uses. -->
+        <div class="as-head">
+          <svg class="as-head-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.6-3.6"/></svg>
+          <input type="text" id="agent-switch-input" placeholder="Filter agents" autocomplete="off" spellcheck="false" role="combobox" aria-controls="agent-switch-list" aria-expanded="true" aria-autocomplete="list" />
+        </div>
+        <ul id="agent-switch-list" class="palette-list" role="listbox" aria-label="Agents"></ul>
         <div class="palette-foot">
-          <span><kbd>↑↓</kbd> navigate</span>
-          <span><kbd>1-9</kbd> jump</span>
-          <span><kbd>↵</kbd> open</span>
-          <span><kbd>Esc</kbd> close</span>
+          <span class="as-foot-nav" id="as-nav-hints">
+            <span><kbd>↑↓</kbd> navigate</span>
+            <span><kbd>↵</kbd> open</span>
+          </span>
+          <span class="as-foot-count" id="as-foot-count"></span>
+          <span class="as-foot-esc"><kbd>Esc</kbd> close</span>
         </div>
       </div>
     </div>
@@ -338,6 +345,17 @@
         <span class="tp-name" id="topbar-project-name"></span>
       </button>
       <div class="topbar-spacer"></div>
+      <!-- Agents this project has. Silent until there is one. The label is
+           rewritten by a poll, so it stays out of the live region: a chip that
+           re-announces itself every few seconds is noise, and the title says
+           the same thing on demand. -->
+      <button class="iconbtn topbar-agents" id="topbar-agents" type="button" hidden>
+        <span class="ta-dot" aria-hidden="true"></span>
+        <span class="ta-count" id="topbar-agents-count"></span>
+        <span class="ta-word" id="topbar-agents-word"></span>
+        <span class="ta-needs" id="topbar-agents-needs" hidden></span>
+        <span class="ta-key" aria-hidden="true">Alt A</span>
+      </button>
       <button class="iconbtn" id="btn-palette" title="Command palette (Ctrl+K)">⌘K</button>
       <button class="iconbtn iconbtn-primary" id="btn-new-session" title="New chat session (restarts the agent)"><svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg> New Chat</button>
       <button class="iconbtn iconbtn-square" id="btn-status-toggle" title="Toggle status panel" aria-label="Toggle status panel">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -3315,6 +3315,24 @@ textarea.aut-goal-input:focus { outline: none; border-color: var(--accent); }
   min-height: 0;
   position: relative;
 }
+/* Reaching an agent means driving the tool's own picker: launch it, select the
+   row, confirm. That is machinery, not something to watch happen, so the
+   terminal stays covered until the conversation is on screen. Same frame as the
+   welcome state so it reads as the chat card loading, not a separate surface. */
+.agent-boot {
+  position: absolute; inset: 0; z-index: 3;
+  display: flex; align-items: center; justify-content: center; gap: var(--space-3);
+  background: var(--bg);
+  border: 1px solid var(--line-2); border-radius: var(--radius-lg);
+  font-size: var(--fs-small); color: var(--text-2);
+}
+.agent-boot[hidden] { display: none; }
+.agent-boot.is-leaving { opacity: 0; transition: opacity var(--motion-fast) var(--ease-out); }
+.ab-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); animation: ap-pulse 1.6s ease-in-out infinite; }
+.ab-name { font-weight: 600; color: var(--text); max-width: 46ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ab-sub { color: var(--text-3); }
+@media (prefers-reduced-motion: reduce) { .ab-dot { animation: none; } }
+
 .chat-empty {
   position: absolute; inset: 0; z-index: 2;
   display: flex; flex-direction: column; align-items: center; justify-content: center;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -412,6 +412,14 @@ body {
   grid-template-rows: 52px 1fr;
   overflow: hidden;
   -webkit-app-region: no-drag;
+  /* Marker for "an agent is waiting on you". Declared here, on the element the
+     theme tokens land on, so it resolves against this theme's amber. Bare
+     --amber clears 3:1 against the page in the dark family and misses it in
+     the light one; folding in --text pushes the lightness away from the
+     background in whichever direction that family runs. The fold is done in
+     oklch because an sRGB fold toward a near-black text collapses the chroma
+     with the lightness and lands on an olive that reads as dim body type. */
+  --as-mark: color-mix(in oklch, var(--amber) 70%, var(--text));
 }
 
 /* ─── Topbar ────────────────────────────────────────────────────────────── */
@@ -478,6 +486,49 @@ body:not([data-page="chat"]) #btn-new-session { display: none; }
   0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 60%, transparent); }
   70%  { box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 0%, transparent); }
   100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 0%, transparent); }
+}
+
+/* Agents running in this project. Quiet while they work, amber the moment one
+   is waiting on the user. Tint and border, never a fill: the bg steps are
+   translucent lifts in the dark family and solid in the light one, so a filled
+   chip inverts between them. */
+.topbar-agents {
+  gap: var(--space-2);
+  padding: 0 var(--space-2) 0 var(--space-3);
+  font-size: var(--fs-micro);
+  font-variant-numeric: tabular-nums;
+}
+.topbar-agents[hidden] { display: none; }
+.ta-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--text-3); flex: 0 0 auto; }
+.ta-count { font-weight: 700; color: var(--text); }
+.ta-word { color: var(--text-3); }
+/* Text, not a nested pill: the chip is already an enclosure, and a box inside a
+   box inside the topbar reads as chrome rather than as a count. */
+.ta-needs { color: var(--as-mark); font-size: var(--fs-micro); font-weight: 600; }
+.ta-needs[hidden] { display: none; }
+/* The chord is the only way in that does not require finding this chip first,
+   so it is on the chip rather than in a tooltip nobody hovers for. It sits
+   beside a button whose whole visible label is its own chord. */
+.ta-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--fs-nano); color: var(--text-3);
+  padding-left: var(--space-1);
+}
+.topbar-agents.is-running { border-color: color-mix(in srgb, var(--accent) 42%, var(--line)); }
+.topbar-agents.is-running .ta-dot { background: var(--accent); animation: ta-breathe 2s var(--ease-in-out) infinite; }
+/* A blocked agent is the one that stopped, so its marker is the still one. */
+.topbar-agents.is-blocked { border-color: color-mix(in srgb, var(--as-mark) 55%, var(--line)); }
+.topbar-agents.is-blocked .ta-dot {
+  background: var(--as-mark); animation: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--as-mark) 28%, transparent);
+}
+/* Nothing running, but agents to read. It keeps the way in without competing
+   with the live states: smaller marker, count stepped back to secondary. */
+.topbar-agents.is-idle .ta-count { color: var(--text-2); font-weight: 600; }
+.topbar-agents.is-idle .ta-dot { width: 5px; height: 5px; background: var(--text-3); animation: none; }
+@keyframes ta-breathe { 0%, 100% { opacity: 1; } 50% { opacity: .5; } }
+@media (prefers-reduced-motion: reduce) {
+  .topbar-agents.is-running .ta-dot { animation: none; }
 }
 
 .update-pop {
@@ -5443,9 +5494,13 @@ input[type="checkbox"]:disabled {
   border-color: var(--line-3);
   background: var(--bg-2);
 }
+/* Drop the track rather than leave it empty: a zero-width column still pays its
+   column gap, which would pull the meta off the edge every other row sits on. */
+.session-row.no-phase { grid-template-columns: minmax(0, 1fr) auto auto; }
 .sessions-list.select-mode .session-row {
   grid-template-columns: auto 1fr auto auto auto;
 }
+.sessions-list.select-mode .session-row.no-phase { grid-template-columns: auto 1fr auto auto; }
 .sessions-list.select-mode .session-row:hover { transform: none; }
 .session-row.selected {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--line-2));
@@ -5473,7 +5528,8 @@ input[type="checkbox"]:disabled {
 .session-phase.execute, .session-phase.build { background: color-mix(in srgb, var(--accent) 12%, transparent); color: var(--accent); border-color: color-mix(in srgb, var(--accent) 30%, transparent); }
 .session-phase.observe, .session-phase.think, .session-phase.plan { background: color-mix(in srgb, var(--accent-2) 12%, transparent); color: var(--accent-2); border-color: color-mix(in srgb, var(--accent-2) 30%, transparent); }
 .session-progress { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; }
-.session-effort { font-size: var(--fs-nano); color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; }
+/* Same grammar as the agent ages nested under it: one time column, one casing. */
+.session-effort { font-size: var(--fs-nano); color: var(--text-3); font-weight: 500; }
 
 /* Sub-line: the hint stays prose, the agent + directory ride in a mono chip
    that truncates instead of growing the head toward the control cluster. */
@@ -8104,97 +8160,387 @@ body[data-mode="light"] .ob-wordmark span {
 .palette-list .pi-icon svg { width: 16px; height: 16px; display: block; }
 .palette-list .pi-shortcut { margin-left: auto; color: var(--text-3); font-size: var(--fs-nano); font-family: 'JetBrains Mono', monospace; }
 /* ─── Agents under the chat that started them ──────────────────────────────
-   Children sit on the list background with no surface of their own, tethered by
-   a rail and indented. Recessing them with a darker fill cannot work across the
-   themes: in the dark family the bg steps are translucent lifts, in the light
-   family they are solid and run the other way, so a "recess" inverts. Indent
-   and tether read the same in both. */
+   A chat with agents is one card holding all of them. The card carries the
+   surface; the children sit on it with none of their own, tethered by a rail
+   and indented. Giving the children a fill cannot work across the themes: in
+   the dark family the bg steps are translucent lifts, in the light family they
+   are solid and run the other way, so a "recess" inverts. */
+.session-block {
+  /* The frame is an inset ring rather than a border so it costs no layout: with
+     a border the chat row inside starts one pixel right of every ungrouped row,
+     and titles twitch sideways as the poll adds and drops groups. */
+  --sb-inset: calc(var(--space-4) + 1px);
+  /* One arc for the card and the row inside it, declared once so the family
+     that gives its cards a wider one moves both together. */
+  --sb-arc: var(--radius-lg);
+  display: flex; flex-direction: column;
+  background: var(--bg-1);
+  box-shadow: inset 0 0 0 1px var(--line);
+  border-radius: var(--sb-arc);
+  overflow: hidden;
+  transition: box-shadow var(--motion-fast) var(--ease);
+}
+.session-block:hover { box-shadow: inset 0 0 0 1px var(--line-2); }
+/* The block is the card, so the chat row inside it gives up the surface and the
+   hover lift it carries when it stands alone. Its arc follows the card's top
+   corners, so the hover band is the same shape here as it is on its own. The
+   dark family dresses cards in a later glass pass, which this has to outrank. */
+.session-block .session-row,
+[data-mode="dark"] .session-block .session-row {
+  background: transparent; border-color: transparent;
+  border-radius: var(--sb-arc) var(--sb-arc) 0 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+}
+.session-block .session-row:hover,
+[data-mode="dark"] .session-block .session-row:hover {
+  background: var(--bg-2); border-color: transparent; transform: none;
+}
+.session-block .session-row.selected { border-color: transparent; }
+/* A control, not a strip: sized to its own label and bordered, so the click
+   target is the thing that looks clickable rather than the whole card width.
+   Its left edge is the chat title's, so the group reads as hanging off the
+   owner instead of the owner sitting indented inside the group. */
 .session-agents {
-  display: inline-flex; align-items: center; gap: var(--space-2);
-  align-self: flex-start;
-  margin: calc(var(--space-1) * -1) 0 0 var(--space-5);
-  padding: 3px 10px 3px 5px;
+  display: inline-flex; align-self: flex-start; align-items: center; gap: var(--space-2);
+  margin: var(--space-2) var(--space-4) var(--space-3) var(--sb-inset);
+  padding: var(--space-1) var(--space-3) var(--space-1) var(--space-2);
   border: 1px solid var(--line); border-radius: var(--radius-pill);
-  background: transparent; color: var(--text-3);
-  font-size: var(--fs-nano); font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
-  cursor: pointer; width: fit-content;
-  transition: color var(--motion-fast) var(--ease), border-color var(--motion-fast) var(--ease), background var(--motion-fast) var(--ease);
+  background: transparent; color: var(--text-2);
+  font-size: var(--fs-nano);
+  cursor: pointer;
+  transition: color var(--motion-fast) var(--ease), background var(--motion-fast) var(--ease), border-color var(--motion-fast) var(--ease);
 }
-.session-agents:hover, .session-agents:focus-visible { color: var(--text); border-color: var(--line-3); background: var(--bg-1); }
-.session-agents .sa-caret { width: 12px; height: 12px; transition: transform var(--motion-fast) var(--ease); }
-.session-agents[aria-expanded="true"] { color: var(--text-2); border-color: var(--line-2); }
+/* Open, the chip is the head of the group, so the rail starts at its bottom
+   edge rather than floating a gap below it. */
+.session-agents[aria-expanded="true"] { margin-bottom: 0; }
+.session-agents:hover, .session-agents:focus-visible { color: var(--text); background: var(--bg-2); border-color: var(--line-2); }
+.session-agents .sa-caret { width: 12px; height: 12px; flex: 0 0 auto; color: var(--text-3); transition: transform var(--motion-fast) var(--ease); }
 .session-agents[aria-expanded="true"] .sa-caret { transform: rotate(180deg); }
-.sa-live { color: var(--accent); margin-left: var(--space-2); }
+.sa-live { color: var(--text-2); }
+.sa-live::before { content: "·"; margin: 0 var(--space-2) 0 0; color: var(--text-3); }
+.session-agents.has-blocked .sa-live { color: var(--as-mark); font-weight: 600; }
+@media (prefers-reduced-motion: reduce) { .session-agents .sa-caret { transition: none; } }
 
+/* The rail hangs from the chip and stops on the chat title's left edge. Capped
+   to a measure: across the full width of this card the state and the age land
+   half a screen from the text they belong to, with nothing between them. */
 .agent-group {
-  display: flex; flex-direction: column; gap: var(--space-1);
-  margin: 0 0 var(--space-1) var(--space-6);
-  padding-left: var(--space-4);
-  border-left: 1px solid var(--line-2);
+  display: flex; flex-direction: column; gap: 2px;
+  margin: 0 var(--space-4) var(--space-3) var(--sb-inset);
+  max-width: 720px;
+  padding-left: var(--space-3);
+  border-left: 1px solid var(--line-3);
 }
+/* One line: the chat these belong to is the row above, so the only fields left
+   are the ones that differ between siblings. */
 .agent-row {
-  display: grid; grid-template-columns: 18px 8px minmax(0, 1fr) auto auto;
-  align-items: center; gap: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid transparent; border-radius: var(--radius-lg);
+  display: grid;
+  grid-template-columns: 14px auto minmax(0, 1fr) auto 44px;
+  align-items: center;
+  column-gap: var(--space-2);
+  min-height: 34px;
+  padding: var(--space-1) var(--space-2);
+  border: 0; border-radius: var(--radius-md);
   background: transparent; color: var(--text);
   font-family: inherit; text-align: left; cursor: pointer;
-  transition: background var(--motion-fast) var(--ease), border-color var(--motion-fast) var(--ease);
+  transition: background var(--motion-fast) var(--ease);
 }
-.agent-row:hover, .agent-row:focus-visible { background: var(--bg-1); border-color: var(--line); }
-.agent-row.is-done { opacity: .82; }
-.agent-idx { font-family: 'JetBrains Mono', monospace; font-size: var(--fs-nano); color: var(--text-3); font-variant-numeric: tabular-nums; }
-.agent-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-3); }
-.agent-row.is-running .agent-dot { background: var(--accent); animation: ap-pulse 1.6s ease-in-out infinite; }
-.agent-row.is-blocked .agent-dot { background: var(--amber); }
+.agent-row:hover, .agent-row:focus-visible { background: var(--bg-2); }
+.agent-dot { justify-self: center; align-self: center; width: 7px; height: 7px; border-radius: 50%; background: var(--text-3); }
+/* Siblings share the chat title, so the id is the field that tells them apart.
+   It is a tiebreaker and not the line's message, so the activity outranks it
+   here and in the switcher both. */
+.agent-id {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--fs-nano); color: var(--text-3);
+}
+.agent-live {
+  min-width: 0;
+  font-size: var(--fs-small); color: var(--text-2);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.agent-state { font-size: var(--fs-nano); color: var(--text-2); }
+.agent-age {
+  font-size: var(--fs-nano); color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+/* Motion means it is moving, and a filled disc against a hollow ring says the
+   same thing standing still: a diameter step alone disappears the moment the
+   breathing is turned off. The accent is a user preference, so it never carries
+   a status on its own. */
+.agent-row.is-running .agent-dot { background: var(--text-2); animation: ta-breathe 2s var(--ease-in-out) infinite; }
+.agent-row.is-blocked .agent-dot {
+  background: var(--as-mark); animation: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--as-mark) 24%, transparent);
+}
 .agent-row.is-done .agent-dot { background: transparent; box-shadow: inset 0 0 0 1.5px var(--text-3); }
-.agent-desc { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.agent-desc strong { font-weight: 600; font-size: var(--fs-small); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.agent-live { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.agent-stat { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-variant-numeric: tabular-nums; }
-.agent-row.is-running .agent-stat:nth-of-type(1) { color: var(--accent); }
-.agent-row.is-blocked .agent-stat:nth-of-type(1) { color: var(--amber); }
+.agent-row.is-done .agent-live { color: var(--text-3); }
+.agent-row.is-done .agent-state { color: var(--text-3); }
 @media (prefers-reduced-motion: reduce) { .agent-row.is-running .agent-dot { animation: none; } }
 
 /* ─── Agent switcher ───────────────────────────────────────────────────────
-   Rows inherit the palette shell. They carry more per row than an action does,
-   because every agent in a chat is titled after that chat: the name cannot tell
-   two of them apart, so state, activity and age have to. */
-.as-row {
+   The title leads: it is what a person recognises, and the id under it is the
+   field that separates two agents born of the same chat. One family, two sizes,
+   two weights: these rows get read ten at a time and every extra treatment is
+   one more thing to decode.
+   One left edge for the marks and one for the text, one right edge for
+   everything: the glyph and the row dots hold 16px, all text holds 40px, and
+   the meta column, the key hints and the footer all stop 16px from the wall.
+   The row box is the only thing inboard of that, inset 8px on both sides.
+   Every rule that lays a row out is id-prefixed. `.palette-list li` is (0,1,1)
+   and sets display, padding and gap, so a bare `.as-*` class silently loses. */
+#agent-switch .palette-card { width: 640px; }
+/* Scrim, card, radius and selection are the command palette's. Two overlays
+   that answer the same chord with unrelated drawings read as two products, and
+   the palette's neutral veil is the one that holds a card apart from the page
+   in the light family, where a tint of the page's own background does not. */
+.as-head {
+  display: flex; align-items: center; gap: var(--space-2);
+  padding: 0 var(--space-4);
+  border-bottom: 1px solid var(--line);
+}
+.as-head-icon { width: 16px; height: 16px; flex: 0 0 auto; color: var(--text-3); }
+/* The dark family paints every text input as a black glass field, at a
+   specificity a class cannot reach. This one is the card's own head, not a
+   field sitting on it, so it takes the card's surface. */
+#agent-switch-input,
+#agent-switch-input:focus {
+  flex: 1 1 auto; min-width: 0;
+  background: transparent !important; color: var(--text);
+  border: 0 !important; outline: 0;
+  border-radius: 0 !important; box-shadow: none !important;
+  padding: var(--space-4) 0;
+  font-family: inherit; font-size: var(--fs-h3); font-weight: 400;
+  line-height: 1.5;
+}
+/* The field is focused the moment the overlay opens and is the only focusable
+   thing in it, so the global ring would land on frame one and say nothing. */
+#agent-switch-input:focus-visible { box-shadow: none !important; }
+#agent-switch-input::placeholder { color: var(--text-3); }
+/* No scroll snapping. A row is a snap target and a section label is not, so the
+   engine pulled the first row to the top and ate the label above it before the
+   card had been touched, which loses the one word the ordering exists to say.
+   The gutter is reserved whether or not the list scrolls: this list is polled,
+   and one agent crossing the scroll threshold would shift every row sideways.
+   Left padding only, so the row box sits 8px inboard of both card walls once
+   the 8px gutter is counted on the right. */
+#agent-switch-list {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 0 0 var(--space-2) var(--space-2);
+  max-height: min(52vh, 460px);
+  scrollbar-gutter: stable;
+}
+/* A list cut flat by the footer looks like it ends there. The ramp is an alpha
+   matte and paints nothing; it is class-gated so the last row of a short list
+   is never dimmed for a scroll that cannot happen. */
+#agent-switch-list.is-scrollable {
+  -webkit-mask-image: linear-gradient(to bottom, rgb(0 0 0) calc(100% - 22px), rgb(0 0 0 / 0));
+  mask-image: linear-gradient(to bottom, rgb(0 0 0) calc(100% - 22px), rgb(0 0 0 / 0));
+}
+#agent-switch-list > li { flex: 0 0 auto; }
+#agent-switch-list::-webkit-scrollbar { width: 8px; }
+#agent-switch-list::-webkit-scrollbar-track { background: transparent; }
+#agent-switch-list::-webkit-scrollbar-thumb {
+  background: var(--line-2); border-radius: var(--radius-pill);
+  border: 2px solid transparent; background-clip: content-box;
+}
+/* Navigation left, the count and the way out right, so the two kinds of hint do
+   not read as one run-on sentence. Everything else about the bar, the surface
+   and the key caps included, is the command palette's: two overlays answering
+   adjacent chords with unrelated drawings read as two products. */
+#agent-switch .palette-foot { padding: var(--space-2) var(--space-4); }
+.as-foot-nav { display: contents; }
+#agent-switch .palette-foot .as-foot-count {
+  margin-left: auto; color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+}
+#agent-switch .palette-foot .as-foot-count:empty { display: none; }
+/* Three states interleaved with no order is a list, not a switcher. What is
+   waiting on a person comes first, and the label says which band you are in.
+   It sticks, so scrolling out of a band can never leave you unlabelled, and it
+   bleeds over the list's left padding so rows pass under it and not beside it. */
+#agent-switch-list .as-group {
+  position: sticky; top: 0; z-index: 1;
+  background: var(--notif-bg);
+  display: block;
+  margin-left: calc(var(--space-2) * -1);
+  padding: var(--space-3) var(--space-2) var(--space-1);
+  padding-left: calc(var(--space-2) + var(--space-2) + 16px + var(--space-2));
+  font-size: var(--fs-nano); font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--text-3);
+  cursor: default;
+}
+#agent-switch-list .as-group:first-child { padding-top: var(--space-2); }
+/* A fixed meta track, not auto: with an auto column the primary text ends
+   wherever the state word happens to, and the titles come out ragged.
+   Baseline alignment per grid row, so the title sits on the state's line and
+   the id sits on the age's line however the two type sizes differ. */
+#agent-switch-list .as-row {
+  position: relative;
   display: grid;
-  grid-template-columns: 16px 8px minmax(0, 1fr) auto auto;
-  align-items: center; gap: 11px;
-  padding: 9px 13px; border-radius: var(--radius-lg);
+  grid-template-columns: 16px minmax(0, 1fr) 76px;
+  grid-template-rows: auto auto;
+  align-items: baseline; align-content: center;
+  column-gap: var(--space-2); row-gap: 2px;
+  height: 44px; padding: 0 var(--space-2);
+  border-radius: var(--radius-lg);
   color: var(--text-2); cursor: pointer;
 }
-.as-row.active, .as-row:hover { background: color-mix(in srgb, var(--accent) 12%, var(--bg-3)); color: var(--text); }
-.as-idx { font-family: 'JetBrains Mono', monospace; font-size: var(--fs-nano); color: var(--text-3); font-variant-numeric: tabular-nums; }
-.as-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-3); }
-/* Three states, three signals each, so the difference survives grayscale. */
-.as-row.is-running .as-dot { background: var(--accent); animation: ap-pulse 1.6s ease-in-out infinite; }
-.as-row.is-blocked .as-dot { background: var(--amber); }
-.as-row.is-done    .as-dot { background: transparent; box-shadow: inset 0 0 0 1.5px var(--text-3); }
-.as-row.is-done { opacity: .82; }
-.as-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.as-text strong { font-weight: 600; font-size: var(--fs-small); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.as-sub { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.as-state { font-size: var(--fs-pico); text-transform: uppercase; letter-spacing: .1em; font-weight: 700; color: var(--text-3); }
-.as-row.is-running .as-state { color: var(--accent); }
-.as-row.is-blocked .as-state { color: var(--amber); }
-.as-age { font-family: 'JetBrains Mono', monospace; font-size: var(--fs-nano); color: var(--text-3); font-variant-numeric: tabular-nums; }
-.as-empty { display: flex; flex-direction: column; gap: 4px; padding: 22px 16px; text-align: center; }
-.as-empty strong { font-size: var(--fs-small); font-weight: 600; color: var(--text-2); }
-.as-empty span { font-size: var(--fs-nano); color: var(--text-3); }
-/* The list has known geometry, so placeholders keep its shape rather than
-   replacing it with a spinner that says less. */
-.as-skel {
-  height: 38px; margin: 4px 0; border-radius: var(--radius-lg);
-  background: linear-gradient(90deg, var(--bg-3) 25%, var(--bg-2) 50%, var(--bg-3) 75%);
+/* One highlight at a time: the pointer moves the selection, so hover carries no
+   style of its own and an arrow key cannot leave a second row lit. */
+#agent-switch-list .as-row:hover { background: transparent; color: var(--text-2); }
+/* The fill is a neutral lift of the card's own text, not a tint. The accent is
+   user-selectable across five values and the only status hue in the card is the
+   waiting marker, so a tinted fill puts the cursor and the alarm in the same
+   register on the row the user is pointing at, and the alarm loses. The accent
+   rides a bar on the leading edge instead, where nothing competes for it. */
+#agent-switch-list .as-row.active {
+  background: color-mix(in srgb, var(--text) 16%, transparent);
+  box-shadow: inset 2px 0 0 var(--accent);
+  color: var(--text);
+}
+#agent-switch-list .as-dot {
+  grid-column: 1; grid-row: 1 / span 2; justify-self: center; align-self: center;
+  width: 7px; height: 7px; border-radius: 50%; background: var(--text-3);
+}
+/* The two stacks dissolve into the row's own grid so the left text and the
+   right meta share its rows. Nesting them in their own boxes leaves 14px type
+   and 11px type centred against each other, which lands every line a pixel or
+   so off its neighbour: too small to read as an offset, too large to look set. */
+#agent-switch-list .as-text,
+#agent-switch-list .as-meta { display: contents; }
+#agent-switch-list .as-name {
+  grid-column: 2; grid-row: 1;
+  font-weight: 600; font-size: var(--fs-body); line-height: 1.35; color: var(--text);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Always two lines, because the id is always there: a row whose second line can
+   vanish re-centres its title and breaks the pitch the eye is tracking. */
+#agent-switch-list .as-sub {
+  grid-column: 2; grid-row: 2;
+  font-size: var(--fs-nano); line-height: 1.45; color: var(--text-2);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* The id is the tiebreaker between siblings, not the line's message, so the
+   activity takes the contrast. The size is stated because a monospace element
+   with no size of its own falls back to the fixed-font default, not to the
+   inherited one, and lands 2px larger than the sentence it sits in. */
+#agent-switch-list .as-id {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--fs-nano);
+  color: var(--text-3); margin-right: var(--space-2);
+}
+#agent-switch-list .as-state {
+  grid-column: 3; grid-row: 1; justify-self: end;
+  font-size: var(--fs-nano); line-height: 1.45; color: var(--text-2);
+}
+#agent-switch-list .as-age {
+  grid-column: 3; grid-row: 2; justify-self: end;
+  font-size: var(--fs-nano); line-height: 1.45; color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+}
+/* Motion means it is moving; a filled disc against a hollow ring says the same
+   thing standing still, which a 2px diameter step does not once the breathing
+   is turned off. The accent is user-selectable across five values, so it can
+   land on any of the semantic hues and cannot carry a status by itself. */
+#agent-switch-list .as-row.is-running .as-dot { background: var(--text-2); animation: ta-breathe 2s var(--ease-in-out) infinite; }
+#agent-switch-list .as-row.is-blocked .as-dot {
+  background: var(--as-mark); animation: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--as-mark) 24%, transparent);
+}
+/* A badge, not a coloured word. The marker has to clear the page in both
+   families, which forces its lightness toward the body text's, and at 11px a
+   hue shift alone then reads as ordinary type in the light one. The enclosure
+   is what makes it a state. */
+#agent-switch-list .as-row.is-blocked .as-state,
+.agent-row.is-blocked .agent-state {
+  color: var(--as-mark); font-weight: 600;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--as-mark) 32%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 1px var(--space-2);
+}
+/* In the list the badge carries the card's own surface rather than a
+   transparent tint, so the selection lift cannot slide underneath it and take
+   the marker's contrast down with it on exactly the row being pointed at. */
+#agent-switch-list .as-row.is-blocked .as-state {
+  background: color-mix(in srgb, var(--as-mark) 13%, var(--notif-bg));
+}
+/* Under a chat the badge lands on two different surfaces, the card and its
+   hover lift, so the tint composites instead of naming one of them. */
+.agent-row.is-blocked .agent-state {
+  background: color-mix(in srgb, var(--as-mark) 13%, transparent);
+}
+/* Finished rows recede by stepping each element back, not by fading the row:
+   a row opacity dims the age and the state too, which are wayfinding, and it
+   composites muddily against the selection fill. */
+#agent-switch-list .as-row.is-done .as-dot { background: transparent; box-shadow: inset 0 0 0 1.5px var(--text-3); }
+#agent-switch-list .as-row.is-done .as-name { color: var(--text-2); font-weight: 500; }
+#agent-switch-list .as-row.is-done .as-sub { color: var(--text-3); }
+#agent-switch-list .as-row.is-done .as-state { color: var(--text-3); }
+/* Selection restores full strength: the row you are pointing at cannot be the
+   dimmest one on screen. */
+#agent-switch-list .as-row.active .as-name { color: var(--text); font-weight: 600; }
+/* Centred on the card, not parked at the row indent: with no rows to align to,
+   a left-aligned line leaves the other five hundred pixels reading as missing. */
+#agent-switch-list .as-empty {
+  display: flex; flex-direction: column; align-items: center; gap: var(--space-1);
+  padding: var(--space-5) var(--space-4);
+  text-align: center; cursor: default;
+}
+#agent-switch-list .as-empty svg { width: 22px; height: 22px; color: var(--text-3); margin-bottom: var(--space-1); }
+#agent-switch-list .as-empty strong { font-size: var(--fs-body); font-weight: 600; color: var(--text-2); }
+#agent-switch-list .as-empty span { font-size: var(--fs-nano); color: var(--text-3); }
+/* Placeholders take the real row's grid, cell for cell, so the card neither
+   jumps nor changes shape when the listing lands. */
+#agent-switch-list .as-skel {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) 76px;
+  grid-template-rows: auto auto;
+  align-content: center;
+  column-gap: var(--space-2); row-gap: 2px;
+  height: 44px; margin: 0;
+  padding: 0 var(--space-2);
+  background: transparent; cursor: default;
+}
+#agent-switch-list .as-skel i,
+#agent-switch-list .as-skel-group i {
+  display: block; border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--bg-2) 25%, var(--bg-3) 50%, var(--bg-2) 75%);
   background-size: 200% 100%;
   animation: ws-shimmer 1.1s linear infinite;
 }
+#agent-switch-list .as-skel .sk-dot { grid-column: 1; grid-row: 1 / span 2; justify-self: center; align-self: center; width: 7px; height: 7px; border-radius: 50%; }
+#agent-switch-list .as-skel .sk-name { grid-column: 2; grid-row: 1; height: 9px; width: 54%; }
+#agent-switch-list .as-skel .sk-sub { grid-column: 2; grid-row: 2; height: 8px; width: 34%; }
+#agent-switch-list .as-skel .sk-meta { grid-column: 3; grid-row: 1; justify-self: end; height: 8px; width: 70%; }
+#agent-switch-list .as-skel:nth-child(3) .sk-name { width: 44%; }
+#agent-switch-list .as-skel:nth-child(4) .sk-name { width: 62%; }
+#agent-switch-list .as-skel:nth-child(5) .sk-name { width: 38%; }
+/* The section labels are part of the shape too, so one stands in for them. */
+#agent-switch-list .as-skel-group {
+  display: block; margin: 0;
+  padding: var(--space-3) var(--space-2) var(--space-1);
+  padding-left: calc(var(--space-2) + 16px + var(--space-2));
+  background: transparent; cursor: default;
+}
+#agent-switch-list .as-skel-group i { height: 7px; width: 68px; }
+
+/* The card descends from the 14vh anchor and settles. Open state stays the one
+   [hidden] boolean the Alt+A toggle already reads, and the entrance is a
+   keyframe rather than a transition so a dropped frame loop costs the motion
+   and never the overlay. The selection itself never animates: nothing in this
+   overlay may depend on a frame loop to become visible. */
+#agent-switch:not([hidden]) { animation: as-scrim-in 110ms var(--ease); }
+#agent-switch:not([hidden]) .palette-card { transform-origin: 50% 0; animation: as-card-in 170ms var(--ease-out); }
+@keyframes as-scrim-in { from { opacity: 0; } }
+@keyframes as-card-in { from { opacity: 0; transform: translateY(-8px) scale(0.985); } }
 @media (prefers-reduced-motion: reduce) {
-  .as-row.is-running .as-dot, .as-skel { animation: none; }
+  #agent-switch-list .as-row.is-running .as-dot,
+  #agent-switch-list .as-skel i,
+  #agent-switch-list .as-skel-group i,
+  #agent-switch:not([hidden]),
+  #agent-switch:not([hidden]) .palette-card { animation: none; }
 }
 
 .palette-foot {
@@ -8701,6 +9047,13 @@ kbd {
   -webkit-backdrop-filter: blur(16px);
   border-radius: var(--radius-xl);
   transition: background var(--motion-base) var(--ease), border-color var(--motion-base) var(--ease), transform var(--motion-base) var(--ease);
+}
+/* A chat with agents frames itself with an inset ring, so it takes this pass's
+   blur and its arc without the border, which would cost it a pixel of layout
+   the ungrouped rows beside it do not pay. */
+[data-mode="dark"] .session-block {
+  --sb-arc: var(--radius-xl);
+  backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px);
 }
 [data-mode="dark"] .agent-card:hover,
 [data-mode="dark"] .session-row:hover,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8103,6 +8103,59 @@ body[data-mode="light"] .ob-wordmark span {
 .palette-list .pi-icon { color: var(--accent); width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; }
 .palette-list .pi-icon svg { width: 16px; height: 16px; display: block; }
 .palette-list .pi-shortcut { margin-left: auto; color: var(--text-3); font-size: var(--fs-nano); font-family: 'JetBrains Mono', monospace; }
+/* ─── Agents under the chat that started them ──────────────────────────────
+   Children sit on the list background with no surface of their own, tethered by
+   a rail and indented. Recessing them with a darker fill cannot work across the
+   themes: in the dark family the bg steps are translucent lifts, in the light
+   family they are solid and run the other way, so a "recess" inverts. Indent
+   and tether read the same in both. */
+.session-agents {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  align-self: flex-start;
+  margin: calc(var(--space-1) * -1) 0 0 var(--space-5);
+  padding: 3px 10px 3px 5px;
+  border: 1px solid var(--line); border-radius: var(--radius-pill);
+  background: transparent; color: var(--text-3);
+  font-size: var(--fs-nano); font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
+  cursor: pointer; width: fit-content;
+  transition: color var(--motion-fast) var(--ease), border-color var(--motion-fast) var(--ease), background var(--motion-fast) var(--ease);
+}
+.session-agents:hover, .session-agents:focus-visible { color: var(--text); border-color: var(--line-3); background: var(--bg-1); }
+.session-agents .sa-caret { width: 12px; height: 12px; transition: transform var(--motion-fast) var(--ease); }
+.session-agents[aria-expanded="true"] { color: var(--text-2); border-color: var(--line-2); }
+.session-agents[aria-expanded="true"] .sa-caret { transform: rotate(180deg); }
+.sa-live { color: var(--accent); margin-left: var(--space-2); }
+
+.agent-group {
+  display: flex; flex-direction: column; gap: var(--space-1);
+  margin: 0 0 var(--space-1) var(--space-6);
+  padding-left: var(--space-4);
+  border-left: 1px solid var(--line-2);
+}
+.agent-row {
+  display: grid; grid-template-columns: 18px 8px minmax(0, 1fr) auto auto;
+  align-items: center; gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid transparent; border-radius: var(--radius-lg);
+  background: transparent; color: var(--text);
+  font-family: inherit; text-align: left; cursor: pointer;
+  transition: background var(--motion-fast) var(--ease), border-color var(--motion-fast) var(--ease);
+}
+.agent-row:hover, .agent-row:focus-visible { background: var(--bg-1); border-color: var(--line); }
+.agent-row.is-done { opacity: .82; }
+.agent-idx { font-family: 'JetBrains Mono', monospace; font-size: var(--fs-nano); color: var(--text-3); font-variant-numeric: tabular-nums; }
+.agent-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-3); }
+.agent-row.is-running .agent-dot { background: var(--accent); animation: ap-pulse 1.6s ease-in-out infinite; }
+.agent-row.is-blocked .agent-dot { background: var(--amber); }
+.agent-row.is-done .agent-dot { background: transparent; box-shadow: inset 0 0 0 1.5px var(--text-3); }
+.agent-desc { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.agent-desc strong { font-weight: 600; font-size: var(--fs-small); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-live { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-stat { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; font-variant-numeric: tabular-nums; }
+.agent-row.is-running .agent-stat:nth-of-type(1) { color: var(--accent); }
+.agent-row.is-blocked .agent-stat:nth-of-type(1) { color: var(--amber); }
+@media (prefers-reduced-motion: reduce) { .agent-row.is-running .agent-dot { animation: none; } }
+
 /* ─── Agent switcher ───────────────────────────────────────────────────────
    Rows inherit the palette shell. They carry more per row than an action does,
    because every agent in a chat is titled after that chat: the name cannot tell

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -8103,6 +8103,47 @@ body[data-mode="light"] .ob-wordmark span {
 .palette-list .pi-icon { color: var(--accent); width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; }
 .palette-list .pi-icon svg { width: 16px; height: 16px; display: block; }
 .palette-list .pi-shortcut { margin-left: auto; color: var(--text-3); font-size: var(--fs-nano); font-family: 'JetBrains Mono', monospace; }
+/* ─── Agent switcher ───────────────────────────────────────────────────────
+   Rows inherit the palette shell. They carry more per row than an action does,
+   because every agent in a chat is titled after that chat: the name cannot tell
+   two of them apart, so state, activity and age have to. */
+.as-row {
+  display: grid;
+  grid-template-columns: 16px 8px minmax(0, 1fr) auto auto;
+  align-items: center; gap: 11px;
+  padding: 9px 13px; border-radius: var(--radius-lg);
+  color: var(--text-2); cursor: pointer;
+}
+.as-row.active, .as-row:hover { background: color-mix(in srgb, var(--accent) 12%, var(--bg-3)); color: var(--text); }
+.as-idx { font-family: 'JetBrains Mono', monospace; font-size: var(--fs-nano); color: var(--text-3); font-variant-numeric: tabular-nums; }
+.as-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--text-3); }
+/* Three states, three signals each, so the difference survives grayscale. */
+.as-row.is-running .as-dot { background: var(--accent); animation: ap-pulse 1.6s ease-in-out infinite; }
+.as-row.is-blocked .as-dot { background: var(--amber); }
+.as-row.is-done    .as-dot { background: transparent; box-shadow: inset 0 0 0 1.5px var(--text-3); }
+.as-row.is-done { opacity: .82; }
+.as-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.as-text strong { font-weight: 600; font-size: var(--fs-small); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.as-sub { font-size: var(--fs-nano); color: var(--text-3); font-family: 'JetBrains Mono', monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.as-state { font-size: var(--fs-pico); text-transform: uppercase; letter-spacing: .1em; font-weight: 700; color: var(--text-3); }
+.as-row.is-running .as-state { color: var(--accent); }
+.as-row.is-blocked .as-state { color: var(--amber); }
+.as-age { font-family: 'JetBrains Mono', monospace; font-size: var(--fs-nano); color: var(--text-3); font-variant-numeric: tabular-nums; }
+.as-empty { display: flex; flex-direction: column; gap: 4px; padding: 22px 16px; text-align: center; }
+.as-empty strong { font-size: var(--fs-small); font-weight: 600; color: var(--text-2); }
+.as-empty span { font-size: var(--fs-nano); color: var(--text-3); }
+/* The list has known geometry, so placeholders keep its shape rather than
+   replacing it with a spinner that says less. */
+.as-skel {
+  height: 38px; margin: 4px 0; border-radius: var(--radius-lg);
+  background: linear-gradient(90deg, var(--bg-3) 25%, var(--bg-2) 50%, var(--bg-3) 75%);
+  background-size: 200% 100%;
+  animation: ws-shimmer 1.1s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .as-row.is-running .as-dot, .as-skel { animation: none; }
+}
+
 .palette-foot {
   display: flex; gap: 14px;
   padding: 9px 16px;

--- a/test/unit/model-catalog.test.js
+++ b/test/unit/model-catalog.test.js
@@ -4,6 +4,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
 const { fallbackModelsFor, isCliStatusLine, isModelValueUsable, modelFlagFor, modelIdFromDisplayLabel, parseModelCatalog, providerLabel, titleFromId, uniqueModels } = require('../../src/lib/model-catalog');
+const { modelArgsFor } = require('../../src/lib/model-routing');
 
 test('modelFlagFor knows routed provider flags', () => {
   assert.equal(modelFlagFor('copilot'), '--model');
@@ -160,6 +161,32 @@ test('parseModelCatalog extracts Claude slash-model choices', () => {
     { value: 'sonnet', label: 'Sonnet 5 · Efficient' },
     { value: 'haiku', label: 'Haiku 4.5 · Fastest' },
   ]);
+});
+
+test('claude long-context row keeps its own id and reads like the other rows', () => {
+  const out = `
+    Select model
+    1. Default (recommended) - Opus 5
+    2. (selected) Opus - Opus 5 · Best for everyday use
+    3. Opus (1M context) - Opus 5 with 1M context · Best for everyday use
+    4. Fable — Fable 5 · Most capable
+    5. Haiku — Haiku 4.5 · Fastest
+  `;
+  assert.deepEqual(parseModelCatalog(out, 'claude'), [
+    { value: 'opus', label: 'Opus 5 · Best for everyday use' },
+    { value: 'opus[1m]', label: 'Opus 5 With 1M Context · Best for everyday use' },
+    { value: 'fable', label: 'Fable 5 · Most capable' },
+    { value: 'haiku', label: 'Haiku 4.5 · Fastest' },
+  ]);
+});
+
+test('the long-context id survives every gate between the picker and --model', () => {
+  assert.equal(isModelValueUsable('opus[1m]', 'claude'), true);
+  assert.equal(isModelValueUsable('claude-opus-5[1m]', 'claude'), true);
+  assert.deepEqual(
+    modelArgsFor('claude', 'smart', { claude: { flag: '--model', smart: 'opus[1m]' } }),
+    ['--model', 'opus[1m]'],
+  );
 });
 
 test('claude probe noise (config paths, API references) yields no model candidates', () => {


### PR DESCRIPTION
This pull request introduces several improvements to session and transcript management, model catalog handling, and process spawning for Claude agent sessions. The main changes ensure more accurate identification and resumption of interactive transcripts, safer environment variable handling when spawning agents, and improved model labeling and catalog parsing, especially for long-context model tiers.

**Session and transcript management:**
* Improved logic to distinguish and resume the correct transcript after a session is resumed, especially when multiple transcripts exist in the project directory. This includes tracking prior transcripts, identifying interactive sessions, and reliably updating the session state to point to the new transcript after resumption. [[1]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R894-R919) [[2]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L1096-R1160) [[3]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L1383-R1444) [[4]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L1395-R1486)
* Changed model selection priority: the model from `settings.json` is now always preferred for display, ensuring the correct model is shown for the current session and avoiding confusion from unrelated transcripts.

**Process spawning and environment safety:**
* Added an allowlist (`SPAWN_ENV_ALLOW`) and sanitization for environment variables passed to spawned agent processes, preventing injection of unsafe or unexpected variables. [[1]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L912-R959) [[2]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L1534-R1624)
* Improved subcommand detection to avoid injecting chat-specific flags into agent management subcommands (like `claude agents`). [[1]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79R1020-R1025) [[2]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L996-R1049) [[3]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L1073-R1126)

**Model catalog and identifier handling:**
* Updated the fallback model catalog to include the new Opus 5 and its long-context variant, and improved parsing and labeling for long-context models (e.g., `opus[1m]`). [[1]](diffhunk://#diff-267acf03420177b979b402357a4b85722de46462f1b001a8f51939850b7231c5L21-R22) [[2]](diffhunk://#diff-267acf03420177b979b402357a4b85722de46462f1b001a8f51939850b7231c5R125-R140) [[3]](diffhunk://#diff-267acf03420177b979b402357a4b85722de46462f1b001a8f51939850b7231c5L260-R287)
* Adjusted model ID validation to recognize long-context suffixes (e.g., `[1m]`) as part of valid model identifiers throughout the codebase. [[1]](diffhunk://#diff-267acf03420177b979b402357a4b85722de46462f1b001a8f51939850b7231c5L331-R357) [[2]](diffhunk://#diff-267acf03420177b979b402357a4b85722de46462f1b001a8f51939850b7231c5L352-R381) [[3]](diffhunk://#diff-1656f9e0d699ffc84ac618ecfab097b434f3a2601ad9a4147aa9b245c0382807L51-R53)

**Other improvements:**
* Added `modelLabel` to session stats for improved display of the current model’s human-readable name.
* Minor refactoring: imported `execFile` in addition to `spawn` from `child_process`.