### PR TITLE
fix: read a file through the descriptor it was checked on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "husk",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "husk",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "husk",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "A desktop home for your CLI agent. Wraps claude / copilot / codex / aider in a clean Electron window with a real PTY, MCP integration, drag-drop context, sessions, voice, and a live status panel.",
   "main": "src/main.js",
   "license": "MIT",

--- a/src/lib/autonomy/snapshot.js
+++ b/src/lib/autonomy/snapshot.js
@@ -213,25 +213,41 @@ function captureScoped(absRoot, paths, entries, warnings, opts, bdir, seen) {
     const abs = joinSafely(absRoot, rel);
     if (!abs) { warnings.push({ path: String(rel), reason: 'path escapes workspaceRoot' }); continue; }
     const key = path.normalize(rel);
-    let lst;
+    // A link is recorded by its target rather than followed, and readlink says
+    // so in one call: it answers only for links, so the kind of everything else
+    // comes off the descriptor opened below.
+    let target = null;
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- abs is bounded to absRoot
+    try { target = fs.readlinkSync(abs); } catch (_) { target = null; }
+    if (target !== null) { entries[key] = { type: 'symlink', target }; continue; }
+
+    // O_NOFOLLOW refuses a link that appeared since, and O_NONBLOCK keeps a
+    // fifo from parking the open until someone writes to it.
+    let fd;
     try {
       // eslint-disable-next-line security/detect-non-literal-fs-filename -- abs is bounded to absRoot
-      lst = fs.lstatSync(abs);
+      fd = fs.openSync(abs, fs.constants.O_RDONLY
+        | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
     } catch (err) {
       if (err && err.code === 'ENOENT') { entries[key] = { type: 'absent' }; continue; }
+      // Where a directory cannot be opened for reading it still records as one.
+      if (err && err.code === 'EISDIR') { entries[key] = { type: 'dir' }; continue; }
+      // Sockets and devices refuse the open and carry no content anyway.
+      if (err && (err.code === 'ENXIO' || err.code === 'ENODEV' || err.code === 'ELOOP')) {
+        entries[key] = { type: 'unreadable' };
+        continue;
+      }
       warnings.push({ path: key, reason: err.message });
       entries[key] = { type: 'unreadable' };
       continue;
     }
     try {
-      if (lst.isSymbolicLink()) {
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- abs is bounded to absRoot
-        entries[key] = { type: 'symlink', target: fs.readlinkSync(abs) };
-      } else if (lst.isDirectory()) {
+      const st = fs.fstatSync(fd);
+      if (st.isDirectory()) {
         entries[key] = { type: 'dir' };
-      } else if (lst.isFile()) {
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- abs is bounded to absRoot
-        const content = fs.readFileSync(abs);
+      } else if (st.isFile()) {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- reads the numeric fd opened above, not a path
+        const content = fs.readFileSync(fd);
         const sha = sha256OfBuffer(content);
         writeBlobAtomic(bdir, sha, content, opts.encrypt, seen);
         entries[key] = { type: 'file', sha };
@@ -242,7 +258,7 @@ function captureScoped(absRoot, paths, entries, warnings, opts, bdir, seen) {
     } catch (err) {
       warnings.push({ path: key, reason: err.message });
       entries[key] = { type: 'unreadable' };
-    }
+    } finally { fs.closeSync(fd); }
   }
 }
 

--- a/src/lib/autopilot-apply.js
+++ b/src/lib/autopilot-apply.js
@@ -47,36 +47,43 @@ function copyInto(worktreePath, workspaceRoot, rel) {
     if (!realPathInside(src, worktreePath)) {
       return { path: rel, ok: false, reason: 'source resolves outside worktree root' };
     }
+    // The source is held open from here on, so its kind and its bytes are the
+    // same file. O_NOFOLLOW refuses a symlink at open, and O_NONBLOCK keeps a
+    // fifo from parking the open until someone writes to it.
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- srcReal verified under worktreePath by realPathInside above
-    if (!fs.lstatSync(srcReal).isFile()) {
-      return { path: rel, ok: false, reason: 'source is not a regular file' };
-    }
+    const srcFd = fs.openSync(srcReal, fs.constants.O_RDONLY
+      | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
+    try {
+      if (!fs.fstatSync(srcFd).isFile()) {
+        return { path: rel, ok: false, reason: 'source is not a regular file' };
+      }
 
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst re-confined under workspaceRoot above
-    fs.mkdirSync(path.dirname(dst), { recursive: true });
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst re-confined under workspaceRoot above
+      fs.mkdirSync(path.dirname(dst), { recursive: true });
 
-    // Destination parent must resolve under the workspace.
-    if (!realParentInside(dst, workspaceRoot)) {
-      return { path: rel, ok: false, reason: 'destination resolves outside workspace root' };
-    }
-    let existing = null;
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst string-confined above and its parent verified by realParentInside
-    try { existing = fs.lstatSync(dst); } catch (_) { existing = null; }
-    if (existing && existing.isSymbolicLink()) {
-      return { path: rel, ok: false, reason: 'destination is a symbolic link' };
-    }
-    if (existing && !existing.isFile()) {
-      return { path: rel, ok: false, reason: 'destination is not a regular file' };
-    }
+      // Destination parent must resolve under the workspace.
+      if (!realParentInside(dst, workspaceRoot)) {
+        return { path: rel, ok: false, reason: 'destination resolves outside workspace root' };
+      }
+      let existing = null;
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst string-confined above and its parent verified by realParentInside
+      try { existing = fs.lstatSync(dst); } catch (_) { existing = null; }
+      if (existing && existing.isSymbolicLink()) {
+        return { path: rel, ok: false, reason: 'destination is a symbolic link' };
+      }
+      if (existing && !existing.isFile()) {
+        return { path: rel, ok: false, reason: 'destination is not a regular file' };
+      }
 
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- srcReal verified under worktreePath by realPathInside above
-    const buf = fs.readFileSync(srcReal);
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst parent verified by realParentInside; O_NOFOLLOW refuses symlinks
-    const fd = fs.openSync(dst, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC
-      | (fs.constants.O_NOFOLLOW || 0), 0o644);
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- writes to the numeric fd opened above, not a path
-    try { fs.writeFileSync(fd, buf); } finally { fs.closeSync(fd); }
-    return { path: rel, ok: true, status: 'written' };
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- reads the numeric fd opened above, not a path
+      const buf = fs.readFileSync(srcFd);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- dst parent verified by realParentInside; O_NOFOLLOW refuses symlinks
+      const fd = fs.openSync(dst, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC
+        | (fs.constants.O_NOFOLLOW || 0), 0o644);
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- writes to the numeric fd opened above, not a path
+      try { fs.writeFileSync(fd, buf); } finally { fs.closeSync(fd); }
+      return { path: rel, ok: true, status: 'written' };
+    } finally { fs.closeSync(srcFd); }
   } catch (err) {
     return { path: rel, ok: false, reason: (err && err.message) || String(err) };
   }

--- a/src/main.js
+++ b/src/main.js
@@ -9769,15 +9769,16 @@ ipcMain.handle('bgAgents:peek', (_e, payload = {}) => {
   let text = '';
   let size = 0;
   try {
-    size = fs.statSync(transcript).size;
-    const fd = fs.openSync(transcript, 'r');
-    const start = Math.max(0, size - BG_PEEK_TAIL_BYTES);
-    const buf = Buffer.alloc(Math.min(size, BG_PEEK_TAIL_BYTES));
-    const n = fs.readSync(fd, buf, 0, buf.length, start);
-    fs.closeSync(fd);
-    text = buf.toString('utf8', 0, n);
-    // A mid-file start lands inside a line; drop the partial one.
-    if (start > 0) text = text.slice(text.indexOf('\n') + 1);
+    const fd = fs.openSync(transcript, fs.constants.O_RDONLY | (fs.constants.O_NONBLOCK || 0));
+    try {
+      size = fs.fstatSync(fd).size;
+      const start = Math.max(0, size - BG_PEEK_TAIL_BYTES);
+      const buf = Buffer.alloc(Math.min(size, BG_PEEK_TAIL_BYTES));
+      const n = fs.readSync(fd, buf, 0, buf.length, start);
+      text = buf.toString('utf8', 0, n);
+      // A mid-file start lands inside a line; drop the partial one.
+      if (start > 0) text = text.slice(text.indexOf('\n') + 1);
+    } finally { fs.closeSync(fd); }
   } catch (err) {
     return { ok: false, error: err.message };
   }

--- a/src/main.js
+++ b/src/main.js
@@ -5906,32 +5906,38 @@ function wfxRefuse(code, message, detail, stage) {
   };
 }
 
-// statSync before readFileSync, always, and on the resolved path: an oversized
-// file is refused by asking the filesystem how big it is rather than by reading
-// it. parseArtifact repeats the size test on the string it gets, which covers
-// the drag-drop path where there is no file to stat.
+// The file is opened once and its kind, size and bytes all come from that one
+// descriptor: an oversized file is refused by asking the filesystem how big it
+// is rather than by reading it. parseArtifact repeats the size test on the
+// string it gets, which covers the drag-drop path where there is no file to open.
 function wfxReadArtifactAt(absPath) {
-  let st;
-  try { st = fs.statSync(absPath); } catch (err) {
+  let fd;
+  // O_NONBLOCK keeps a fifo from parking the open until someone writes to it.
+  try { fd = fs.openSync(absPath, fs.constants.O_RDONLY | (fs.constants.O_NONBLOCK || 0)); } catch (err) {
     return wfxRefuse('unreadable', 'that file could not be opened', err && err.message);
   }
-  if (!st.isFile()) return wfxRefuse('not-a-file', 'that path is not a file', absPath);
-  if (st.size > WorkflowArtifact.MAX_ARTIFACT_BYTES) {
-    return wfxRefuse('too-large',
-      `that file is ${st.size} bytes and a Husk workflow may be ${WorkflowArtifact.MAX_ARTIFACT_BYTES}`,
-      `${st.size} bytes`);
-  }
   let bytes;
-  try { bytes = fs.readFileSync(absPath); } catch (err) {
+  let size = 0;
+  try {
+    const st = fs.fstatSync(fd);
+    if (!st.isFile()) return wfxRefuse('not-a-file', 'that path is not a file', absPath);
+    size = st.size;
+    if (size > WorkflowArtifact.MAX_ARTIFACT_BYTES) {
+      return wfxRefuse('too-large',
+        `that file is ${size} bytes and a Husk workflow may be ${WorkflowArtifact.MAX_ARTIFACT_BYTES}`,
+        `${size} bytes`);
+    }
+    bytes = fs.readFileSync(fd);
+  } catch (err) {
     return wfxRefuse('unreadable', 'that file could not be read', err && err.message);
-  }
+  } finally { fs.closeSync(fd); }
   // The validator's answer travels back exactly as it came, refusal code and
   // all, since a surface keys its title and its recovery advice off that code.
   const result = WorkflowArtifact.parseArtifact(bytes);
   if (!result.ok) return Object.assign({ stage: 'validate' }, result);
   // chainCheck is this machine's finding rather than a field of the file, and it
   // rides beside the artifact so the sheet gets both in one round trip.
-  return { ok: true, artifact: result.artifact, warnings: result.warnings, chainCheck: result.chainCheck, bytes: st.size };
+  return { ok: true, artifact: result.artifact, warnings: result.warnings, chainCheck: result.chainCheck, bytes: size };
 }
 
 // ─── IPC: read an artifact ───────────────────────────────────────────────────
@@ -6357,16 +6363,20 @@ function wfxReadRunLog(sessionId) {
     return { ok: false, reason: 'unreadable', bytes: 0 };
   }
   const file = path.join(autopilotStorageRoot(), 'sessions', sessionId, 'audit.jsonl');
+  let fd;
   try {
-    const st = fs.statSync(file);
+    fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NONBLOCK || 0));
+    const st = fs.fstatSync(fd);
     if (!st.isFile()) return { ok: false, reason: 'unreadable', bytes: 0 };
     if (st.size > WorkflowArtifact.MAX_CHAIN_BYTES) return { ok: false, reason: 'too-large', bytes: st.size };
-    const raw = fs.readFileSync(file, 'utf8');
+    const raw = fs.readFileSync(fd, 'utf8');
     const lines = raw.split('\n').filter((l) => l.length > 0);
     if (!lines.length) return { ok: false, reason: 'unreadable', bytes: st.size };
     return { ok: true, lines, bytes: st.size };
   } catch (_) {
     return { ok: false, reason: 'unreadable', bytes: 0 };
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -375,12 +375,18 @@ const STATUSLINE_CANDIDATES = () => [
 
 let statuslineRefusedOnce = false;
 
-// sha256 of a regular file, or null.
+// sha256 of a regular file, or null. The kind, the size and the bytes are all
+// read from one descriptor. O_NOFOLLOW refuses a symlink at open, O_NONBLOCK
+// keeps a fifo from parking the open until someone writes to it.
 function statuslineDigest(file) {
-  const st = fs.lstatSync(file);
-  if (!st.isFile()) return null;
-  if (st.size > 4 * 1024 * 1024) return null;
-  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+  const fd = fs.openSync(file, fs.constants.O_RDONLY
+    | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
+  try {
+    const st = fs.fstatSync(fd);
+    if (!st.isFile()) return null;
+    if (st.size > 4 * 1024 * 1024) return null;
+    return crypto.createHash('sha256').update(fs.readFileSync(fd)).digest('hex');
+  } finally { fs.closeSync(fd); }
 }
 
 // Returns the script to run, or null. The rule lives in lib/statusline-trust.

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -685,6 +685,18 @@ const MANUAL_UPDATE_CMD = {
 // update, and at the end of the first-run flow). Bullets are trusted static
 // strings; the <strong> lead-ins are intentional markup.
 const WHATS_NEW = {
+  '2.11.1': {
+    items: [
+      {
+        title: 'Steadier file handling',
+        body: 'Husk now opens a file once and works from that handle, so what it checked and what it reads are always the same file. This covers the statusline script, workflow files and their run logs, agent transcripts, and the folders Autopilot captures and restores.',
+      },
+      {
+        title: 'Guides that stay in the frame',
+        body: 'The workflow canvas guide keeps to the canvas on a short window instead of spilling over the toolbar.',
+      },
+    ],
+  },
   '2.11.0': {
     items: [
       {

--- a/src/renderer/wfx-install.js
+++ b/src/renderer/wfx-install.js
@@ -9,7 +9,6 @@
 (function () {
   // ── The shell ──────────────────────────────────────────────────────────────
   // Looked up per call, so a markup change is reported rather than cached.
-  const $ = (sel) => document.querySelector(sel);
   const byId = (id) => document.getElementById(id);
 
   // The builder is required: a manifest renders through it or not at all.


### PR DESCRIPTION
Each of these sites checked a path and then acted on the path again. They now open once and take the kind, the size and the bytes from that one descriptor.

- `statuslineDigest`
- `wfxReadArtifactAt`
- `wfxReadRunLog`
- `bgAgents:peek`, which also no longer leaks the descriptor when the read throws
- `applyOne` in autopilot-apply, which holds the source open across the destination checks
- `captureScoped` in autonomy/snapshot

Opens by path carry `O_NONBLOCK` so a fifo is refused rather than parking the open, and `O_NOFOLLOW` where a symlink should not be followed.

Also drops an unused lookup helper in the install sheet.